### PR TITLE
Update c++ compilation standard to 2014 from 2011

### DIFF
--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -34,3 +34,10 @@ void operator delete[](void * ptr) {
   free(ptr);
 }
 
+void operator delete(void * ptr, size_t /*size*/) {
+  free(ptr);
+}
+
+void operator delete[](void * ptr, size_t /*size*/) {
+  free(ptr);
+}

--- a/platform.txt
+++ b/platform.txt
@@ -35,7 +35,7 @@ compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.stm.e
 
 compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -Dprintf=iprintf -MMD {compiler.stm.extra_include}
 
-compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu++11 -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD {compiler.stm.extra_include}
+compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std={compiler.cpp.std} -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD {compiler.stm.extra_include}
 
 compiler.ar.flags=rcs
 
@@ -57,6 +57,7 @@ build.ldscript=ldscript.ld
 compiler.c.extra_flags=
 compiler.c.elf.extra_flags=
 compiler.cpp.extra_flags=
+compiler.cpp.std=gnu++14
 compiler.S.extra_flags=
 compiler.ar.extra_flags=
 compiler.elf2hex.extra_flags=


### PR DESCRIPTION
Requires a recent arm toolchain to be used.

Based on PR #191 proposed by @xloem
Updated using @lacklustrlabs suggestion:
Make the '-std=gnu++14' flag a variable using 'compiler.cpp.flags' variable.
This way it is easy to change the -std setting in platform.local.txt without
overriding anything else.

platform.local.txt:
compiler.cpp.std=gnu++11

Signed-off-by: Frederic Pillon <frederic.pillon@st.com>