### PR TITLE
Menu options to support floating point formatting functions

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -6,6 +6,7 @@ menu.xserial=Serial interface
 menu.usb=USB interface
 
 menu.opt=Optimize
+menu.rtlib=C Runtime Library
 menu.upload_method=Upload method
 menu.flash=Flash Memory Size
 
@@ -894,3 +895,92 @@ RemRam.menu.opt.o3lto.build.flags.ldspecs=-flto
 RemRam.menu.opt.ogstd=Debug (-g)
 RemRam.menu.opt.ogstd.build.flags.optimize=-g -Og
 RemRam.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime Library
+Nucleo_144.menu.rtlib.nano=Newlib Nano (default)
+Nucleo_144.menu.rtlib.nano.build.flags.ldspecs=--specs=nano.specs
+Nucleo_144.menu.rtlib.nanofp=Newlib Nano + Float Printf
+Nucleo_144.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+Nucleo_144.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+Nucleo_144.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+Nucleo_144.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+Nucleo_144.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+Nucleo_144.menu.rtlib.full=Newlib Standard
+Nucleo_144.menu.rtlib.full.build.flags.ldspecs=
+
+Nucleo_64.menu.rtlib.nano=Newlib Nano (default)
+Nucleo_64.menu.rtlib.nano.build.flags.ldspecs=--specs=nano.specs
+Nucleo_64.menu.rtlib.nanofp=Newlib Nano + Float Printf
+Nucleo_64.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+Nucleo_64.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+Nucleo_64.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+Nucleo_64.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+Nucleo_64.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+Nucleo_64.menu.rtlib.full=Newlib Standard
+Nucleo_64.menu.rtlib.full.build.flags.ldspecs=
+
+Nucleo_32.menu.rtlib.nano=Newlib Nano (default)
+Nucleo_32.menu.rtlib.nano.build.flags.ldspecs=--specs=nano.specs
+Nucleo_32.menu.rtlib.nanofp=Newlib Nano + Float Printf
+Nucleo_32.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+Nucleo_32.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+Nucleo_32.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+Nucleo_32.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+Nucleo_32.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+Nucleo_32.menu.rtlib.full=Newlib Standard
+Nucleo_32.menu.rtlib.full.build.flags.ldspecs=
+
+Disco.menu.rtlib.nano=Newlib Nano (default)
+Disco.menu.rtlib.nano.build.flags.ldspecs=--specs=nano.specs
+Disco.menu.rtlib.nanofp=Newlib Nano + Float Printf
+Disco.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+Disco.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+Disco.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+Disco.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+Disco.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+Disco.menu.rtlib.full=Newlib Standard
+Disco.menu.rtlib.full.build.flags.ldspecs=
+
+GenF103.menu.rtlib.nano=Newlib Nano (default)
+GenF103.menu.rtlib.nano.build.flags.ldspecs=--specs=nano.specs
+GenF103.menu.rtlib.nanofp=Newlib Nano + Float Printf
+GenF103.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+GenF103.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+GenF103.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+GenF103.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+GenF103.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+GenF103.menu.rtlib.full=Newlib Standard
+GenF103.menu.rtlib.full.build.flags.ldspecs=
+
+GenF4.menu.rtlib.nano=Newlib Nano (default)
+GenF4.menu.rtlib.nano.build.flags.ldspecs=--specs=nano.specs
+GenF4.menu.rtlib.nanofp=Newlib Nano + Float Printf
+GenF4.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+GenF4.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+GenF4.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+GenF4.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+GenF4.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+GenF4.menu.rtlib.full=Newlib Standard
+GenF4.menu.rtlib.full.build.flags.ldspecs=
+
+Maple.menu.rtlib.nano=Newlib Nano (default)
+Maple.menu.rtlib.nano.build.flags.ldspecs=--specs=nano.specs
+Maple.menu.rtlib.nanofp=Newlib Nano + Float Printf
+Maple.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+Maple.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+Maple.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+Maple.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+Maple.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+Maple.menu.rtlib.full=Newlib Standard
+Maple.menu.rtlib.full.build.flags.ldspecs=
+
+RemRam.menu.rtlib.nano=Newlib Nano (default)
+RemRam.menu.rtlib.nano.build.flags.ldspecs=--specs=nano.specs
+RemRam.menu.rtlib.nanofp=Newlib Nano + Float Printf
+RemRam.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+RemRam.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+RemRam.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+RemRam.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+RemRam.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+RemRam.menu.rtlib.full=Newlib Standard
+RemRam.menu.rtlib.full.build.flags.ldspecs=

--- a/platform.txt
+++ b/platform.txt
@@ -33,7 +33,7 @@ compiler.extra_flags=-mcpu={build.mcu} -mthumb "@{build.opt.path}"
 
 compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.stm.extra_include}
 
-compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -Dprintf=iprintf -MMD {compiler.stm.extra_include}
+compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -MMD {compiler.stm.extra_include}
 
 compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std={compiler.cpp.std} -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD {compiler.stm.extra_include}
 
@@ -46,7 +46,7 @@ compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,
 compiler.elf2bin.flags=-O binary
 compiler.elf2hex.flags=-O ihex
 
-compiler.ldflags={build.flags.ldspecs}
+compiler.ldflags=
 compiler.size.cmd=arm-none-eabi-size
 compiler.define=-DARDUINO=
 
@@ -82,7 +82,7 @@ build.info.flags=-D{build.series} -DARDUINO={runtime.ide.version} -DARDUINO_{bui
 build.xSerial=-DHAL_UART_MODULE_ENABLED
 build.enable_usb=
 build.flags.optimize=-Os
-build.flags.ldspecs=
+build.flags.ldspecs=--specs=nano.specs
 
 # Pre and post build hooks
 build.opt.name=build_opt.h
@@ -110,7 +110,7 @@ recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} {build.i
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} {compiler.ldflags} {compiler.arm.cmsis.ldflags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -Wl,--start-group {object_files} -Wl,--whole-archive "{archive_file_path}" -Wl,--no-whole-archive -lc -Wl,--end-group -lm -lgcc -lstdc++ --specs=nano.specs
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} {compiler.ldflags} {compiler.arm.cmsis.ldflags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -Wl,--start-group {object_files} -Wl,--whole-archive "{archive_file_path}" -Wl,--no-whole-archive -lc -Wl,--end-group -lm -lgcc -lstdc++
 
 ## Create output (.bin file)
 recipe.objcopy.bin.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.elf2bin.flags} {compiler.elf2bin.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.bin"


### PR DESCRIPTION
When you want to use sscanf() or sprintf() functions to work with floating point numbers the default Newlib Nano runtime will silently fail.

I added a new sub-menu to select the C runtime you want to use:
* Newlib Nano, without floating point support (as before)
* Newlib Nano + Float Printf (only printf supports fp numbers)
* Newlib Nano + Float Scanf (only scanf supports fp numbers)
* Newlib Nano + Float Printf/Scanf (both support fp numbers)
* Newlib Standard (not Nano)
