### PR TITLE
TIMx_IRQHandler should be WEAK

### DIFF
--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -1030,7 +1030,7 @@ void attachIntHandle(stimer_t *obj, void (*irqHandle)(stimer_t *))
   * @param  None
   * @retval None
   */
-void TIM1_IRQHandler(void)
+WEAK void TIM1_IRQHandler(void)
 {
   if(timer_handles[0] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[0]);
@@ -1060,7 +1060,7 @@ void TIM1_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM2_IRQHandler(void)
+WEAK void TIM2_IRQHandler(void)
 {
   if(timer_handles[1] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[1]);
@@ -1074,7 +1074,7 @@ void TIM2_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM3_IRQHandler(void)
+WEAK void TIM3_IRQHandler(void)
 {
   if(timer_handles[2] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[2]);
@@ -1088,7 +1088,7 @@ void TIM3_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM4_IRQHandler(void)
+WEAK void TIM4_IRQHandler(void)
 {
   if(timer_handles[3] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[3]);
@@ -1102,7 +1102,7 @@ void TIM4_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM5_IRQHandler(void)
+WEAK void TIM5_IRQHandler(void)
 {
   if(timer_handles[4] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[4]);
@@ -1116,7 +1116,7 @@ void TIM5_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM6_IRQHandler(void)
+WEAK void TIM6_IRQHandler(void)
 {
   if(timer_handles[5] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[5]);
@@ -1130,7 +1130,7 @@ void TIM6_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM7_IRQHandler(void)
+WEAK void TIM7_IRQHandler(void)
 {
   if(timer_handles[6] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[6]);
@@ -1144,7 +1144,7 @@ void TIM7_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM8_IRQHandler(void)
+WEAK void TIM8_IRQHandler(void)
 {
   if(timer_handles[7] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[7]);
@@ -1164,7 +1164,7 @@ void TIM8_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM9_IRQHandler(void)
+WEAK void TIM9_IRQHandler(void)
 {
   if(timer_handles[8] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[8]);
@@ -1179,7 +1179,7 @@ void TIM9_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM10_IRQHandler(void)
+WEAK void TIM10_IRQHandler(void)
 {
   if(timer_handles[9] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[9]);
@@ -1194,7 +1194,7 @@ void TIM10_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM11_IRQHandler(void)
+WEAK void TIM11_IRQHandler(void)
 {
   if(timer_handles[10] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[10]);
@@ -1208,7 +1208,7 @@ void TIM11_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM12_IRQHandler(void)
+WEAK void TIM12_IRQHandler(void)
 {
   if(timer_handles[11] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[11]);
@@ -1223,7 +1223,7 @@ void TIM12_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM13_IRQHandler(void)
+WEAK void TIM13_IRQHandler(void)
 {
   if(timer_handles[12] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[12]);
@@ -1238,7 +1238,7 @@ void TIM13_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM14_IRQHandler(void)
+WEAK void TIM14_IRQHandler(void)
 {
   if(timer_handles[13] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[13]);
@@ -1252,7 +1252,7 @@ void TIM14_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM15_IRQHandler(void)
+WEAK void TIM15_IRQHandler(void)
 {
   if(timer_handles[14] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[14]);
@@ -1267,7 +1267,7 @@ void TIM15_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM16_IRQHandler(void)
+WEAK void TIM16_IRQHandler(void)
 {
   if(timer_handles[15] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[15]);
@@ -1282,7 +1282,7 @@ void TIM16_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM17_IRQHandler(void)
+WEAK void TIM17_IRQHandler(void)
 {
   if(timer_handles[16] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[16]);
@@ -1296,7 +1296,7 @@ void TIM17_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM18_IRQHandler(void)
+WEAK void TIM18_IRQHandler(void)
 {
   if(timer_handles[17] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[17]);
@@ -1310,7 +1310,7 @@ void TIM18_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM19_IRQHandler(void)
+WEAK void TIM19_IRQHandler(void)
 {
   if(timer_handles[18] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[18]);
@@ -1324,7 +1324,7 @@ void TIM19_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM20_IRQHandler(void)
+WEAK void TIM20_IRQHandler(void)
 {
   if(timer_handles[19] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[19]);
@@ -1338,7 +1338,7 @@ void TIM20_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM21_IRQHandler(void)
+WEAK void TIM21_IRQHandler(void)
 {
   if(timer_handles[20] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[20]);
@@ -1352,7 +1352,7 @@ void TIM21_IRQHandler(void)
   * @param  None
   * @retval None
   */
-void TIM22_IRQHandler(void)
+WEAK void TIM22_IRQHandler(void)
 {
   if(timer_handles[21] != NULL) {
     HAL_TIM_IRQHandler(timer_handles[21]);


### PR DESCRIPTION
Do not merge this one.
~Tests on going~
Already defined as weak in CMSIS device startup file and aliased to Default_Handler.
Defining TIMx_IRQHandler in timer.c as weak allow to redefine them at user sketch level but if they are not defined, no guarantee that they are used instead of Default_Handler

Close this PR. Will be handled thanks #146 