### PR TITLE
Add define for ARDUINO_CORE_STM32 that can be used to identify this Arduino core

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -29,7 +29,7 @@ compiler.c.elf.cmd=arm-none-eabi-gcc
 compiler.objcopy.cmd=arm-none-eabi-objcopy
 compiler.elf2hex.cmd=arm-none-eabi-objcopy
 
-compiler.extra_flags=-mcpu={build.mcu} -mthumb "@{build.opt.path}"
+compiler.extra_flags=-mcpu={build.mcu} -mthumb "@{build.opt.path}" -DARDUINO_CORE_STM32
 
 compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.stm.extra_include}
 


### PR DESCRIPTION
It would be nice if it was possible to identify this Arduino core. I have added a define for ARDUINO_CORE_STM32.
