### PR TITLE
Fix SPI transfer16

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -201,9 +201,15 @@ byte SPIClass::transfer(uint8_t _pin, uint8_t data, SPITransferMode _mode)
 uint16_t SPIClass::transfer16(uint8_t _pin, uint16_t data, SPITransferMode _mode)
 {
   uint16_t rx_buffer = 0;
+  uint16_t tmp;
 
   if (_pin > SPI_CHANNELS_NUM)
     return rx_buffer;
+
+  if (spiSettings[_pin].msb) {
+    tmp = ((data & 0xff00) >> 8) | ((data & 0xff) << 8);
+    data = tmp;
+  }
 
   if(_pin != g_active_id) {
     spi_init(&_spi, spiSettings[_pin].clk, spiSettings[_pin].dMode, spiSettings[_pin].msb);
@@ -217,6 +223,11 @@ uint16_t SPIClass::transfer16(uint8_t _pin, uint16_t data, SPITransferMode _mode
 
   if((_pin != BOARD_SPI_OWN_SS) && (_mode == SPI_LAST) && (_spi.pin_ssel == NC))
     digitalWrite(_pin, HIGH);
+
+  if (spiSettings[_pin].msb) {
+    tmp = ((rx_buffer & 0xff00) >> 8) | ((rx_buffer & 0xff) << 8);
+    rx_buffer = tmp;
+  }
 
   return rx_buffer;
 }


### PR DESCRIPTION
When the SPI device is configured for MSB first, the 16 bit data being
sent and received on the SPI bus has the bytes swapped if the
SPI.transfer16() method is used. Swapping the bytes before and after the
call to spi_transfer() fixes the problem.

Tested using an AS5147P magnetic encoder spi device. Before the fix, saw
frame errors due to the bytes being swapped, when the same unmodified
code worked perfectly on an AVR based SparkFun RedBoard.

Signed-off-by: Theodore A. Roth <troth@openavr.org>