### PR TITLE
Update c++ compilation standard to 2014 from 2011.

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -35,7 +35,7 @@ compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.stm.e
 
 compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -Dprintf=iprintf -MMD {compiler.stm.extra_include}
 
-compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu++11 -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD {compiler.stm.extra_include}
+compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu++14 -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD {compiler.stm.extra_include}
 
 compiler.ar.flags=rcs
 


### PR DESCRIPTION
Requires a recent arm toolchain to be used.

This allows boost::hana and all sorts of crazy programming techniques.