### PR TITLE
Remove I2C buffer length limitation required by M24SR64-Y library

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -129,7 +129,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
     }
 
     // clamp to buffer length
-    if(quantity > BUFFER_LENGTH){
+    if(quantity >= BUFFER_LENGTH){
       quantity = BUFFER_LENGTH;
     }
     // perform blocking read into buffer

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -26,7 +26,10 @@
 #include "Stream.h"
 #include "variant.h"
 
+// Defines a default buffer length
+#ifndef BUFFER_LENGTH
 #define BUFFER_LENGTH 32
+#endif
 
 #define MASTER_ADDRESS 0x33
 

--- a/variants/DISCO_L475VG_IOT/variant.h
+++ b/variants/DISCO_L475VG_IOT/variant.h
@@ -171,6 +171,8 @@ enum {
 #define SDA                     14
 #define SCL                     15
 
+#define BUFFER_LENGTH           255 //Define I2C maximum buffer length
+
 //Timer Definitions
 //Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6


### PR DESCRIPTION
The [M24SR64-Y library](https://github.com/stm32duino/M24SR64-Y/pull/1) needs an I2C buffer of 255 bytes. 
So we must to give the possibility to increase the I2C buffer size.