### PR TITLE
Enhance memory management

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -282,7 +282,7 @@ Nucleo_64.menu.pnum.NUCLEO_L152RE.build.cmsis_lib_gcc=arm_cortexM3l_math
 Nucleo_64.menu.pnum.NUCLEO_L476RG=Nucleo L476RG
 Nucleo_64.menu.pnum.NUCLEO_L476RG.node=NODE_L476RG
 Nucleo_64.menu.pnum.NUCLEO_L476RG.upload.maximum_size=1048576
-Nucleo_64.menu.pnum.NUCLEO_L476RG.upload.maximum_data_size=131072
+Nucleo_64.menu.pnum.NUCLEO_L476RG.upload.maximum_data_size=98304
 Nucleo_64.menu.pnum.NUCLEO_L476RG.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_L476RG.build.board=NUCLEO_L476RG
 Nucleo_64.menu.pnum.NUCLEO_L476RG.build.series=STM32L4xx

--- a/cores/arduino/syscalls.c
+++ b/cores/arduino/syscalls.c
@@ -27,6 +27,7 @@ extern size_t uart_debug_write(uint8_t *data, uint32_t size);
 
 register char * stack_ptr asm("sp");
 
+__attribute__((weak))
 caddr_t _sbrk( int incr ) {
   extern char _end; /* Defined by the linker */
   static char *heap_end = &_end ;

--- a/cores/arduino/syscalls.c
+++ b/cores/arduino/syscalls.c
@@ -5,6 +5,7 @@
   *
   */
 
+#include "stm32_def.h"
 #if defined (  __GNUC__  ) /* GCC CS3 */
   #include <sys/stat.h>
 #endif
@@ -25,8 +26,6 @@ extern size_t uart_debug_write(uint8_t *data, uint32_t size);
 #define UNUSED(x) x ## _UNUSED
 #endif
 
-register char * stack_ptr asm("sp");
-
 __attribute__((weak))
 caddr_t _sbrk( int incr ) {
   extern char _estack; /* Defined in the linker script */
@@ -35,7 +34,7 @@ caddr_t _sbrk( int incr ) {
   static char *heap_end = &_end ;
   char *prev_heap_end = heap_end;
 
-  if (heap_end + incr > stack_ptr) {
+  if (heap_end + incr > (char *)__get_MSP()) {
     /* Heap and stack collision */
     errno = ENOMEM;
     return (caddr_t) -1;

--- a/cores/arduino/syscalls.c
+++ b/cores/arduino/syscalls.c
@@ -29,12 +29,19 @@ register char * stack_ptr asm("sp");
 
 __attribute__((weak))
 caddr_t _sbrk( int incr ) {
+  extern char _estack; /* Defined in the linker script */
+  extern char _Min_Stack_Size; /* Defined in the linker script */
   extern char _end; /* Defined by the linker */
   static char *heap_end = &_end ;
   char *prev_heap_end = heap_end;
 
   if (heap_end + incr > stack_ptr) {
     /* Heap and stack collision */
+    errno = ENOMEM;
+    return (caddr_t) -1;
+  }
+  /* Ensure to keep minimun stack size defined in the linker script */
+  if (heap_end + incr >= (char*)(&_estack - &_Min_Stack_Size)) {
     errno = ENOMEM;
     return (caddr_t) -1;
   }

--- a/cores/arduino/syscalls.c
+++ b/cores/arduino/syscalls.c
@@ -29,13 +29,8 @@ register char * stack_ptr asm("sp");
 
 caddr_t _sbrk( int incr ) {
   extern char _end; /* Defined by the linker */
-  static char *heap_end = NULL ;
-  char *prev_heap_end ;
-
-  if ( heap_end == NULL ) {
-    heap_end = &_end ;
-  }
-  prev_heap_end = heap_end;
+  static char *heap_end = &_end ;
+  char *prev_heap_end = heap_end;
 
   if (heap_end + incr > stack_ptr) {
     /* Heap and stack collision */

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -435,8 +435,13 @@ void TwoWire::allocateRxBuffer(size_t length)
   if(rxBufferAllocated < length) {
   // By default we allocate BUFFER_LENGTH bytes. It is the min size of the buffer.
     if(length < BUFFER_LENGTH) { length = BUFFER_LENGTH; }
-    rxBuffer = (uint8_t *)realloc(rxBuffer, length * sizeof(uint8_t));
-	rxBufferAllocated = (rxBuffer != nullptr) ? length: 0;
+    uint8_t *tmp = (uint8_t *)realloc(rxBuffer, length * sizeof(uint8_t));
+    if(tmp != nullptr) {
+      rxBuffer = tmp;
+      rxBufferAllocated = length;
+    } else {
+      _Error_Handler("No enough memory! (%i)\n", length);
+    }
   }
 }
 
@@ -445,8 +450,13 @@ inline void TwoWire::allocateTxBuffer(size_t length)
   if(txBufferAllocated < length) {
     // By default we allocate BUFFER_LENGTH bytes. It is the min size of the buffer.
     if(length < BUFFER_LENGTH) { length = BUFFER_LENGTH; }
-    txBuffer = (uint8_t *)realloc(txBuffer, length * sizeof(uint8_t));
-    txBufferAllocated = (txBuffer != nullptr) ? length: 0;
+    uint8_t *tmp = (uint8_t *)realloc(txBuffer, length * sizeof(uint8_t));
+    if(tmp != nullptr) {
+      txBuffer = tmp;
+      txBufferAllocated = length;
+    } else {
+      _Error_Handler("No enough memory! (%i)\n", length);
+    }
   }
 }
 

--- a/variants/NUCLEO_L432KC/ldscript.ld
+++ b/variants/NUCLEO_L432KC/ldscript.ld
@@ -33,7 +33,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x2000c000;    /* end of RAM */
+_estack = 0x20010000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
@@ -41,9 +41,8 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 256K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 48K
-SRAM2 (rw)      : ORIGIN = 0x10000000, LENGTH = 16K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 64K
+FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 256K
 }
 
 /* Define output sections */
@@ -58,7 +57,7 @@ SECTIONS
   } >FLASH
 
   /* The program code and other data goes into FLASH */
-  .text ALIGN(8):
+  .text :
   {
     . = ALIGN(8);
     *(.text)           /* .text sections (code) */
@@ -139,25 +138,6 @@ SECTIONS
     . = ALIGN(8);
     _edata = .;        /* define a global symbol at data end */
   } >RAM AT> FLASH
-
-  _sisram2 = LOADADDR(.sram2);
-
-  /* CCM-RAM section
-  *
-  * IMPORTANT NOTE!
-  * If initialized variables will be placed in this section,
-  * the startup code needs to be modified to copy the init-values.
-  */
-  .sram2 :
-  {
-    . = ALIGN(8);
-    _ssram2 = .;       /* create a global symbol at sram2 start */
-    *(.sram2)
-    *(.sram2*)
-
-    . = ALIGN(8);
-    _esram2 = .;       /* create a global symbol at sram2 end */
-  } >SRAM2 AT> FLASH
 
 
   /* Uninitialized data section */


### PR DESCRIPTION
This PR include:
 * Fix possible issue with realloc usage
 * Define `_sbrk` as weak (Required by https://github.com/stm32duino/STM32FreeRTOS/issues/9)
 * Avoid user heap to override the minimum stack size (Fix #307)
 * Fix Nucleo-L432KC and Nucleo-L476RG SRAM usage