### PR TITLE
Configure I2C Fast Mode when I2C freq is more than 100kHz

### DIFF
--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -261,7 +261,12 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
   handle->Init.Timing      = timing;
 #else
   handle->Init.ClockSpeed      = timing;
-  handle->Init.DutyCycle       = I2C_DUTYCYCLE_2;
+  /* Standard mode (sm) is up to 100kHz, then it's Fast mode (fm)     */
+  /* In fast mode duty cyble bit must be set in CCR register          */
+  if(timing > 100000)
+    handle->Init.DutyCycle       = I2C_DUTYCYCLE_16_9;
+  else
+    handle->Init.DutyCycle       = I2C_DUTYCYCLE_2;
 #endif
   handle->Init.OwnAddress1     = ownAddress;
   handle->Init.OwnAddress2     = 0xFF;
@@ -326,6 +331,12 @@ void i2c_setTiming(i2c_t *obj, uint32_t frequency)
   obj->handle.Init.Timing = f;
 #else
   obj->handle.Init.ClockSpeed = f;
+  /* Standard mode (sm) is up to 100kHz, then it's Fast mode (fm)     */
+  /* In fast mode duty cyble bit must be set in CCR register          */
+  if(frequency > 100000)
+    obj->handle.Init.DutyCycle       = I2C_DUTYCYCLE_16_9;
+  else
+    obj->handle.Init.DutyCycle       = I2C_DUTYCYCLE_2;
 #endif
 /*
   else if(frequency <= 600000)


### PR DESCRIPTION
##Description

For STM32 families that have a DutyCycle init parameter, we need to
select the Fast Mode dedicated configuration which will set the
fast mode bit in CCR register.

Fixes #203 
so #203 can be removed from the list to be addressed in #217 

## Tests

Tested on NUCLEO_L152RE and NUCLEO_F429ZI with eepromTest example from extEEPROM library.