### PR TITLE
I2C update following new STM32F1 HAL release

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -81,7 +81,6 @@ void TwoWire::begin(uint8_t address)
 
   i2c_custom_init(&_i2c,I2C_100KHz,I2C_ADDRESSINGMODE_7BIT,ownAddress,master);
 
-#ifndef STM32F1xx
   if(master == false){
     // i2c_attachSlaveTxEvent(&_i2c, reinterpret_cast<void(*)(i2c_t*)>(&TwoWire::onRequestService));
     // i2c_attachSlaveRxEvent(&_i2c, reinterpret_cast<void(*)(i2c_t*, uint8_t*, int)>(&TwoWire::onReceiveService));
@@ -89,7 +88,6 @@ void TwoWire::begin(uint8_t address)
     i2c_attachSlaveTxEvent(&_i2c, onRequestService);
     i2c_attachSlaveRxEvent(&_i2c, onReceiveService);
   }
-#endif
 }
 
 void TwoWire::begin(int address)
@@ -111,8 +109,6 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 {
   UNUSED(sendStop);
   if (master == true) {
-    //NOTE: do not work with STM32F1xx boards (latest HAL version: 1.0.4)
-#ifndef STM32F1xx
     if (isize > 0) {
       // send internal address; this mode allows sending a repeated start to access
       // some devices' internal registers. This function is executed by the hardware
@@ -131,10 +127,6 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
       }
       endTransmission(false);
     }
-#else
-    UNUSED(iaddress);
-	UNUSED(isize);
-#endif /* !STM32F1xx */
 
     // clamp to buffer length
     if(quantity > BUFFER_LENGTH){
@@ -377,22 +369,12 @@ void TwoWire::onRequestService(void)
 void TwoWire::onReceive( void (*function)(int) )
 {
   user_onReceive = function;
-
-#ifdef STM32F1xx
-  //Enable slave receive IT
-  i2c_attachSlaveRxEvent(&_i2c, onReceiveService);
-#endif
 }
 
 // sets function called on slave read
 void TwoWire::onRequest( void (*function)(void) )
 {
   user_onRequest = function;
-
-#ifdef STM32F1xx
-  //Enable slave transmit IT
-  i2c_attachSlaveTxEvent(&_i2c, onRequestService);
-#endif
 }
 
 // Preinstantiate Objects //////////////////////////////////////////////////////

--- a/libraries/Wire/examples/master_reader_writer/master_reader_writer.ino
+++ b/libraries/Wire/examples/master_reader_writer/master_reader_writer.ino
@@ -1,11 +1,13 @@
 /* Wire Master Reader Writer
 by Wi6Labs
 
-Demonstrates use of the Wire library, particullary with STM32F1xx boards.
+Demonstrates use of the Wire library.
 Reads/writes data from/to an I2C/TWI slave device.
 Refer to the "Wire Slave Sender Receiver" example for use with this.
 
 Created 27 June 2017
+Updated 14 August 2017
+  - this example is now common to all STM32 boards
 
 This example code is in the public domain.
 */
@@ -40,5 +42,5 @@ void loop()
   Wire.endTransmission();           // stop transmitting
   x++;
 
-  delay(1000);
+  delay(500);
 }

--- a/libraries/Wire/examples/slave_sender_receiver/slave_sender_receiver.ino
+++ b/libraries/Wire/examples/slave_sender_receiver/slave_sender_receiver.ino
@@ -1,45 +1,32 @@
 /* Wire Slave Receiver
 by Wi6Labs
 
-Demonstrates use of the Wire library, particullary with STM32F1xx boards where
-we can't use slave Tx & Rx mode in same time.
+Demonstrates use of the Wire library.
 Receives/sends data as an I2C/TWI slave device.
 Refer to the "Wire Master Reader Writer" example for use with this.
 
 Created 27 June 2017
+Updated 14 August 2017
+  - this example is now common to all STM32 boards
 
 This example code is in the public domain.
 */
 
 #include <Wire.h>
 
-#define SLAVE_MODE_RX 0
-#define SLAVE_MODE_TX 1
-
 #define I2C_ADDR  2
-
-int w_r_mode = SLAVE_MODE_TX;
-bool switch_mode = false;
 
 void setup()
 {
   Wire.begin(I2C_ADDR);         // join i2c bus with address #4
   Wire.onRequest(requestEvent); // register event
+  Wire.onReceive(receiveEvent); // register event
   Serial.begin(9600);           // start serial for output
 }
 
 void loop()
 {
-  if(switch_mode == true) {
-    switch_mode = false;
-    Wire.end();
-    Wire.begin(I2C_ADDR);
-    if(w_r_mode == SLAVE_MODE_TX) {
-      Wire.onRequest(requestEvent); // register event
-    } else {
-      Wire.onReceive(receiveEvent); // register event
-    }
-  }
+  //empty loop
 }
 
 // function that executes whenever data is received from master
@@ -48,23 +35,17 @@ void receiveEvent(int howMany)
 {
   while(1 < Wire.available()) // loop through all but the last
   {
-    char c = Wire.read(); // receive byte as a character
-    Serial.print(c);         // print the character
+    char c = Wire.read();     // receive byte as a character
+    Serial.print(c);          // print the character
   }
-  int x = Wire.read();    // receive byte as an integer
-  Serial.println(x);         // print the integer
-
-  switch_mode = true;
-  w_r_mode = SLAVE_MODE_TX;
+  int x = Wire.read();        // receive byte as an integer
+  Serial.println(x);          // print the integer
 }
 
 // function that executes whenever data is requested by master
 // this function is registered as an event, see setup()
 void requestEvent()
 {
-  Wire.write("hello "); // respond with message of 6 bytes
-                       // as expected by master
-
-  switch_mode = true;
-  w_r_mode = SLAVE_MODE_RX;
+  Wire.write("hello\n");  // respond with message of 6 bytes
+                          // as expected by master
 }


### PR DESCRIPTION
The new STM32F1xx HAL release allow to remove specific set up for STM32F1 boards inside I2C core and library.
The specific examples for F1 has been reworked too.