### PR TITLE
Add dfu-util upload method

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -180,3 +180,13 @@ tools.bmp_upload.upload.speed=230400
 tools.bmp_upload.upload.params.verbose=-batch
 tools.bmp_upload.upload.params.quiet=--batch-silent
 tools.bmp_upload.upload.pattern="{path}{cmd}" -nx -b {upload.speed} {upload.verbose} -ex "set confirm off" -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "load" -ex "compare-sections" -ex "kill" "{build.path}/{build.project_name}.elf"
+
+# DFU upload using dfu-util
+tools.dfuutil_upload.cmd=dfu-util
+tools.dfuutil_upload.path.windows={runtime.tools.STM32Tools.path}/tools/win/dfu-util
+tools.dfuutil_upload.path.macosx={runtime.tools.STM32Tools.path}/tools/macosx/dfu-util
+tools.dfuutil_upload.path.linux={runtime.tools.STM32Tools.path}/tools/linux/dfu-util
+tools.dfuutil_upload.path.linux64={runtime.tools.STM32Tools.path}/tools/linux64/dfu-util
+tools.dfuutil_upload.upload.params.verbose=-d
+tools.dfuutil_upload.upload.params.quiet=
+tools.dfuutil_upload.upload.pattern="{path}/{cmd}" -a 0 -s "{upload.address}:leave" -D "{build.path}/{build.project_name}.bin"

--- a/platform.txt
+++ b/platform.txt
@@ -189,4 +189,4 @@ tools.dfuutil_upload.path.linux={runtime.hardware.path}/tools/linux/dfu-util
 tools.dfuutil_upload.path.linux64={runtime.hardware.path}/tools/linux64/dfu-util
 tools.dfuutil_upload.upload.params.verbose=-d
 tools.dfuutil_upload.upload.params.quiet=
-tools.dfuutil_upload.upload.pattern="{path}/{cmd}" -a 0 -s "{upload.address}:leave" -D "{build.path}/{build.project_name}.bin"
+tools.dfuutil_upload.upload.pattern="{path}/{cmd}" -a {upload.protocol} -s "{upload.address}:leave" -D "{build.path}/{build.project_name}.bin"

--- a/platform.txt
+++ b/platform.txt
@@ -183,10 +183,10 @@ tools.bmp_upload.upload.pattern="{path}{cmd}" -nx -b {upload.speed} {upload.verb
 
 # DFU upload using dfu-util
 tools.dfuutil_upload.cmd=dfu-util
-tools.dfuutil_upload.path.windows={runtime.tools.STM32Tools.path}/tools/win/dfu-util
-tools.dfuutil_upload.path.macosx={runtime.tools.STM32Tools.path}/tools/macosx/dfu-util
-tools.dfuutil_upload.path.linux={runtime.tools.STM32Tools.path}/tools/linux/dfu-util
-tools.dfuutil_upload.path.linux64={runtime.tools.STM32Tools.path}/tools/linux64/dfu-util
+tools.dfuutil_upload.path.windows={runtime.hardware.path}/tools/win/dfu-util
+tools.dfuutil_upload.path.macosx={runtime.hardware.path}/tools/macosx/dfu-util
+tools.dfuutil_upload.path.linux={runtime.hardware.path}/tools/linux/dfu-util
+tools.dfuutil_upload.path.linux64={runtime.hardware.path}/tools/linux64/dfu-util
 tools.dfuutil_upload.upload.params.verbose=-d
 tools.dfuutil_upload.upload.params.quiet=
 tools.dfuutil_upload.upload.pattern="{path}/{cmd}" -a 0 -s "{upload.address}:leave" -D "{build.path}/{build.project_name}.bin"


### PR DESCRIPTION
This allows the dfu-util tool to be used as an upload method if specified in a board's definition. In my testing this is compatible both with the built-in DFU bootloader (only tested on an F446) and a custom software bootloader that implements DFU mode (again, on the F446).

At the moment I'm using it in my WIP branch adding my RUMBA32 board, [here](https://github.com/chrissbarr/Arduino_Core_STM32/tree/RUMBA32). It's partly dependent (on Windows) on the recent PR I submitted in the Arduino_Tools repo updating the dfu-util version (stm32duino/Arduino_Tools#29), as the older version of dfu-util did not seem to work on Windows, and the file structure has been updated slightly.

I haven't added any examples to any of the existing boards, mostly because I'm not sure which boards would benefit from using the DFU upload method - but I could get them added to this PR if anyone has suggestions.

Here are two boards.txt examples from my RUMBA32 fork. The first uses ST's built-in DFU bootloader (so BOOT0 must be held high on reset):

```
RUMBA32_F446.menu.upload_method.DFUnative=DFU (Native)
RUMBA32_F446.menu.upload_method.DFUnative.upload.protocol=dfuutil_upload
RUMBA32_F446.menu.upload_method.DFUnative.upload.tool=dfuutil_upload
RUMBA32_F446.menu.upload_method.DFUnative.upload.address=0x08000000
```

And this using my bootloader, which sits in the first page(s) of flash and is supposed to upload the user code to the page starting at 0x08010000:

```
RUMBA32_F446.menu.upload_method.DFUbootloader=DFU Bootloader (0x10000)
RUMBA32_F446.menu.upload_method.DFUbootloader.upload.protocol=dfuutil_upload
RUMBA32_F446.menu.upload_method.DFUbootloader.upload.tool=dfuutil_upload
RUMBA32_F446.menu.upload_method.DFUbootloader.upload.address=0x08010000
RUMBA32_F446.menu.upload_method.DFUbootloader.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x10000
RUMBA32_F446.menu.upload_method.DFUbootloader.build.ldscript=ldscript_0x10000.ld
```

I'm not sure that my bootloader in particular is any use with this core (I wrote it to set aside space for EEPROM emulation in the STM32GENERIC core - haven't yet investigated if I will still need it with this core), but because the address, VECT_TAB_OFFSET and ldscript can be set in the upload_method definition, this should be adjustable to any other bootloaders people want to use - or just with the built in DFU bootloader common to many STM32 chips.

Questions:
- Can/should we set a default for the `address` variable? It's likely to be `0x08000000` for most boards, unless they use a custom bootloader.
- What's the difference between `upload.protocol` and `upload.tool` in `boards.txt`? I'm missing something in how they map from the `boards.txt` to the `platform.txt` in my examples, and feel I probably shouldn't be repeating the same thing twice.
- Can I append to `build.extra_flags`, rather than overwriting it (like in my second example), where all I want is to add the `DVECT_TAB_OFFSET=0x10000` flag?

Before merging:

- [ ] Someone should test the dfu-util upload method (preferably on one or more boards with the built-in bootloader)
- [x] stm32duino/Arduino_Tools#29 needs to be merged (otherwise Windows upload doesn't work)

Thoughts?