### PR TITLE
I2C Slave : rework slave receive data sequence

### DIFF
--- a/cores/arduino/stm32/twi.h
+++ b/cores/arduino/stm32/twi.h
@@ -91,12 +91,13 @@ struct i2c_s {
 #if !defined(STM32F0xx) && !defined(STM32L0xx)
   IRQn_Type irqER;
 #endif //!defined(STM32F0xx) && !defined(STM32L0xx)
-  uint8_t slaveMode;
+  volatile uint8_t slaveMode;
   uint8_t isMaster;
+  volatile int slaveRxNbData; // Number of accumulated bytes received in Slave mode
   void (*i2c_onSlaveReceive)(uint8_t *, int);
   void (*i2c_onSlaveTransmit)(void);
-  uint8_t i2cTxRxBuffer[I2C_TXRX_BUFFER_SIZE];
-  uint8_t i2cTxRxBufferSize;
+  volatile uint8_t i2cTxRxBuffer[I2C_TXRX_BUFFER_SIZE];
+  volatile uint8_t i2cTxRxBufferSize;
 };
 
 ///@brief I2C state


### PR DESCRIPTION
## Description 

This work includes some rework of the Slave RX path, which is based on
below principle:
- we don't know in advance how many bytes will be sent by the I2C master
so we'll be listening to bytes 1 by 1
- in order to get them one by one, we're programing the I2C with
HAL_I2C_Slave_Sequential_Receive_IT and 1 byte at a time and we're using
the HAL_I2C_SlaveRxCpltCallback to store the byte then programing again
for next byte.
- this sequence is ended when the HAL_I2C_ListenCpltCallback is called,
which happens when the master ends the ongoing sequence. We can then
prepare for the next one.

In order to implement this mecanism, we're introduced a local counter
slaveRxNbData where we store the number of received bytes, as well as a
new slave mode SLAVE_MODE_LISTEN which allows for extra checks.

i2c_s structure members that can be modified from main context or under
interrupt context have been marked as volatile.

Addresses #217 

## TESTS
Example used: master_reader_writer + slave_sender_recevier
Has been tested with NUCLEO boards F411RE, L152RE, F091RC, L476_RG in various combinations 1 as master, the other as slave, with a X-NUCLEO-IKS01A1 connected on one board to provide the required pull-up resistors on the I2C lines.

