### PR TITLE
Allow use of a custom startup file

### DIFF
--- a/cores/arduino/stm32/startup_stm32yyxx.S
+++ b/cores/arduino/stm32/startup_stm32yyxx.S
@@ -1,4 +1,5 @@
 #include "stm32_def_build.h"
 
+#if defined(CMSIS_STARTUP_FILE)
 #include CMSIS_STARTUP_FILE
-
+#endif

--- a/cores/arduino/stm32/stm32_def_build.h
+++ b/cores/arduino/stm32/stm32_def_build.h
@@ -1,6 +1,7 @@
 #ifndef _STM32_DEF_BUILD_
 #define _STM32_DEF_BUILD_
 
+#if !defined(CMSIS_STARTUP_FILE) && !defined(CUSTOM_STARTUP_FILE)
 #if defined(STM32F030x6)
 #define CMSIS_STARTUP_FILE "startup_stm32f030x6.s"
 #elif defined(STM32F030x8)
@@ -296,4 +297,7 @@
 #else
 #error UNKNOWN CHIP
 #endif
-#endif //_STM32_DEF_BUILD_
+#else
+#warning "No CMSIS startup file defined, custom one should be used"
+#endif /* !CMSIS_STARTUP_FILE && !CUSTOM_STARTUP_FILE */
+#endif /* _STM32_DEF_BUILD_ */

--- a/platform.txt
+++ b/platform.txt
@@ -59,7 +59,7 @@ compiler.c.extra_flags=
 compiler.c.elf.extra_flags=
 compiler.cpp.extra_flags=
 compiler.cpp.std=gnu++14
-compiler.S.extra_flags=
+compiler.S.extra_flags={build.startup_file}
 compiler.ar.extra_flags=
 compiler.elf2bin.extra_flags=
 compiler.elf2hex.extra_flags=
@@ -81,6 +81,7 @@ build.info.flags=-D{build.series} -DARDUINO={runtime.ide.version} -DARDUINO_{bui
 # Defaults config
 build.xSerial=-DHAL_UART_MODULE_ENABLED
 build.enable_usb=
+build.startup_file=
 build.flags.optimize=-Os
 build.flags.ldspecs=--specs=nano.specs
 


### PR DESCRIPTION
Syntax in the board.txt:
`xxx.build.startup_file=-DCUSTOM_STARTUP_FILE`

Example to use a custom startup file for Nucleo_L476RG:
`    Nucleo_64.menu.pnum.NUCLEO_L476RG.build.startup_file=-DCUSTOM_STARTUP_FILE`
Then add a "*.S" file in the "variant/NUCLEO_L476RG/" folder
**Important note: extension must be '.S' not '.s'**

`CUSTOM_STARTUP_FILE `could also be defined thanks the build_opt.h.
`CMSIS_STARTUP_FILE `could now be overridden using the build_opt.h, ex:
`-DCMSIS_STARTUP_FILE=\"startup_stm32l476xx.s\"`

Fix #352 