### PR TITLE
Enhance DEBUG_UART feature (used by printf)

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -220,7 +220,7 @@ void HardwareSerial::begin(unsigned long baud, byte config)
 
   _serial.baudrate = (uint32_t)baud;
 
-  // Manage databitshardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+  // Manage databits
   switch(config & 0x07) {
     case 0x02:
       databits = 6;

--- a/cores/arduino/stm32/uart.c
+++ b/cores/arduino/stm32/uart.c
@@ -97,6 +97,7 @@ void uart_init(serial_t *obj)
   UART_HandleTypeDef *huart = &(obj->handle);
   GPIO_InitTypeDef GPIO_InitStruct;
   GPIO_TypeDef *port;
+  uint32_t function = (uint32_t)NC;
 
   // Determine the UART to use (UART_1, UART_2, ...)
   USART_TypeDef *uart_tx = pinmap_peripheral(obj->pin_tx, PinMap_UART_TX);
@@ -238,27 +239,29 @@ void uart_init(serial_t *obj)
   //Configure GPIOs
   //RX
   port = set_GPIO_Port_Clock(STM_PORT(obj->pin_rx));
+  function = pinmap_function(obj->pin_rx, PinMap_UART_RX);
   GPIO_InitStruct.Pin         = STM_GPIO_PIN(obj->pin_rx);
-  GPIO_InitStruct.Mode        = STM_PIN_MODE(pinmap_function(obj->pin_rx,PinMap_UART_RX));
+  GPIO_InitStruct.Mode        = STM_PIN_MODE(function);
   GPIO_InitStruct.Speed       = GPIO_SPEED_FREQ_HIGH;
-  GPIO_InitStruct.Pull        = STM_PIN_PUPD(pinmap_function(obj->pin_rx,PinMap_UART_RX));
+  GPIO_InitStruct.Pull        = STM_PIN_PUPD(function);
 #ifdef STM32F1xx
-  pin_SetF1AFPin(STM_PIN_AFNUM(pinmap_function(obj->pin_rx,PinMap_UART_RX)));
+  pin_SetF1AFPin(STM_PIN_AFNUM(function));
 #else
-  GPIO_InitStruct.Alternate   = STM_PIN_AFNUM(pinmap_function(obj->pin_rx,PinMap_UART_RX));
+  GPIO_InitStruct.Alternate   = STM_PIN_AFNUM(function);
 #endif /* STM32F1xx */
   HAL_GPIO_Init(port, &GPIO_InitStruct);
 
   //TX
   port = set_GPIO_Port_Clock(STM_PORT(obj->pin_tx));
+  function = pinmap_function(obj->pin_tx, PinMap_UART_TX);
   GPIO_InitStruct.Pin         = STM_GPIO_PIN(obj->pin_tx);
-  GPIO_InitStruct.Mode        = STM_PIN_MODE(pinmap_function(obj->pin_tx,PinMap_UART_TX));
+  GPIO_InitStruct.Mode        = STM_PIN_MODE(function);
   GPIO_InitStruct.Speed       = GPIO_SPEED_FREQ_HIGH;
-  GPIO_InitStruct.Pull        = STM_PIN_PUPD(pinmap_function(obj->pin_tx,PinMap_UART_TX));
+  GPIO_InitStruct.Pull        = STM_PIN_PUPD(function);
 #ifdef STM32F1xx
-  pin_SetF1AFPin(STM_PIN_AFNUM(pinmap_function(obj->pin_tx,PinMap_UART_TX)));
+  pin_SetF1AFPin(STM_PIN_AFNUM(function));
 #else
-  GPIO_InitStruct.Alternate   = STM_PIN_AFNUM(pinmap_function(obj->pin_tx,PinMap_UART_TX));
+  GPIO_InitStruct.Alternate   = STM_PIN_AFNUM(function);
 #endif /* STM32F1xx */
   HAL_GPIO_Init(port, &GPIO_InitStruct);
 

--- a/variants/board_template/variant.h
+++ b/variants/board_template/variant.h
@@ -109,6 +109,10 @@ enum {
 #define SERIAL_UART_INSTANCE    x //ex: 2 for Serial2 (USART2)
 // DEBUG_UART could be redefined to print on another instance than 'Serial'
 //#define DEBUG_UART              ((USART_TypeDef *) U(S)ARTX) // ex: USART3
+// DEBUG_UART baudrate, default: 9600 if not defined
+//#define DEBUG_UART_BAUDRATE     x
+// DEBUG_UART Tx pin name, default: the first one found in PinMap_UART_TX for DEBUG_UART
+//#define DEBUG_PINNAME_TX        PX_n // PinName used for TX
 
 // UART Emulation (uncomment if needed, required TIM1)
 //#define UART_EMUL_RX            PX_n // PinName used for RX


### PR DESCRIPTION
If the debug UART is not initialized by a Serial instance, init it at 9600 (8N1) by default.
Else use the config done by the Serial instance.

Those values could be redefined in the variant.h
DEBUG_UART could be redefined to print on another instance than 'Serial'
`#define DEBUG_UART              ((USART_TypeDef *) U(S)ARTX) // ex: USART3`
DEBUG_UART baudrate, default: 9600 if not defined
`#define DEBUG_UART_BAUDRATE     115200`
DEBUG_UART Tx pin name, default: the first one found in PinMap_UART_TX for DEBUG_UART
`#define DEBUG_PINNAME_TX        PX_n // PinName used for TX`
