### PR TITLE
Fixed missing parentheses and added STM32F042x6

### DIFF
--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -49,7 +49,7 @@ uint32_t pinNametoDigitalPin(PinName p);
 // Convert an analog pin number Axx to a PinName Pxy
 #define analogInputToPinName(p)     (digitalPinToPinName(analogInputToDigitalPin(p)))
 // All pins could manage EXTI
-#define digitalPinToInterrupt(p)    ((digitalPinIsValid(p) ? p : NOT_AN_INTERRUPT)
+#define digitalPinToInterrupt(p)    ((digitalPinIsValid(p) ? p : NOT_AN_INTERRUPT))
 
 #define digitalPinHasI2C(p)         (pin_in_pinmap(digitalPinToPinName(p), PinMap_I2C_SDA) ||\
                                      pin_in_pinmap(digitalPinToPinName(p), PinMap_I2C_SCL))

--- a/cores/arduino/stm32/stm32_def_build.h
+++ b/cores/arduino/stm32/stm32_def_build.h
@@ -44,6 +44,8 @@
 #define CMSIS_STARTUP_FILE "startup_stm32l432xx.s"
 #elif defined(STM32F103xB)
 #define CMSIS_STARTUP_FILE "startup_stm32f103xb.s"
+#elif defined(STM32F042x6)
+#define CMSIS_STARTUP_FILE "startup_stm32f042x6.s"
 #else
 #error UNKNOWN CHIP
 #endif


### PR DESCRIPTION
There is an error in pins_arduino.h.  The macro is missing a bracket.

**digitalPinToInterrupt(p)    ((digitalPinIsValid(p) ? p : NOT_AN_INTERRUPT)**

I also added the STM32F042x6 startup file define in stm32_def_build.h

