### PR TITLE
initialize state before calling HAL_XXX_Init for SPI and I2C

### DIFF
--- a/cores/arduino/stm32/spi_com.c
+++ b/cores/arduino/stm32/spi_com.c
@@ -222,6 +222,7 @@ void spi_init(spi_t *obj, uint32_t speed, spi_mode_e mode, uint8_t msb)
   /* Fill default value */
   handle->Instance               = obj->spi;
   handle->Init.Mode              = SPI_MODE_MASTER;
+  handle->State                  = HAL_SPI_STATE_RESET;
 
   spi_freq = spi_getClkFreqInst(obj->spi);
   if(speed >= (spi_freq/SPI_SPEED_CLOCK_DIV2_MHZ)) {

--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -253,6 +253,8 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
   handle->Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
   handle->Init.NoStretchMode   = I2C_NOSTRETCH_DISABLE;
 
+  handle->State = HAL_I2C_STATE_RESET;
+
   if(master == 0) {
     HAL_NVIC_SetPriority(obj->irq, 0, 1);
     HAL_NVIC_EnableIRQ(obj->irq);


### PR DESCRIPTION
If we use a dynamic instanciation, the state is not well
initialized. This can ends with a blocking or strange
behaviour.