### PR TITLE
Remove global variable used for uart Rx

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -179,19 +179,21 @@ void HardwareSerial::init(void)
 
 void HardwareSerial::_rx_complete_irq(serial_t* obj)
 {
-  // No Parity error, read byte and store it in the buffer if there is
-  // room
-  unsigned char c = uart_getc(obj);
+  // No Parity error, read byte and store it in the buffer if there is room
+  unsigned char c;
 
-  rx_buffer_index_t i = (unsigned int)(obj->rx_head + 1) % SERIAL_RX_BUFFER_SIZE;
+  if (uart_getc(obj, &c) == 0) {
 
-  // if we should be storing the received character into the location
-  // just before the tail (meaning that the head would advance to the
-  // current location of the tail), we're about to overflow the buffer
-  // and so we don't write the character or advance the head.
-  if (i != obj->rx_tail) {
-    obj->rx_buff[obj->rx_head] = c;
-    obj->rx_head = i;
+    rx_buffer_index_t i = (unsigned int)(obj->rx_head + 1) % SERIAL_RX_BUFFER_SIZE;
+
+    // if we should be storing the received character into the location
+    // just before the tail (meaning that the head would advance to the
+    // current location of the tail), we're about to overflow the buffer
+    // and so we don't write the character or advance the head.
+    if (i != obj->rx_tail) {
+      obj->rx_buff[obj->rx_head] = c;
+      obj->rx_head = i;
+    }
   }
 }
 

--- a/cores/arduino/stm32/uart.c
+++ b/cores/arduino/stm32/uart.c
@@ -70,9 +70,13 @@
 #define UART_NUM (8)
 #elif defined(STM32F2xx)
 #define UART_NUM (6)
-#else // STM32F1xx || STM32F3xx || STM32L0xx || STM32L1xx || STM32L4xx
+#elif defined(STM32F1xx) || defined(STM32F3xx) ||\
+      defined(STM32L0xx) || defined(STM32L1xx) || defined(STM32L4xx)
 #define UART_NUM (5)
+#else
+#error "Unknown Family - unknown UART_NUM"
 #endif
+
 static UART_HandleTypeDef *uart_handlers[UART_NUM] = {NULL};
 static void (*rx_callback[UART_NUM])(serial_t*);
 static serial_t *rx_callback_obj[UART_NUM];

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -188,7 +188,8 @@ typedef struct serial_s serial_t;
 struct serial_s {
   USART_TypeDef *uart;
   UART_HandleTypeDef handle;
-  int index;
+  uint8_t index;
+  uint8_t recv;
   uint32_t baudrate;
   uint32_t databits;
   uint32_t stopbits;
@@ -279,7 +280,7 @@ struct serial_s {
 void uart_init(serial_t *obj);
 void uart_deinit(serial_t *obj);
 size_t uart_write(serial_t *obj, uint8_t data, uint16_t size);
-int uart_getc(serial_t *obj);
+int uart_getc(serial_t *obj, unsigned char* c);
 void uart_attach_rx_callback(serial_t *obj, void (*callback)(serial_t*));
 void uart_attach_tx_callback(serial_t *obj, int (*callback)(serial_t*));
 


### PR DESCRIPTION
In case of several Serial instances, a global variable was used for all received char.