### PR TITLE
Fix issue on SPI for F0, F3, F7 and L4 platforms

### DIFF
--- a/cores/arduino/stm32/spi_com.c
+++ b/cores/arduino/stm32/spi_com.c
@@ -269,6 +269,9 @@ void spi_init(spi_t *obj, uint32_t speed, spi_mode_e mode, uint8_t msb)
   }
 
   handle->Init.TIMode            = SPI_TIMODE_DISABLE;
+#if defined(STM32F0xx) || defined(STM32F3xx) || defined(STM32F7xx) || defined(STM32L4xx)
+  handle->Init.NSSPMode          = SPI_NSS_PULSE_DISABLE;
+#endif
 
   if(obj->pin_mosi != NC) {
     port = set_GPIO_Port_Clock(STM_PORT(obj->pin_mosi));


### PR DESCRIPTION
Hi all,
I found a potential issue in the SPI library when the SPI instance is generated using dynamic allocation. In particular the "NSSPMode" field of the “Init” structure of the "SPI_HandleTypeDef" could be randomly initialized and it could cause troubles in the "HAL_SPI_Init". In order to avoid that we need to correctly initialized this field inside the spi_init.
I also fixed some compilation warnings (for Nucleo-L476RG) due to a misalignment in the .text section of the Linker Script. Probably this issue affects other platforms too.
Best Regards,
Carlo