### PR TITLE
Avoid to have first analog pin value (A0) lesser than NUM_ANALOG_INPUTS

### DIFF
--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -50,7 +50,10 @@ enum {
 // Arduino analog pins
 // Analog pins must be contiguous to be able to loop on each value
 #define MAX_ANALOG_INPUTS 20
-_Static_assert(NUM_ANALOG_INPUTS <= MAX_ANALOG_INPUTS, "Core NUM_ANALOG_INPUTS limited to MAX_ANALOG_INPUTS" );
+_Static_assert(NUM_ANALOG_INPUTS <= MAX_ANALOG_INPUTS,
+               "Core NUM_ANALOG_INPUTS limited to MAX_ANALOG_INPUTS" );
+_Static_assert(NUM_ANALOG_FIRST >= NUM_ANALOG_INPUTS,
+               "First analog pin value (A0) must be greater than or equal to NUM_ANALOG_INPUTS" );
 
 // Defined for backward compatibility with Firmata which unfortunately use it
 #define AEND (NUM_ANALOG_FIRST+NUM_ANALOG_INPUTS)

--- a/variants/board_template/variant.h
+++ b/variants/board_template/variant.h
@@ -75,6 +75,7 @@ enum {
 // !!!
 #define NUM_ANALOG_INPUTS       0
 // Define digital pin number of the first analog input  (i.e. which digital pin is A0)
+// First analog pin value (A0) must be greater than or equal to NUM_ANALOG_INPUTS
 #define NUM_ANALOG_FIRST        0
 
 // Below ADC, DAC and PWM definitions already done in the core


### PR DESCRIPTION
To be able to use `analogRead(A0)` and `analogRead(0)`, A0 pin value
must be greater than or equal to `NUM_ANALOG_INPUTS`.
Ex:
If `NUM_ANALOG_INPUTS` was 6 (A0 to A5) and A0 was defined to 3 (D3),
`analogRead(A0)` would read A3 instead of A0.

