### PR TITLE
Added ability to bind std:function on interrupts

### DIFF
--- a/cores/arduino/WInterrupts.cpp
+++ b/cores/arduino/WInterrupts.cpp
@@ -19,14 +19,14 @@
 #include "WInterrupts.h"
 #include "Arduino.h"
 
-#ifdef __cplusplus
- extern "C" {
-#endif
+// #ifdef __cplusplus
+//  extern "C" {
+// #endif
 
 #include "PinAF_STM32F1.h"
+#include "interrupt.h"
 
-void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode)
-{
+void attachInterrupt(uint32_t pin, callback_function_t callback, uint32_t mode){
   uint32_t it_mode;
   PinName p = digitalPinToPinName(pin);
   GPIO_TypeDef* port = set_GPIO_Port_Clock(STM_PORT(p));
@@ -57,6 +57,12 @@ void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode)
   stm32_interrupt_enable(port, STM_GPIO_PIN(p), callback, it_mode);
 }
 
+void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode)
+{
+  callback_function_t _c = callback;
+  attachInterrupt(pin,_c,mode);
+}
+
 void detachInterrupt(uint32_t pin)
 {
   PinName p = digitalPinToPinName(pin);
@@ -65,3 +71,6 @@ void detachInterrupt(uint32_t pin)
 	  return;
   stm32_interrupt_disable(port, STM_GPIO_PIN(p));
 }
+// #ifdef __cplusplus
+//  }
+// #endif

--- a/cores/arduino/WInterrupts.cpp
+++ b/cores/arduino/WInterrupts.cpp
@@ -19,10 +19,6 @@
 #include "WInterrupts.h"
 #include "Arduino.h"
 
-// #ifdef __cplusplus
-//  extern "C" {
-// #endif
-
 #include "PinAF_STM32F1.h"
 #include "interrupt.h"
 
@@ -71,6 +67,3 @@ void detachInterrupt(uint32_t pin)
 	  return;
   stm32_interrupt_disable(port, STM_GPIO_PIN(p));
 }
-// #ifdef __cplusplus
-//  }
-// #endif

--- a/cores/arduino/WInterrupts.h
+++ b/cores/arduino/WInterrupts.h
@@ -20,17 +20,29 @@
 #define _WIRING_INTERRUPTS_
 
 #include <stdint.h>
+// #include "interrupt.h"
+
 
 #ifdef __cplusplus
-extern "C" {
+#include <functional>
+typedef std::function<void(void)> callback_function_t;
+
+// extern "C" {
+// #endif
+
+void attachInterrupt(uint32_t pin, callback_function_t callback, uint32_t mode);
+// }
 #endif
 
+// #ifdef __cplusplus
+// extern "C" {
+// #endif
 void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode);
 
 void detachInterrupt(uint32_t pin);
 
-#ifdef __cplusplus
-}
-#endif
+// #ifdef __cplusplus
+// }
+// #endif
 
 #endif /* _WIRING_INTERRUPTS_ */

--- a/cores/arduino/WInterrupts.h
+++ b/cores/arduino/WInterrupts.h
@@ -20,29 +20,17 @@
 #define _WIRING_INTERRUPTS_
 
 #include <stdint.h>
-// #include "interrupt.h"
-
 
 #ifdef __cplusplus
 #include <functional>
+
 typedef std::function<void(void)> callback_function_t;
-
-// extern "C" {
-// #endif
-
 void attachInterrupt(uint32_t pin, callback_function_t callback, uint32_t mode);
-// }
+
 #endif
 
-// #ifdef __cplusplus
-// extern "C" {
-// #endif
 void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode);
 
 void detachInterrupt(uint32_t pin);
-
-// #ifdef __cplusplus
-// }
-// #endif
 
 #endif /* _WIRING_INTERRUPTS_ */

--- a/cores/arduino/board.h
+++ b/cores/arduino/board.h
@@ -4,6 +4,7 @@
 /*
  * Core and peripherals registers definitions
 */
+#include "interrupt.h"
 #ifdef __cplusplus
 extern "C"{
 #endif // __cplusplus
@@ -13,13 +14,6 @@ extern "C"{
 #include "digital_io.h"
 #include "hal_uart_emul.h"
 #include "hw_config.h"
-#ifdef __cplusplus
-}
-#endif // __cplusplus
-#include "interrupt.h"
-#ifdef __cplusplus
-extern "C"{
-#endif // __cplusplus
 #include "spi_com.h"
 #include "stm32_eeprom.h"
 #include "timer.h"

--- a/cores/arduino/board.h
+++ b/cores/arduino/board.h
@@ -3,14 +3,23 @@
 
 /*
  * Core and peripherals registers definitions
- */
+*/
+#ifdef __cplusplus
+extern "C"{
+#endif // __cplusplus
 #include "analog.h"
 #include "clock.h"
 #include "core_callback.h"
 #include "digital_io.h"
 #include "hal_uart_emul.h"
 #include "hw_config.h"
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 #include "interrupt.h"
+#ifdef __cplusplus
+extern "C"{
+#endif // __cplusplus
 #include "spi_com.h"
 #include "stm32_eeprom.h"
 #include "timer.h"
@@ -22,5 +31,7 @@
 #endif //USBCON
 
 void init( void ) ;
-
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 #endif /* _BOARD_H_ */

--- a/cores/arduino/stm32/interrupt.cpp
+++ b/cores/arduino/stm32/interrupt.cpp
@@ -49,9 +49,6 @@
 #include "stm32_def.h"
 #include "interrupt.h"
 
-// #ifdef __cplusplus
-//  extern "C" {
-// #endif
 /**
   * @}
   */
@@ -411,8 +408,4 @@ void EXTI15_10_IRQHandler(void)
 /**
   * @}
   */
-// #ifdef __cplusplus
-// }
-// #endif
-
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cores/arduino/stm32/interrupt.cpp
+++ b/cores/arduino/stm32/interrupt.cpp
@@ -49,9 +49,9 @@
 #include "stm32_def.h"
 #include "interrupt.h"
 
-#ifdef __cplusplus
- extern "C" {
-#endif
+// #ifdef __cplusplus
+//  extern "C" {
+// #endif
 /**
   * @}
   */
@@ -62,8 +62,9 @@
 
 /*As we can have only one interrupt/pin id, don't need to get the port info*/
 typedef struct {
-  uint32_t irqnb;
-  void (*callback)(void);
+  IRQn_Type irqnb;
+  // void (*callback)(void);
+  std::function<void(void)> callback;
   uint32_t mode;
 }gpio_irq_conf_str;
 
@@ -156,16 +157,7 @@ uint8_t get_pin_id(uint16_t pin)
 
   return id;
 }
-/**
-  * @brief  This function enable the interruption on the selected port/pin
-  * @param  port : one of the gpio port
-  * @param  pin : one of the gpio pin
-  **@param  callback : callback to call when the interrupt falls
-  * @param  mode : one of the supported interrupt mode defined in stm32_hal_gpio
-  * @retval None
-  */
-void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, void (*callback)(void), uint32_t mode)
-{
+void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, callback_function_t callback, uint32_t mode){
   GPIO_InitTypeDef GPIO_InitStruct;
   uint8_t id = get_pin_id(pin);
 
@@ -228,6 +220,21 @@ void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, void (*callback)(v
 }
 
 /**
+  * @brief  This function enable the interruption on the selected port/pin
+  * @param  port : one of the gpio port
+  * @param  pin : one of the gpio pin
+  **@param  callback : callback to call when the interrupt falls
+  * @param  mode : one of the supported interrupt mode defined in stm32_hal_gpio
+  * @retval None
+  */
+void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, void (*callback)(void), uint32_t mode)
+{
+  std::function<void(void)> _c = callback;
+  stm32_interrupt_enable(port,pin,_c,mode);
+
+}
+
+/**
   * @brief  This function disable the interruption on the selected port/pin
   * @param  port : one of the gpio port
   * @param  pin : one of the gpio pin
@@ -263,6 +270,10 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
 }
 
 #if defined (STM32F0xx) || defined (STM32L0xx)
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
   * @brief This function handles external line 0 to 1 interrupt request.
   * @param  None
@@ -302,7 +313,13 @@ void EXTI4_15_IRQHandler(void)
     HAL_GPIO_EXTI_IRQHandler(pin);
   }
 }
+#ifdef __cplusplus
+}
+#endif
 #else
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
   * @brief This function handles external line 0 interrupt request.
   * @param  None
@@ -379,20 +396,24 @@ void EXTI15_10_IRQHandler(void)
     HAL_GPIO_EXTI_IRQHandler(pin);
   }
 }
-#endif
-/**
-  * @}
-  */
 
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
 #ifdef __cplusplus
 }
 #endif
+#endif
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+// #ifdef __cplusplus
+// }
+// #endif
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cores/arduino/stm32/interrupt.cpp
+++ b/cores/arduino/stm32/interrupt.cpp
@@ -63,7 +63,6 @@
 /*As we can have only one interrupt/pin id, don't need to get the port info*/
 typedef struct {
   IRQn_Type irqnb;
-  // void (*callback)(void);
   std::function<void(void)> callback;
   uint32_t mode;
 }gpio_irq_conf_str;

--- a/cores/arduino/stm32/interrupt.h
+++ b/cores/arduino/stm32/interrupt.h
@@ -45,15 +45,10 @@
 
 #ifdef __cplusplus
 #include <functional>
-// extern "C" {
 
 typedef std::function<void(void)> callback_function_t;
 void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, callback_function_t callback, uint32_t mode);
-// }
 #endif
-// #ifdef __cplusplus
-//  extern "C" {
-// #endif
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
@@ -61,9 +56,6 @@ void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, callback_function_
 /* Exported functions ------------------------------------------------------- */
 void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, void (*callback)(void), uint32_t mode);
 void stm32_interrupt_disable(GPIO_TypeDef *port, uint16_t pin);
-// #ifdef __cplusplus
-// }
-// #endif
 
 #endif /* __INTERRUPT_H */
 

--- a/cores/arduino/stm32/interrupt.h
+++ b/cores/arduino/stm32/interrupt.h
@@ -44,8 +44,16 @@
 #include "PinNames.h"
 
 #ifdef __cplusplus
- extern "C" {
+#include <functional>
+// extern "C" {
+
+typedef std::function<void(void)> callback_function_t;
+void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, callback_function_t callback, uint32_t mode);
+// }
 #endif
+// #ifdef __cplusplus
+//  extern "C" {
+// #endif
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
@@ -53,9 +61,9 @@
 /* Exported functions ------------------------------------------------------- */
 void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, void (*callback)(void), uint32_t mode);
 void stm32_interrupt_disable(GPIO_TypeDef *port, uint16_t pin);
-#ifdef __cplusplus
-}
-#endif
+// #ifdef __cplusplus
+// }
+// #endif
 
 #endif /* __INTERRUPT_H */
 

--- a/cores/arduino/wiring.h
+++ b/cores/arduino/wiring.h
@@ -38,13 +38,7 @@
 #include "wiring_time.h"
 #include "WInterrupts.h"
 
-// #ifdef __cplusplus
-// extern "C"{
-// #endif // __cplusplus
 #include <board.h>
-// #ifdef __cplusplus
-// }
-// #endif
 
 #ifdef __cplusplus
 #include "HardwareSerial.h"

--- a/cores/arduino/wiring.h
+++ b/cores/arduino/wiring.h
@@ -38,13 +38,13 @@
 #include "wiring_time.h"
 #include "WInterrupts.h"
 
-#ifdef __cplusplus
-extern "C"{
-#endif // __cplusplus
+// #ifdef __cplusplus
+// extern "C"{
+// #endif // __cplusplus
 #include <board.h>
-#ifdef __cplusplus
-}
-#endif
+// #ifdef __cplusplus
+// }
+// #endif
 
 #ifdef __cplusplus
 #include "HardwareSerial.h"


### PR DESCRIPTION
The function attachInterrupt now also accept std:function<void(void)> in order to bind object method to an interrupt.