### PR TITLE
Added _Error_Handler(const char *, int)

### DIFF
--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -20,14 +20,6 @@
 
 #include "PeripheralPins.h"
 
-/**
- * Libc porting layers
- */
-#if defined (  __GNUC__  ) /* GCC CS3 */
-#include <syscalls.h> /** RedHat Newlib minimal stub */
-#define WEAK __attribute__ ((weak))
-#endif
-
 // Arduino digital pin alias
 // GPIO port (A to K) * 16 pins: 176
 enum {

--- a/cores/arduino/stm32/stm32_def.c
+++ b/cores/arduino/stm32/stm32_def.c
@@ -1,0 +1,23 @@
+#include "stm32_def.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief  This function is executed in case of error occurrence.
+  * @param  None
+  * @retval None
+  */
+WEAK void _Error_Handler(const char * msg, int val)
+{
+  /* User can add his own implementation to report the HAL error return state */
+  printf("Error: %s (%i)\n", msg, val);
+  while(1)
+  {
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/cores/arduino/stm32/stm32_def.h
+++ b/cores/arduino/stm32/stm32_def.h
@@ -74,11 +74,25 @@
 #define CAN1 CAN
 #endif
 
+/**
+ * Libc porting layers
+ */
+#if defined (  __GNUC__  ) /* GCC CS3 */
+#include <syscalls.h> /** RedHat Newlib minimal stub */
+#define WEAK __attribute__ ((weak))
+#endif
+
 #ifdef __cplusplus
 extern "C"{
 #endif // __cplusplus
+
 // weaked functions declaration
 void SystemClock_Config(void);
+
+void _Error_Handler(const char *, int);
+
+#define Error_Handler() _Error_Handler(__FILE__, __LINE__)
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus


### PR DESCRIPTION
Allow to use the SystemClock_Config() from STM32CubeMX without any change.
It could be redefined by user at sketch level (weak)

extern "C" void _Error_Handler(const char * file, int line)
{
...
}

Fix #66