### PR TITLE
Added new HardwareSerial constructor using pin number

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -138,6 +138,13 @@ void serialEventRun(void)
 }
 
 // Constructors ////////////////////////////////////////////////////////////////
+HardwareSerial::HardwareSerial(uint32_t _rx, uint32_t _tx)
+{
+  _serial.pin_rx = digitalPinToPinName(_rx);
+  _serial.pin_tx = digitalPinToPinName(_tx);
+  init();
+}
+
 HardwareSerial::HardwareSerial(PinName _rx, PinName _tx)
 {
   _serial.pin_rx = _rx;

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -101,6 +101,7 @@ class HardwareSerial : public Stream
     serial_t _serial;
 
   public:
+    HardwareSerial(uint32_t _rx, uint32_t _tx);
     HardwareSerial(PinName _rx, PinName _tx);
     HardwareSerial(void* peripheral);
     void begin(unsigned long baud) { begin(baud, SERIAL_8N1); }


### PR DESCRIPTION
Allow to instantiate HardwareSerial with pin number.
Both lines are the same:
```
HardwareSerial SerialLora(PA_1, PA_0); // PinNames
HardwareSerial SerialLora(PA1, PA0); // Pin number
```