### PR TITLE
Specify the ARM GCC version in platforms.txt

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -19,7 +19,7 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
-compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+compiler.path={runtime.tools.arm-none-eabi-gcc-6-2017-q2-update.path}/bin/
 
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.c.cmd=arm-none-eabi-gcc


### PR DESCRIPTION
I had a conflict with the version of the ARM GCC used by the official Arduino SAMD core, this changes specifies the version of GCC in the path, so that the arduino-builder/IDE can select the right version.