### PR TITLE
Disabled Core callback feature

### DIFF
--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -37,20 +37,22 @@ void initVariant() { }
  */
 int main( void )
 {
-	initVariant();
+  initVariant();
 
 #if defined(USBCON)
-	usbd_interface_init();
+  usbd_interface_init();
 #endif
 
-	setup();
+  setup();
 
-	for (;;)
-	{
-		CoreCallback();
-		loop();
-		if (serialEventRun) serialEventRun();
-	}
+  for (;;)
+  {
+#if defined(CORE_CALLBACK)
+    CoreCallback();
+#endif
+    loop();
+    if (serialEventRun) serialEventRun();
+  }
 
-	return 0;
+  return 0;
 }

--- a/cores/arduino/stm32/core_callback.c
+++ b/cores/arduino/stm32/core_callback.c
@@ -43,7 +43,7 @@
  * list. Otherwise, your function should be called inside the loop() function of
  * the sketch.
  */
-
+#if defined(CORE_CALLBACK)
 #ifdef __cplusplus
  extern "C" {
 #endif
@@ -107,5 +107,5 @@ void CoreCallback(void)
 #ifdef __cplusplus
 }
 #endif
-
+#endif // CORE_CALLBACK
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cores/arduino/stm32/core_callback.h
+++ b/cores/arduino/stm32/core_callback.h
@@ -38,7 +38,7 @@
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __CALLBACK_H
 #define __CALLBACK_H
-
+#if defined(CORE_CALLBACK)
 #include "variant.h"
 
 #ifdef __cplusplus
@@ -61,7 +61,7 @@ void CoreCallback(void);
 #ifdef __cplusplus
 }
 #endif
-
+#endif // CORE_CALLBACK
 #endif /* __CALLBACK_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
STM32Ethernet do not use anymore this feature.
Disabled it to avoid unuseful call in the main while{}.
Define CORE_CALLBACK allow to enable it.
