### PR TITLE
Remove Ethernet library dependency

### DIFF
--- a/cores/arduino/board.h
+++ b/cores/arduino/board.h
@@ -6,8 +6,8 @@
  */
 #include "analog.h"
 #include "clock.h"
+#include "core_callback.h"
 #include "digital_io.h"
-#include "ethernet.h"
 #include "hal_uart_emul.h"
 #include "hw_config.h"
 #include "interrupt.h"

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -47,9 +47,7 @@ int main( void )
 
 	for (;;)
 	{
-		// Define by Ethernet library. It is defined as __weak.
-		stm32_eth_scheduler();
-		
+		CoreCallback();
 		loop();
 		if (serialEventRun) serialEventRun();
 	}

--- a/cores/arduino/stm32/core_callback.c
+++ b/cores/arduino/stm32/core_callback.c
@@ -1,0 +1,111 @@
+/**
+  ******************************************************************************
+  * @file    core_callback.c
+  * @author  WI6LABS
+  * @version V1.0.0
+  * @date    8-September-2017
+  * @brief   Provides methods to add callback to call inside the main loop.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/*
+ * @NOTE
+ * This file provides methods to add callback in the main() function loop.
+ * If you need to call as often as possible a function to update your system and
+ * you want to be sure this function to be called, you can add it to the callback
+ * list. Otherwise, your function should be called inside the loop() function of
+ * the sketch.
+ */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "core_callback.h"
+
+// List of callback to call
+static void (*callbackList[CALLBACK_LIST_SIZE])(void);
+
+/**
+  * @brief  Adds a callback pointer
+  * @param  func: callback pointer
+  * @retval None
+  */
+void registerCoreCallback(void (*func)(void))
+{
+  if(func == NULL)
+    return;
+
+  for(uint8_t i = 0; i < CALLBACK_LIST_SIZE; i++) {
+    if(callbackList[i] == NULL) {
+      callbackList[i] = func;
+      break;
+    }
+  }
+}
+
+/**
+  * @brief  Removes a callback pointer
+  * @param  func: callback pointer
+  * @retval None
+  */
+void unregisterCoreCallback(void (*func)(void))
+{
+  if(func == NULL)
+    return;
+
+  for(uint8_t i = 0; i < CALLBACK_LIST_SIZE; i++) {
+    if(callbackList[i] == func) {
+      callbackList[i] = NULL;
+      break;
+    }
+  }
+}
+
+/**
+  * @brief  Calls callback of the list. There is no priority. First added first
+  *         called. This function must be called only in main() function loop.
+  * @param  None
+  * @retval None
+  */
+void CoreCallback(void)
+{
+  for(uint8_t i = 0; i < CALLBACK_LIST_SIZE; i++) {
+    if(callbackList[i] != NULL)
+      callbackList[i]();
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cores/arduino/stm32/core_callback.h
+++ b/cores/arduino/stm32/core_callback.h
@@ -1,14 +1,14 @@
 /**
   ******************************************************************************
-  * @file    ethernet.h
+  * @file    core_callback.h
   * @author  WI6LABS
   * @version V1.0.0
-  * @date    14-June-2017
-  * @brief   Header for ethernet background task for LwIP stack.
+  * @date    8-September-2017
+  * @brief   Header for callback methods.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -36,34 +36,32 @@
   */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef __ETHERNET_H
-#define __ETHERNET_H
+#ifndef __CALLBACK_H
+#define __CALLBACK_H
 
-/* Includes ------------------------------------------------------------------*/
+#include "Arduino.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
 
+/* Includes ------------------------------------------------------------------*/
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
 /* Exported macro ------------------------------------------------------------*/
+#ifndef CALLBACK_LIST_SIZE
+#define CALLBACK_LIST_SIZE  4
+#endif
+
 /* Exported functions ------------------------------------------------------- */
-
-/* This function is defined by the NativeEthernet library and it is used as
-background task inside the main loop. */
-__weak void stm32_eth_scheduler(void)
-{
-  /* NOTE : This function should not be modified. It is defined in the Ethernet
-            library.
-   */
-}
-
-void stm32_eth_scheduler(void);
+void registerCoreCallback(void (*func)(void));
+void unregisterCoreCallback(void (*func)(void));
+void CoreCallback(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __ETHERNET_H */
+#endif /* __CALLBACK_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
The Ethernet library is no more linked to the core.
See STM32Ethernet [PR](https://github.com/stm32duino/STM32Ethernet/pull/2).