### PR TITLE
Fix issue on SPI and remove compilation warnings for Nucleo-L476RG

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -20,6 +20,7 @@ SPIClass SPI;
 
 SPIClass::SPIClass() : _CSpin(-1)
 {
+  memset(&_spi, 0x0, sizeof(spi_t));
   _spi.pin_miso = digitalPinToPinName(MISO);
   _spi.pin_mosi = digitalPinToPinName(MOSI);
   _spi.pin_sclk = digitalPinToPinName(SCK);
@@ -31,6 +32,7 @@ ssel pin. Enable this pin disable software CS. See microcontroller documentation
 for the list of available SS pins. */
 SPIClass::SPIClass(uint8_t mosi, uint8_t miso, uint8_t sclk, uint8_t ssel) : _CSpin(-1)
 {
+  memset(&_spi, 0x0, sizeof(spi_t));
   _spi.pin_miso = digitalPinToPinName(miso);
   _spi.pin_mosi = digitalPinToPinName(mosi);
   _spi.pin_sclk = digitalPinToPinName(sclk);

--- a/variants/NUCLEO_L476RG/ldscript.ld
+++ b/variants/NUCLEO_L476RG/ldscript.ld
@@ -70,7 +70,7 @@ SECTIONS
   } >FLASH
 
   /* The program code and other data goes into FLASH */
-  .text :
+  .text ALIGN(8) :
   {
     . = ALIGN(4);
     *(.text)           /* .text sections (code) */


### PR DESCRIPTION
Hi all,
I found an issue on SPI that I experienced during the porting of the X-NUCLEO-IHM02A1; in practice the issue happens when we allocate the SPI instance with a “new”. In this way, sometimes I noticed that the Init struct of the SPI_HandleTypeDef is randomly initialized and it is due to the fact that the “new” operator is implemented using a “malloc” and so it does not guarantee that the created instances are initialized to 0. So we can apply two possible fixes:
1)	Modify the “new” implementation with a calloc instead a malloc (probably it is the safest solution because in this way we prevent that this issue will be present in other libraries).
2)	Add a memset to 0 at “_spi” field of the SPI class at the beginning of the two constructors (in this way we solve the issue for the SPI library but not, if it is present, for the other libraries).

I also patched the linker script for Nucleo-L476RG in order to remove the compilation warnings about .text section misalignment.
Best Regards,

Carlo
