### PR TITLE
Added setXXX methods to change used pins of an instance

### DIFF
--- a/libraries/SPI/keywords.txt
+++ b/libraries/SPI/keywords.txt
@@ -17,7 +17,10 @@ transfer		KEYWORD2
 #setBitOrder	KEYWORD2
 setDataMode		KEYWORD2
 setClockDivider	KEYWORD2
-
+setMISO			KEYWORD2
+setMOSI			KEYWORD2
+setSCLK			KEYWORD2
+setSSEL			KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -112,6 +112,17 @@ class SPIClass {
     SPIClass();
     SPIClass(uint8_t mosi, uint8_t miso, uint8_t sclk, uint8_t ssel = (uint8_t)NC);
 
+    // setMISO/MOSI/SCLK/SSEL have to be called before begin()
+    void setMISO(uint32_t miso) { _spi.pin_miso = digitalPinToPinName(miso); };
+    void setMOSI(uint32_t mosi) { _spi.pin_mosi = digitalPinToPinName(mosi); };
+    void setSCLK(uint32_t sclk) { _spi.pin_sclk = digitalPinToPinName(sclk); };
+    void setSSEL(uint32_t ssel) { _spi.pin_ssel = digitalPinToPinName(ssel); };
+
+    void setMISO(PinName miso) { _spi.pin_miso = (miso); };
+    void setMOSI(PinName mosi) { _spi.pin_mosi = (mosi); };
+    void setSCLK(PinName sclk) { _spi.pin_sclk = (sclk); };
+    void setSSEL(PinName ssel) { _spi.pin_ssel = (ssel); };
+
     void begin(uint8_t _pin = CS_PIN_CONTROLLED_BY_USER);
     void end(void);
 

--- a/libraries/Wire/keywords.txt
+++ b/libraries/Wire/keywords.txt
@@ -17,6 +17,8 @@ endTransmission		KEYWORD2
 requestFrom		KEYWORD2
 onReceive		KEYWORD2
 onRequest		KEYWORD2
+setSCL			KEYWORD2
+setSDA			KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -67,6 +67,11 @@ class TwoWire : public Stream
   public:
     TwoWire();
     TwoWire(uint8_t sda, uint8_t scl);
+    // setSCL/SDA have to be called before begin()
+    void setSCL(uint32_t scl) { _i2c.scl = digitalPinToPinName(scl); };
+    void setSDA(uint32_t sda) { _i2c.sda = digitalPinToPinName(sda); };
+    void setSCL(PinName scl) { _i2c.scl = scl; };
+    void setSDA(PinName sda) { _i2c.sda = sda; };
     void begin();
     void begin(uint8_t);
     void begin(int);


### PR DESCRIPTION
Example to change pins used by Wire instance (by default use defined SDA/SCL ):
```
Wire.setSDA(A4);
Wire.setSCL(PC2);
Wire.begin();
```

Example to change pins used by SPI instance (by default use defined MISO/MOSI/SCK):
```
SPI.setMOSI(22);
SPI.setMISO(PA3);
SPI.begin();
```