### PR TITLE
Fix Serial config

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -57,28 +57,32 @@ typedef uint8_t rx_buffer_index_t;
 #endif
 
 // Define config for Serial.begin(baud, config);
-#define SERIAL_5N1 0x00
-#define SERIAL_6N1 0x02
+// below configs are not supported by STM32
+//#define SERIAL_5N1 0x00
+//#define SERIAL_5N2 0x08
+//#define SERIAL_5E1 0x20
+//#define SERIAL_5E2 0x28
+//#define SERIAL_5O1 0x30
+//#define SERIAL_5O2 0x38
+//#define SERIAL_6N1 0x02
+//#define SERIAL_6N2 0x0A
+
+#ifdef UART_WORDLENGTH_7B
 #define SERIAL_7N1 0x04
-#define SERIAL_8N1 0x06
-#define SERIAL_5N2 0x08
-#define SERIAL_6N2 0x0A
 #define SERIAL_7N2 0x0C
-#define SERIAL_8N2 0x0E
-#define SERIAL_5E1 0x20
 #define SERIAL_6E1 0x22
+#define SERIAL_6E2 0x2A
+#define SERIAL_6O1 0x32
+#define SERIAL_6O2 0x3A
+#endif
+#define SERIAL_8N1 0x06
+#define SERIAL_8N2 0x0E
 #define SERIAL_7E1 0x24
 #define SERIAL_8E1 0x26
-#define SERIAL_5E2 0x28
-#define SERIAL_6E2 0x2A
 #define SERIAL_7E2 0x2C
 #define SERIAL_8E2 0x2E
-#define SERIAL_5O1 0x30
-#define SERIAL_6O1 0x32
 #define SERIAL_7O1 0x34
 #define SERIAL_8O1 0x36
-#define SERIAL_5O2 0x38
-#define SERIAL_6O2 0x3A
 #define SERIAL_7O2 0x3C
 #define SERIAL_8O2 0x3E
 


### PR DESCRIPTION
Fix #50
Arduino defined several configs (data, parity and stop bits) values
for Serial.begin(speed, config)
See: https://www.arduino.cc/en/Serial/Begin
Below configs could not be supported by STM32 as minimum
wordlength (data + parity) is UART_WORDLENGTH_7B (7 bits).
SERIAL_5N1
SERIAL_5N2
SERIAL_5E1
SERIAL_5E2
SERIAL_5O1
SERIAL_5O2
SERIAL_6N1
SERIAL_6N2