### PR TITLE
Clean variants files

### DIFF
--- a/cores/arduino/pins_arduino_var.h
+++ b/cores/arduino/pins_arduino_var.h
@@ -100,6 +100,54 @@ uint32_t pinNametoDigitalPin(PinName p);
                                      (digitalPinFirstOccurence(p) == PIN_SERIAL_TX))
 #endif
 
+// Default Definitions, could be redefined in variant.h
+#ifndef ADC_RESOLUTION
+#define ADC_RESOLUTION              12
+#endif
+#ifndef DACC_RESOLUTION
+#define DACC_RESOLUTION             12
+#endif
+#ifndef PWM_RESOLUTION
+#define PWM_RESOLUTION              8
+#endif
+#ifndef PWM_FREQUENCY
+#define PWM_FREQUENCY               1000
+#endif
+#ifndef PWM_MAX_DUTY_CYCLE
+#define PWM_MAX_DUTY_CYCLE          255
+#endif
+
+// Default for Arduino connector compatibility
+// SPI Definitions
+#ifndef SS
+#define SS                          10
+#endif
+#ifndef SS1
+#define SS1                         4
+#endif
+#ifndef SS2
+#define SS2                         7
+#endif
+#ifndef SS3
+#define SS3                         8
+#endif
+#ifndef MOSI
+#define MOSI                        11
+#endif
+#ifndef MISO
+#define MISO                        12
+#endif
+#ifndef SCK
+#define SCK                         13
+#endif
+// I2C Definitions
+#ifndef SDA
+#define SDA                         14
+#endif
+#ifndef SCL
+#define SCL                         15
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/DISCO_F100RB/variant.h
+++ b/variants/DISCO_F100RB/variant.h
@@ -112,42 +112,32 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
-#define LED_BUILTIN             21
+// On-board LED pin number
+#define LED_BUILTIN             PC9
 #define LED_GREEN               LED_BUILTIN
-#define LED_BLUE                20
+#define LED_BLUE                PC8
 
-//On-board user button
+// On-board user button
 #define USER_BTN                5
 
-//SPI definitions
-#define SS                      43
-#define SS1                     40
-#define SS2                     41
-#define SS3                     42
-#define MOSI                    46
-#define MISO                    45
-#define SCK                     44
+// SPI Definitions
+#define SS                      PB12
+#define SS1                     PB9
+#define SS2                     PB10
+#define SS3                     PB11
+#define MOSI                    PB15
+#define MISO                    PB14
+#define SCK                     PB13
 
-//I2C Definitions
-#define SDA                     38
-#define SCL                     37
+// I2C Definitions
+#define SDA                     PB7
+#define SCL                     PB6
 
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM15
-#define TIMER_UART_EMULATED     TIM16
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM17  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/DISCO_F407VG/variant.h
+++ b/variants/DISCO_F407VG/variant.h
@@ -137,49 +137,33 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
-#define LED_BUILTIN             18
+// On-board LED pin number
+#define LED_BUILTIN             PD12
 #define LED_GREEN               LED_BUILTIN
-#define LED_BLUE                58
-#define LED_RED                 19
-#define LED_ORANGE              57
+#define LED_BLUE                PD15
+#define LED_RED                 PD14
+#define LED_ORANGE              PD13
 
-//On-board user button
+// On-board user button
 #define USER_BTN                2
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
+// SPI Definitions
 #define SS2                     14
-#define MOSI                    44
+#define MOSI                    PA7
 #define MISO                    5
-#define SCK                     43
+#define SCK                     PA5
 
-//I2C Definitions
-#define SDA                     66
-#define SCL                     26
+// I2C Definitions
+#define SDA                     PB7
+#define SCL                     PB8
 
-//Timer Definitions
-//Do not use timer used by PWM pin. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pin. See PinMap_PWM.
 #define TIMER_TONE              TIM6
 #define TIMER_SERVO             TIM7
-#define TIMER_UART_EMULATED     TIM6
 
 // UART Definitions
 #define SERIAL_UART_INSTANCE    2 //Connected to ST-Link
-// UART Emulation
-#define UART_EMUL_RX            PE_9
-#define UART_EMUL_TX            PE_11
 
 // Default pin used for 'Serial' instance (ex: ST-Link)
 // Mandatory for Firmata

--- a/variants/DISCO_F746NG/variant.h
+++ b/variants/DISCO_F746NG/variant.h
@@ -69,42 +69,18 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                22
+// On-board user button
+#define USER_BTN                PI11
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
-#define TIMER_UART_EMULATED     TIM7
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/DISCO_L072CZ_LRWAN1/variant.h
+++ b/variants/DISCO_L072CZ_LRWAN1/variant.h
@@ -79,16 +79,7 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             PA5
 #define LED_LD2                 LED_BUILTIN
 #define LED_GREEN2              LED_BUILTIN
@@ -99,28 +90,14 @@ enum {
 #define LED_RED                 5
 #define LED_LD4                 LED_RED
 
-//On-board user button
+// On-board user button
 #define USER_BTN                6
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM22
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/DISCO_L475VG_IOT/variant.h
+++ b/variants/DISCO_L475VG_IOT/variant.h
@@ -139,45 +139,21 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED1                    LED_BUILTIN
 #define LED2                    PB14
 #define LED3                    PC9
 #define LED4                    LED3
 
-//On-board user button
+// On-board user button
 #define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
-#define TIMER_UART_EMULATED     TIM7
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_F030R8/variant.h
+++ b/variants/NUCLEO_F030R8/variant.h
@@ -112,40 +112,18 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                24
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM3  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_F091RC/variant.h
+++ b/variants/NUCLEO_F091RC/variant.h
@@ -109,49 +109,22 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                23
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
-#define TIMER_UART_EMULATED     TIM7
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions
 #define SERIAL_UART_INSTANCE    2 //Connected to ST-Link
-// UART Emulation
-#define UART_EMUL_RX            PB_14
-#define UART_EMUL_TX            PB_13
 
 // Default pin used for 'Serial' instance (ex: ST-Link)
 // Mandatory for Firmata

--- a/variants/NUCLEO_F103RB/variant.h
+++ b/variants/NUCLEO_F103RB/variant.h
@@ -111,41 +111,18 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION                12
-#define DACC_RESOLUTION               12
-
-//PWR resolution
-#define PWM_RESOLUTION                8
-#define PWM_FREQUENCY                 1000
-#define PWM_MAX_DUTY_CYCLE            255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                23
+// On-board user button
+#define USER_BTN                PC13
 
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM4
-#define TIMER_UART_EMULATED     TIM4
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_F207ZG/variant.h
+++ b/variants/NUCLEO_F207ZG/variant.h
@@ -155,41 +155,20 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
-#define LED_BUILTIN             33
+// On-board LED pin number
+#define LED_BUILTIN             PB0
 #define LED_GREEN               LED_BUILTIN
-#define LED_BLUE                73
-#define LED_RED                 74
+#define LED_BLUE                PB7
+#define LED_RED                 PB14
 
-//On-board user button
-#define USER_BTN                75
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM in PeripheralPins.c
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM in PeripheralPins.c
 #define TIMER_TONE              TIM6
-#define TIMER_UART_EMULATED     TIM7
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_F302R8/variant.h
+++ b/variants/NUCLEO_F302R8/variant.h
@@ -109,41 +109,18 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                23
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_F303K8/variant.h
+++ b/variants/NUCLEO_F303K8/variant.h
@@ -67,38 +67,22 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
+// On-board user button
 //#define USER_BTN              NC
 
-
-//SPI definitions
-#define SS                      10
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
+// I2C Definitions
 #define SDA                     4
 #define SCL                     5
 
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
  // UART Definitions

--- a/variants/NUCLEO_F303RE/variant.h
+++ b/variants/NUCLEO_F303RE/variant.h
@@ -111,49 +111,22 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                23
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
-#define TIMER_UART_EMULATED     TIM7
 
 //Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions
 #define SERIAL_UART_INSTANCE    2 //Connected to ST-Link
-// UART Emulation
-#define UART_EMUL_RX            PC_1
-#define UART_EMUL_TX            PC_3
 
 // Default pin used for 'Serial' instance (ex: ST-Link)
 // Mandatory for Firmata

--- a/variants/NUCLEO_F401RE/variant.h
+++ b/variants/NUCLEO_F401RE/variant.h
@@ -110,49 +110,22 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                23
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM10
-#define TIMER_UART_EMULATED     TIM11
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions
 #define SERIAL_UART_INSTANCE    2 //Connected to ST-Link
-// UART Emulation
-#define UART_EMUL_RX            PC_1
-#define UART_EMUL_TX            PC_3
 
 // Default pin used for 'Serial' instance (ex: ST-Link)
 // Mandatory for Firmata

--- a/variants/NUCLEO_F411RE/variant.h
+++ b/variants/NUCLEO_F411RE/variant.h
@@ -110,42 +110,18 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                23
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM10
-#define TIMER_UART_EMULATED     TIM11
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_F429ZI/variant.h
+++ b/variants/NUCLEO_F429ZI/variant.h
@@ -142,51 +142,24 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
-#define LED_BUILTIN             33
+// On-board LED pin number
+#define LED_BUILTIN             PB0
 #define LED_GREEN               LED_BUILTIN
-#define LED_BLUE                73
-#define LED_RED                 74
+#define LED_BLUE                PB7
+#define LED_RED                 PB14
 
-//On-board user button
-#define USER_BTN                75
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
-#define TIMER_UART_EMULATED     TIM7
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions
 #define SERIAL_UART_INSTANCE    3 //Connected to ST-Link
-// UART Emulation
-#define UART_EMUL_RX            PF_15
-#define UART_EMUL_TX            PE_13
 
 // Serial pin used for console (ex: stlink)
 // Rerquired by Firmata

--- a/variants/NUCLEO_F446RE/variant.h
+++ b/variants/NUCLEO_F446RE/variant.h
@@ -111,41 +111,19 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWM resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_LD2                 LED_BUILTIN
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
+// On-board user button
 #define USER_BTN                PC13
 
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM10
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_L053R8/variant.h
+++ b/variants/NUCLEO_L053R8/variant.h
@@ -109,42 +109,18 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                23
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
-#define TIMER_UART_EMULATED     TIM7
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_L152RE/variant.h
+++ b/variants/NUCLEO_L152RE/variant.h
@@ -114,42 +114,18 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                23
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM10
-#define TIMER_UART_EMULATED     TIM11
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_L432KC/variant.h
+++ b/variants/NUCLEO_L432KC/variant.h
@@ -67,38 +67,22 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
+// On-board user button
 //#define USER_BTN                NC
 
-
-//SPI definitions
-#define SS                      10
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
+// I2C Definitions
 #define SDA                     4
 #define SCL                     5
 
-//Timer Definitions
+// Timer Definitions
 //Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions

--- a/variants/NUCLEO_L476RG/variant.h
+++ b/variants/NUCLEO_L476RG/variant.h
@@ -109,49 +109,22 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
-
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
-
-//On-board LED pin number
+// On-board LED pin number
 #define LED_BUILTIN             13
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
-#define USER_BTN                23
+// On-board user button
+#define USER_BTN                PC13
 
-
-//SPI definitions
-#define SS                      10
-#define SS1                     4
-#define SS2                     7
-#define SS3                     8
-#define MOSI                    11
-#define MISO                    12
-#define SCK                     13
-
-//I2C Definitions
-#define SDA                     14
-#define SCL                     15
-
-//Timer Definitions
-//Do not use timer used by PWM pins when possible. See PinMap_PWM.
+// Timer Definitions
+// Do not use timer used by PWM pins when possible. See PinMap_PWM.
 #define TIMER_TONE              TIM6
-#define TIMER_UART_EMULATED     TIM7
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
 
 // UART Definitions
 #define SERIAL_UART_INSTANCE    2 //Connected to ST-Link
-// UART Emulation
-#define UART_EMUL_RX            PB_13
-#define UART_EMUL_TX            PB_14
 
 // Default pin used for 'Serial' instance (ex: ST-Link)
 // Mandatory for Firmata

--- a/variants/board_template/variant.h
+++ b/variants/board_template/variant.h
@@ -69,39 +69,43 @@ enum {
   AEND
 };
 
-//ADC resolution is 12bits
-#define ADC_RESOLUTION          12
-#define DACC_RESOLUTION         12
 
-//PWR resolution
-#define PWM_RESOLUTION          8
-#define PWM_FREQUENCY           1000
-#define PWM_MAX_DUTY_CYCLE      255
+// Below ADC, DAC and PWM definitions already done in the core
+// Could be redefined here if needed
+// ADC resolution is 12bits
+//#define ADC_RESOLUTION          12
+//#define DACC_RESOLUTION         12
 
-//On-board LED pin number
+// PWM resolution
+//#define PWM_RESOLUTION          8
+//#define PWM_FREQUENCY           1000
+//#define PWM_MAX_DUTY_CYCLE      255
+
+// On-board LED pin number
 #define LED_BUILTIN             Dx
 #define LED_GREEN               LED_BUILTIN
 
-//On-board user button
+// On-board user button
 #define USER_BTN                Dx
 
+// Below SPI and I2C definitions already done in the core
+// Could be redefined here if needed
+// SPI Definitions
+//#define SS                      10 // Default for Arduino connector compatibility
+//#define MOSI                    11 // Default for Arduino connector compatibility
+//#define MISO                    12 // Default for Arduino connector compatibility
+//#define SCK                     13 // Default for Arduino connector compatibility
 
-//SPI definitions
-#define SS                      10 // Default for Arduino connector compatibility
-#define MOSI                    11 // Default for Arduino connector compatibility
-#define MISO                    12 // Default for Arduino connector compatibility
-#define SCK                     13 // Default for Arduino connector compatibility
+// I2C Definitions
+//#define SDA                     14 // Default for Arduino connector compatibility
+//#define SCL                     15 // Default for Arduino connector compatibility
 
-//I2C Definitions
-#define SDA                     14 // Default for Arduino connector compatibility
-#define SCL                     15 // Default for Arduino connector compatibility
-
-//Timer Definitions
+// Timer Definitions
 //Do not use timer used by PWM pins when possible. See PinMap_PWM in PeripheralPins.c
 #define TIMER_TONE              TIMx
-#define TIMER_UART_EMULATED     TIMx
+//#define TIMER_UART_EMULATED     TIMx
 
-//Do not use basic timer: OC is required
+// Do not use basic timer: OC is required
 #define TIMER_SERVO             TIMx  //TODO: advanced-control timers don't work
 
 // UART Definitions


### PR DESCRIPTION
- Common definitions are moved to pins_arduino_var.h.
  They could be redefined in variant.h if needed.
- Removed *UART_EMUL* definitions as it is needed to be reworked in SoftwareSerial library.
- Pin number over D15 replaced by pin name (more relevant)
- Fixed some typos