### PR TITLE
Change variant RemRam for final design (v1.3)

### DIFF
--- a/variants/REMRAM_V1/variant.cpp
+++ b/variants/REMRAM_V1/variant.cpp
@@ -55,7 +55,7 @@ extern "C"
       PE_1, // D8 - EXT_D5
 
       // SPI
-      PB_2, // D9 - SS_SD
+      PB_2, // D9 - SS_SDLCD
       PC_4, // D10 - SS_E
       PA_7, // D11 - MOSI
       PA_6, // D12 - MISO
@@ -120,7 +120,9 @@ extern "C"
       PC_14, // D54 - BTN_EN1
       PC_15, // D55 - BTN_EN2
       PC_13, // D56 - SD_CARD_DET
-      PE_6,  // D57 - KILL_PIN
+
+      // SD Card Reader
+      PE_7,  // D57 - SS_SD
 
       // Endstops
       PB_12, // D58 - X_MIN

--- a/variants/REMRAM_V1/variant.h
+++ b/variants/REMRAM_V1/variant.h
@@ -65,7 +65,7 @@ extern "C"
     PE1, // D8 - EXT_D5
 
     // SPI
-    PB2, // D9 - SS_SD
+    PB2, // D9 - SS_SDLCD
     PC4, // D10 - SS_E
     PA7, // D11 - MOSI
     PA6, // D12 - MISO
@@ -130,7 +130,9 @@ extern "C"
     PC14, // D54 - BTN_EN1
     PC15, // D55 - BTN_EN2
     PC13, // D56 - SD_CARD_DET
-    PE6,  // D57 - KILL_PIN
+
+    // SD Card Reader
+    PE7,  // D57 - SS_SD
 
     // Endstops
     PB12, // D58 - X_MIN


### PR DESCRIPTION
I had to make some backward incompatible changes:
 * Remove the KILL_PIN
 * Change SS_SD to SS_SDLCD for external SD card
 * Added SS_SD for on-board SD card reader

Since the only development boards are in my possession, this breaking change shouldn't affect anybody.

Going forward the board in version 1 is considered feature complete and won't change in a backward incompatible way.