### PR TITLE
Fixed ADC read value

### DIFF
--- a/cores/arduino/stm32/analog.c
+++ b/cores/arduino/stm32/analog.c
@@ -607,6 +607,11 @@ uint16_t adc_read_value(PinName pin)
 #ifndef STM32L0xx
   AdcChannelConf.SamplingTime = SAMPLINGTIME;                     /* Sampling time value to be set for the selected channel */
 #endif
+#if defined (STM32F3xx) || defined (STM32L4xx)
+  AdcChannelConf.SingleDiff   = ADC_SINGLE_ENDED;                 /* Single-ended input channel */
+  AdcChannelConf.OffsetNumber = ADC_OFFSET_NONE;                  /* No offset subtraction */
+  AdcChannelConf.Offset = 0;                                      /* Parameter discarded because offset correction is disabled */
+#endif
   /*##-2- Configure ADC regular channel ######################################*/
   if (HAL_ADC_ConfigChannel(&AdcHandle, &AdcChannelConf) != HAL_OK)
   {


### PR DESCRIPTION
Fix #168
Last STM32L4xx HAL Drivers update change ADC init (using LL).
Some ADC_ChannelConfTypeDef fields were missing. Mainly SingleDiff.