### PR TITLE
Remove unused .pin field of gpio_irq_conf_str structure

### DIFF
--- a/cores/arduino/stm32/interrupt.c
+++ b/cores/arduino/stm32/interrupt.c
@@ -63,7 +63,6 @@
 
 /*As we can have only one interrupt/pin id, don't need to get the port info*/
 typedef struct {
-  uint32_t pin;
   uint32_t irqnb;
   void (*callback)(void);
   uint32_t mode;
@@ -94,42 +93,41 @@ typedef struct {
   */
 static gpio_irq_conf_str gpio_irq_conf[NB_EXTI] = {
 #if defined (STM32F0xx) || defined (STM32L0xx)
-  {.pin = GPIO_PIN_0,   .irqnb = EXTI0_1_IRQn,   .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_1,   .irqnb = EXTI0_1_IRQn,   .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_2,   .irqnb = EXTI2_3_IRQn,   .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_3,   .irqnb = EXTI2_3_IRQn,   .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_4,   .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_5,   .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_6,   .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_7,   .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_8,   .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_9,   .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_10,  .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_11,  .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_12,  .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_13,  .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_14,  .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_15,  .irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}
+  {.irqnb = EXTI0_1_IRQn,   .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_0
+  {.irqnb = EXTI0_1_IRQn,   .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_1
+  {.irqnb = EXTI2_3_IRQn,   .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_2
+  {.irqnb = EXTI2_3_IRQn,   .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_3
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_4
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_5
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_6
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_7
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_8
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_9
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_10
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_11
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_12
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_13
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_14
+  {.irqnb = EXTI4_15_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}  //GPIO_PIN_15
 #else
-  {.pin = GPIO_PIN_0,   .irqnb = EXTI0_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_1,   .irqnb = EXTI1_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_2,   .irqnb = EXTI2_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_3,   .irqnb = EXTI3_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_4,   .irqnb = EXTI4_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_5,   .irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_6,   .irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_7,   .irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_8,   .irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_9,   .irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_10,  .irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_11,  .irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_12,  .irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_13,  .irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_14,  .irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING},
-  {.pin = GPIO_PIN_15,  .irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}
+  {.irqnb = EXTI0_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_0
+  {.irqnb = EXTI1_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_1
+  {.irqnb = EXTI2_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_2
+  {.irqnb = EXTI3_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_3
+  {.irqnb = EXTI4_IRQn,      .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_4
+  {.irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_5
+  {.irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_6
+  {.irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_7
+  {.irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_8
+  {.irqnb = EXTI9_5_IRQn,    .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_9
+  {.irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_10
+  {.irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_11
+  {.irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_12
+  {.irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_13
+  {.irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}, //GPIO_PIN_14
+  {.irqnb = EXTI15_10_IRQn,  .callback = NULL, .mode = GPIO_MODE_IT_RISING}  //GPIO_PIN_15
 #endif
 };
-
 /**
   * @}
   */


### PR DESCRIPTION
Reduce gpio_irq_conf array of 64 bytes.
Pin is the index.