### PR TITLE
Some linker script has the stack pointer __NOT__ 8-byte aligned

### DIFF
--- a/variants/NUCLEO_F091RC/ldscript.ld
+++ b/variants/NUCLEO_F091RC/ldscript.ld
@@ -46,7 +46,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20007FFF;    /* end of RAM */
+_estack = 0x20008000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;;      /* required amount of heap  */
 _Min_Stack_Size = 0x400;; /* required amount of stack */

--- a/variants/NUCLEO_F303RE/ldscript.ld
+++ b/variants/NUCLEO_F303RE/ldscript.ld
@@ -46,7 +46,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x2000FFFF;    /* end of RAM */
+_estack = 0x20010000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;;      /* required amount of heap  */
 _Min_Stack_Size = 0x400;; /* required amount of stack */

--- a/variants/NUCLEO_L053R8/ldscript.ld
+++ b/variants/NUCLEO_L053R8/ldscript.ld
@@ -46,7 +46,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20001FFF;    /* end of RAM */
+_estack = 0x20002000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;;      /* required amount of heap  */
 _Min_Stack_Size = 0x400;; /* required amount of stack */

--- a/variants/NUCLEO_L476RG/ldscript.ld
+++ b/variants/NUCLEO_L476RG/ldscript.ld
@@ -46,7 +46,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20017FFF;    /* end of RAM */
+_estack = 0x20018000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;;      /* required amount of heap  */
 _Min_Stack_Size = 0x400;; /* required amount of stack */


### PR DESCRIPTION
Ex: 0x20001FFF is the last valid byte address of RAM for NUCLEO_L053R8,
but the error is that it is not aligned and there is no reason to put
this value as stack pointer.
When Cortex-M push something in the stack, it first decrement the stack
pointer and then writes at the new address.
So using initial value 0x20002000 is ok.
The first word will be at address _estack-4, in RAM