### PR TITLE
Fix possible issue on serial ports

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -70,14 +70,13 @@ int HardwareSerial::_tx_complete_irq(serial_t* obj)
 {
   // If interrupts are enabled, there must be more data in the output
   // buffer. Send the next byte
-  unsigned char c = obj->tx_buff[obj->tx_tail];
   obj->tx_tail = (obj->tx_tail + 1) % SERIAL_TX_BUFFER_SIZE;
 
   if (obj->tx_head == obj->tx_tail) {
     return -1;
   }
 
-  return c;
+  return 0;
 }
 
 // Public Methods //////////////////////////////////////////////////////////////


### PR DESCRIPTION
In my opinion, there is a potential bug when a character equal to -1 is sent by serial port; in this case according the current implementation the following character in the queue is not transmitted. For this reason I propose to simplify _tx_complete_irq implementation just returning 0 if we still have characters to be transmitted, -1 otherwise.