### PR TITLE
Update wiring_private.h to include stdarg.h

### DIFF
--- a/cores/arduino/wiring_private.h
+++ b/cores/arduino/wiring_private.h
@@ -1,5 +1,8 @@
 /*
-  Copyright (c) 2011 Arduino.  All right reserved.
+  wiring_private.h - Internal header file.
+  Part of Arduino - http://www.arduino.cc/
+
+  Copyright (c) 2005-2006 David A. Mellis
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -8,15 +11,19 @@
 
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-  See the GNU Lesser General Public License for more details.
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
 
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+  You should have received a copy of the GNU Lesser General
+  Public License along with this library; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+  Boston, MA  02111-1307  USA
 */
 
 #ifndef WiringPrivate_h
 #define WiringPrivate_h
+
+#include <stdio.h>
+#include <stdarg.h>
 
 #endif


### PR DESCRIPTION
va_start & va_end was not defined
To have them defined include wiring_private.h

Fix #240
