### PR TITLE
Added force rebuild menu

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -7,6 +7,7 @@ menu.usb=USB interface
 
 menu.opt=Optimize
 menu.upload_method=Upload method
+menu.rebuild=Force rebuild
 
 ################################################################################
 # Nucleo 144 boards
@@ -553,3 +554,20 @@ Disco.menu.opt.o3lto.build.flags.ldspecs=-flto
 Disco.menu.opt.ogstd=Debug (-g)
 Disco.menu.opt.ogstd.build.flags.optimize=-g -Og
 Disco.menu.opt.ogstd.build.flags.ldspecs=
+
+# Force rebuild
+Nucleo_144.menu.rebuild.none=None
+Nucleo_144.menu.rebuild.forced=force
+Nucleo_144.menu.rebuild.forced.build.force=1
+
+Nucleo_64.menu.rebuild.none=None
+Nucleo_64.menu.rebuild.forced=force
+Nucleo_64.menu.rebuild.forced.build.force=1
+
+Nucleo_32.menu.rebuild.none=None
+Nucleo_32.menu.rebuild.forced=force
+Nucleo_32.menu.rebuild.forced.build.force=1
+
+Disco.menu.rebuild.none=None
+Disco.menu.rebuild.forced=force
+Disco.menu.rebuild.forced.build.force=1

--- a/platform.txt
+++ b/platform.txt
@@ -76,6 +76,7 @@ build.xSerial=
 build.enable_usb=
 build.flags.optimize=
 build.flags.ldspecs=
+build.force=0
 
 # Pre and post build hooks
 build.opt.name=build_opt.h
@@ -86,6 +87,11 @@ build.opt.path={build.path}/sketch/{build.opt.name}
 recipe.hooks.prebuild.1.pattern.windows=cmd /c "if not exist {build.opt.sourcepath} mkdir {build.path}\sketch & type NUL > {build.opt.path}"
 recipe.hooks.prebuild.1.pattern.linux=bash -c "[ -f {build.opt.sourcepath} ] || (mkdir -p {build.path}/sketch && touch {build.opt.path})"
 recipe.hooks.prebuild.1.pattern.macosx=bash -c "[ -f {build.opt.sourcepath} ] || (mkdir -p {build.path}/sketch && touch {build.opt.path})"
+
+# Check if force rebuild required (required aggressively cache compiled core to be disabled)
+recipe.hooks.sketch.prebuild.1.pattern.windows=cmd /c "if {build.force} equ 1 ( if exist {build.path}\core del /Q /F /S {build.path}\core {build.path}\libraries > nul 2>&1)"
+recipe.hooks.sketch.prebuild.1.pattern.linux=bash -c "[ {build.force} -eq 0 ] || [ ! -d {build.path}/core ] || rm -fr {build.path}/core {build.path}/libraries"
+recipe.hooks.sketch.prebuild.1.pattern.macosx=bash -c "[ {build.force} -eq 0 ] || [ ! -d {build.path}/core ] || rm -fr {build.path}/core {build.path}/libraries"
 
 # compile patterns
 # ---------------------


### PR DESCRIPTION
Allow to force a rebuild, useful with build_opt.h feature. 
When updating build_opt.h file, Arduino IDE does not detect change in the source then do not rebuild and new build options are ignored. This avoid to restart IDE to take those changes in account.

Required aggressively cache compiled core to be disabled
else no force rebuild.

Need to be tested on Linux/MacOSx