### PR TITLE
Added .DS_Store, boards.local.txt and platform.local.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.orig
 *.swp
+.DS_Store
+boards.local.txt
+platform.local.txt


### PR DESCRIPTION
You can keep local platform configurations in the `boards.local.txt` and `platform.local.txt`

For example if you want to use -std=c++17 you can add this file to the root:

platform.local.txt:
`compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=c++17 -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD {compiler.stm.extra_include}`

(using a g++ 7.2 cross compiler)

This PR simply adds those files to .gitignore so that your private/local changes won't accidentally be included in any commit.