### PR TITLE
Improves micros() accuracy using SysTick COUNTFLAG

### DIFF
--- a/cores/arduino/stm32/clock.c
+++ b/cores/arduino/stm32/clock.c
@@ -35,66 +35,11 @@
   *
   ******************************************************************************
   */
-/** @addtogroup CMSIS
-  * @{
-  */
-
-/** @addtogroup stm32f4xx_system
-  * @{
-  */
-
-/** @addtogroup STM32F4xx_System_Private_Includes
-  * @{
-  */
 #include "stm32_def.h"
 
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F4xx_System_Private_TypesDefinitions
-  * @{
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F4xx_System_Private_Defines
-  * @{
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F4xx_System_Private_Macros
-  * @{
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F4xx_System_Private_Variables
-  * @{
-  */
-
-/**
-  * @}
-  */
-
-/** @addtogroup STM32F4xx_System_Private_FunctionPrototypes
-  * @{
-  */
-
-/**
-  * @}
-  */
 
 /**
   * @brief  Function called to read the current micro second
@@ -176,17 +121,6 @@ void delayInsideIT(uint32_t delay_us)
 #endif
 }
 
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
 #ifdef __cplusplus
 }
 #endif

--- a/cores/arduino/stm32/clock.c
+++ b/cores/arduino/stm32/clock.c
@@ -48,16 +48,15 @@
   */
 uint32_t GetCurrentMicro(void)
 {
-  uint32_t m0 = HAL_GetTick();
-  uint32_t u0 = SysTick->LOAD - SysTick->VAL;
-  uint32_t m1 = HAL_GetTick();
-  uint32_t u1 = SysTick->LOAD - SysTick->VAL;
-
-  if (m1 > m0) {
-    return ( m1 * 1000 + (u1 * 1000) / SysTick->LOAD);
-  } else {
-    return ( m0 * 1000 + (u0 * 1000) / SysTick->LOAD);
+  /* Ensure COUNTFLAG is reset by reading SysTick control and status register */
+  LL_SYSTICK_IsActiveCounterFlag();
+  uint32_t m = HAL_GetTick();
+  uint32_t u = SysTick->LOAD - SysTick->VAL;
+  if(LL_SYSTICK_IsActiveCounterFlag()) {
+    m = HAL_GetTick();
+    u = SysTick->LOAD - SysTick->VAL;
   }
+  return ( m * 1000 + (u * 1000) / SysTick->LOAD);
 }
 
 /**


### PR DESCRIPTION
Test:

```
  for( uint32_t i = 0; i<2000; i++) { 
    start_us= micros();
    delayMicroseconds(i);
    end_us = micros();
  }
```
_diff_ = `end_us - start_us` is the difference btw the requested delay and the measured one with micros()
_old_ = number of the same difference in the 2000 iteration  for the previous implementation
_new_ = number of the same difference in the 2000 iteration  for this PR implementation

 **Nucleo-F103RB**

| diff (ms) | old | new |
| :---: | :---: | :---: |
| 0 |  0 | 4 |  
| 1 | 0 | 149 |  
| 2 | 633 | 1842 |  
| 3 | 1015 | 5 |  
| 4 | 348 | 0 |  
| 5 | 3 | 0 |  

 **Discovery L475VG IOT**

| diff (ms) | old | new |
| :---: | :---: | :---: |
| 0 |  148 | 699 |  
| 1 | 811 | 1030 |  
| 2 | 1038 | 271 |  
| 3 | 3 | 0 |  
| 4 | 0 | 0 |  
| 5 | 0 | 0 |  
