### PR TITLE
Use define instead of enum for pins in variant.h

### DIFF
--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -23,9 +23,6 @@
 // Avoid PortName issue
 _Static_assert(LastPort <= 0x0F, "PortName must be less than 16");
 
-// Avoid pins number misalignment
-_Static_assert(NUM_DIGITAL_PINS==PEND, "NUM_DIGITAL_PINS and PEND differ!");
-
 // Arduino digital pins alias
 // GPIO port (A to K) * 16 pins: 176
 enum {

--- a/variants/BLACK_F407VE/variant.h
+++ b/variants/BLACK_F407VE/variant.h
@@ -44,80 +44,85 @@ extern "C"{
  *        Pins
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
+// Left Side
+#define PE2  0
+#define PE3  1
+#define PE4  2  // BUT K0
+#define PE5  3  // BUT K1
+#define PE6  4
+#define PC13 5
+#define PC0  6  // A8
+#define PC1  7  // A9
+#define PC2  8  // A10
+#define PC3  9  // A11
+#define PA0  10 // A0/WK_UP: BUT K_UP
+#define PA1  11 // A1
+#define PA2  12 // A2
+#define PA3  13 // A3
+#define PA4  14 // A4
+#define PA5  15 // A5
+#define PA6  16 // LED D2
+#define PA7  17 // LED D3 (active LOW)
+#define PC4  18 // A12
+#define PC5  19 // A13
+#define PB0  20 // A6
+#define PB1  21 // A7
+#define PE7  22
+#define PE8  23
+#define PE9  24
+#define PE10 25
+#define PE11 26
+#define PE12 27
+#define PE13 28
+#define PE14 29
+#define PE15 30
+#define PB10 31
+#define PB11 32
+#define PB12 33
+#define PB13 34
+#define PB14 35
+// Right Side
+#define PE1  36
+#define PE0  37
+#define PB9  38
+#define PB8  39
+#define PB7  40
+#define PB6  41
+#define PB5  42
+#define PB3  43
+#define PD7  44
+#define PD6  45
+#define PD5  46
+#define PD4  47
+#define PD3  48
+#define PD2  49
+#define PD1  50
+#define PD0  51
+#define PC12 52
+#define PC11 53
+#define PC10 54
+#define PA15 55
+#define PA12 56 // USB_DP
+#define PA11 57 // USB_DM
+#define PA10 58
+#define PA9  59
+#define PA8  60
+#define PC9  61
+#define PC8  62
+#define PC7  63
+#define PC6  64
+#define PD15 65
+#define PD14 66
+#define PD13 67
+#define PD12 68
+#define PD11 69
+#define PD10 70
+#define PD9  71
+#define PD8  72
+#define PB15 73
+#define PB4  74
 
-enum {
-  // Left Side
-  //Ext   //Int
-  //5V    //5V
-  //5V    //5V
-  //3V3   //3V3
-  //3V3   //3V3
-  //GND   //GND
-  PE2,    PE3,    // D0, D1
-  PE4,    PE5,    // PE_4: BUT K0, PE_5: BUT K1
-  PE6,    PC13,
-  PC0,    PC1,
-  PC2,    PC3,
-  //VREF- //VREF+
-  PA0,    PA1,    // D10, D11 PA_0(WK_UP): BUT K_UP)
-  PA2,    PA3,
-  PA4,    PA5,
-  PA6,    PA7,    // PA_6: LED D2, PA_7: LED D3 (active LOW)
-  PC4,    PC5,
-  PB0,    PB1,    // D20, D21
-  PE7,    PE8,
-  PE9,    PE10,
-  PE11,   PE12,
-  PE13,   PE14,
-  PE15,   PB10,   // D30, D31
-  PB11,   PB12,
-  PB13,   PB14,
-  // Right Side
-  //Int   //Ext
-  //3V3   //3V3
-  //3V3   //3V3
-  //BOOT0 //BOOT1
-  //GND   //GND
-  //GND   //GND
-  PE1,    PE0,
-  PB9,    PB8,
-  PB7,    PB6,    // D40, D41
-  PB5,    PB3,
-  PD7,    PD6,
-  PD5,    PD4,
-  PD3,    PD2,
-  PD1,    PD0,    // D50, D51
-  PC12,   PC11,
-  PC10,   PA15,
-  PA12,   PA11,   // PA_11: USB_DM, PA_12: USB_DP
-  PA10,   PA9,
-  PA8,    PC9,    // D60, D61
-  PC8,    PC7,
-  PC6,    PD15,
-  PD14,   PD13,
-  PD12,   PD11,
-  PD10,   PD9,    // D70, D71
-  PD8,    PB15,
-  PB4,
-  // Analog pins
-  PA0_A,          // D75
-  PA1_A,
-  PA2_A,
-  PA3_A,
-  PA4_A,
-  PA5_A,          // D80
-  PB0_A,
-  PB1_A,
-  PC0_A,
-  PC1_A,
-  PC2_A,
-  PC3_A,
-  PC4_A,
-  PC5_A,
-  PEND
-};
-
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        89
 // This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       14

--- a/variants/BLUEPILL_F103C8/variant.h
+++ b/variants/BLUEPILL_F103C8/variant.h
@@ -44,50 +44,47 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
 // USB connector on the top, MCU side
 // Left Side
-  PB9,  //D0
-  PB8,  //D1
-  PB7,  //D2
-  PB6,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB3,  //D6
-  PA15, //D7
-  PA12, //D8 - USB DP
-  PA11, //D9 - USB DM
-  PA10, //D10
-  PA9,  //D11
-  PA8,  //D12
-  PB15, //D13
-  PB14, //D14
-  PB13, //D15
-  PB12, //D16
+#define PB9  0
+#define PB8  1
+#define PB7  2
+#define PB6  3
+#define PB5  4
+#define PB4  5
+#define PB3  6
+#define PA15 7
+#define PA12 8  // USB DP
+#define PA11 9  // USB DM
+#define PA10 10
+#define PA9  11
+#define PA8  12
+#define PB15 13
+#define PB14 14
+#define PB13 15
+#define PB12 16
 // Right side
-  PC13, //D17 - LED
-  PC14, //D18
-  PC15, //D19
-  PA0,  //D20/A0
-  PA1,  //D21/A1
-  PA2,  //D22/A2
-  PA3,  //D23/A3
-  PA4,  //D24/A4
-  PA5,  //D25/A5
-  PA6,  //D26/A6
-  PA7,  //D27/A7
-  PB0,  //D28/A8
-  PB1,  //D29/A9
-  PB10, //D30
-  PB11, //D31
+#define PC13 17 // LED
+#define PC14 18
+#define PC15 19
+#define PA0  20 // A0
+#define PA1  21 // A1
+#define PA2  22 // A2
+#define PA3  23 // A3
+#define PA4  24 // A4
+#define PA5  25 // A5
+#define PA6  26 // A6
+#define PA7  27 // A7
+#define PB0  28 // A8
+#define PB1  29 // A9
+#define PB10 30
+#define PB11 31
 // Other
-  PB2,  //D32 - BOOT1
-  PA13, //D33 - SWDI0
-  PA14, //D34 - SWCLK
-  PEND
-};
+#define PB2  32 // BOOT1
+#define PA13 33 // SWDI0
+#define PA14 34 // SWCLK
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        35
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       10

--- a/variants/BLUE_F407VE_Mini/variant.h
+++ b/variants/BLUE_F407VE_Mini/variant.h
@@ -44,121 +44,103 @@ extern "C"{
  *        Pins
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
+// External (left to right)
+// GND
+// VBAT
+// 5V
+#define PE0  0
+#define PE2  1
+#define PE4  2
+#define PE6  3
+#define PC14 4  // OSC32_IN
+#define PC0  5  // A8
+#define PC2  6  // A10
+#define PA0  7  // A0
+#define PA1  8  // A1
+#define PA4  9  // A4
+#define PA6  10
+#define PC4  11 // A12
+#define PB0  12 // A6
+#define PB2  13
+#define PE8  14
+#define PE9  15
+#define PE11 16
+#define PE13 17
+#define PE15 18
+#define PB11 19
+#define PB13 20
+#define PB15 21
+#define PD9  22
+#define PD11 23
+#define PD13 24
+#define PD15 25
+#define PC6  26
+#define PC8  27
+#define PC9  28
+#define PA9  29
+#define PA11 30 // USB_DM
+#define PA13 31
+#define PA15 32
+#define PC11 33
+#define PC12 34
+#define PD1  35
+#define PD3  36
+#define PD5  37
+#define PD7  38
+#define PB4  39
+#define PB6  40
+#define PB8  41
+// GND
+// 3V3
+// GND
+// Internal (left to right)
+// GND
+// 3V3
+// 5V
+#define PE1  42
+#define PE3  43
+#define PE5  44
+#define PC13 45
+#define PC15 46 // OSC32_OUT
+#define PC1  47 // A9
+#define PC3  48 // A11
+#define PA2  49 // A2
+#define PA3  50 // A3
+#define PA5  51 // A5
+#define PA7  52
+#define PC5  53 // A13
+#define PB1  54 // A7
+#define PE7  55
+#define PE10 56
+#define PE12 57
+#define PE14 58
+#define PB10 59
+#define PB12 60
+#define PB14 61
+#define PD8  62
+#define PD10 63
+#define PD12 64
+#define PD14 65
+#define PC7  66
+#define PA8  67
+#define PA10 68
+#define PA12 69 // USB_DP
+#define PA14 70
+#define PC10 71
+#define PD0  72
+#define PD2  73
+#define PD4  74
+#define PD6  75
+#define PB3  76
+#define PB5  77
+#define PB7  78
+#define PB9  79 // LED
 
-enum {
-//External (left to right) 
-  //GND   
-  //VBAT  
-  //5V    
-  PE0,   //D0
-  PE2,   
-  PE4,   
-  PE6,   
-  PC14,  //OSC32_IN
-  PC0,   
-  PC2,   
-  PA0,   
-  PA1,   
-  PA4,   
-  PA6,   //D10
-  PC4,   
-  PB0,   
-  PB2,   
-  PE8,   
-  PE9, 
-  PE11,  
-  PE13,  
-  PE15,  
-  PB11,  
-  PB13,  //D20
-  PB15,
-  PD9,   
-  PD11,  
-  PD13,  
-  PD15,  
-  PC6,   
-  PC8,   
-  PC9, 
-  PA9,   
-  PA11,  //D30 - USB_DM
-  PA13,
-  PA15,
-  PC11,  
-  PC12,  
-  PD1,   
-  PD3,   
-  PD5,   
-  PD7,   
-  PB4,   
-  PB6,   //D40
-  PB8,   
-  //GND   
-  //3V3   
-  //GND   
-//Internal (left to right) 
-  //GND  
-  //3V3  
-  //5V  
-  PE1,
-  PE3,
-  PE5, 
-  PC13,
-  PC15,  //OSC32_OUT
-  PC1, 
-  PC3, 
-  PA2, 
-  PA3,   //D50
-  PA5, 
-  PA7,
-  PC5, 
-  PB1, 
-  PE7, 
-  PE10,
-  PE12,
-  PE14,
-  PB10,
-  PB12,  //D60
-  PB14,
-  PD8, 
-  PD10,
-  PD12,
-  PD14,
-  PC7, 
-  PA8, 
-  PA10,
-  PA12,  //USB_DP
-  PA14,  //D70
-  PC10,
-  PD0, 
-  PD2, 
-  PD4, 
-  PD6, 
-  PB3,  
-  PB5,  
-  PB7,  
-  PB9,   //D79 - LED
-  //GND  
-  //3V3  
-  //GND  
-  // Analog pins
-  PA0_A,   //D80
-  PA1_A,
-  PA2_A,
-  PA3_A,
-  PA4_A,
-  PA5_A,
-  PB0_A,
-  PB1_A,
-  PC0_A,
-  PC1_A,
-  PC2_A,   //D90
-  PC3_A,
-  PC4_A,
-  PC5_A,
-  PEND
-};
+// GND
+// 3V3
+// GND
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        94
 // This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       14

--- a/variants/DISCO_F030R8/variant.h
+++ b/variants/DISCO_F030R8/variant.h
@@ -46,85 +46,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  //P1 connector Right side (bottom view)
-  PC13, //D0
-  PC14, //D1
-  PC15, //D2
-  PF0,  //D3
-  PF1,  //D4
-  PC0,  //D5
-  PC1,  //D6
-  PC2,  //D7
-  PC3,  //D8
-  PA0,  //D9 - USER_BTN
-  PA1,  //D10
-  PA2,  //D11
-  PA3,  //D12
-  PF4,  //D13
-  PF5,  //D14
-  PA4,  //D15
-  PA5,  //D16
-  PA6,  //D17
-  PA7,  //D18
-  PC4,  //D19
-  PC5,  //D20
-  PB0,  //D21
-  PB1,  //D22
-  PB2,  //D23
-  PB10, //D24
-  PB11, //D25
-  PB12, //D26
-  //P2 connector Left side (bottom view)
-  PB9,  //D27
-  PB8,  //D28
-  PB7,  //D29
-  PB6,  //D30
-  PB5,  //D31
-  PB4,  //D32
-  PB3,  //D33
-  PD2,  //D34
-  PC12, //D35
-  PC11, //D36
-  PC10, //D37
-  PA15, //D38
-  PA14, //D39
-  PF7,  //D40
-  PF6,  //D41
-  PA13, //D42
-  PA12, //D43
-  PA11, //D44
-  PA10, //D45
-  PA9,  //D46
-  PA8,  //D47
-  PC9,  //D48 - LED_GREEN (LD3)
-  PC8,  //D49 - LED_BLUE (LD4)
-  PC7,  //D50
-  PC6,  //D51
-  PB15, //D52
-  PB14, //D53
-  PB13, //D54
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PC_0_A, //D55/A0 = D5
-  PC_1_A, //D56/A1 = D6
-  PC_2_A, //D57/A2 = D7
-  PC_3_A, //D58/A3 = D8
-  PA_0_A, //D59/A4 = D9
-  PA_1_A, //D60/A5 = D10
-  PA_2_A, //D61/A6 = D11
-  PA_3_A, //D62/A7 = D12
-  PA_4_A, //D63/A8 = D15
-  PA_5_A, //D64/A9 = D16
-  PA_6_A, //D65/A10 = D17
-  PA_7_A, //D66/A11 = D18
-  PC_4_A, //D67/A12 = D19
-  PC_5_A, //D68/A13 = D20
-  PB_0_A, //D69/A14 = D21
-  PB_1_A, //D70/A15 = D22
-  PEND
-};
+// P1 connector Right side (bottom view)
+#define PC13 0
+#define PC14 1
+#define PC15 2
+#define PF0  3
+#define PF1  4
+#define PC0  5  // A0
+#define PC1  6  // A1
+#define PC2  7  // A2
+#define PC3  8  // A3
+#define PA0  9  // A4/USER_BTN
+#define PA1  10 // A5
+#define PA2  11 // A6
+#define PA3  12 // A7
+#define PF4  13
+#define PF5  14
+#define PA4  15 // A8
+#define PA5  16 // A9
+#define PA6  17 // A10
+#define PA7  18 // A11
+#define PC4  19 // A12
+#define PC5  20 // A13
+#define PB0  21 // A14
+#define PB1  22 // A15
+#define PB2  23
+#define PB10 24
+#define PB11 25
+#define PB12 26
+// P2 connector Left side (bottom view)
+#define PB9  27
+#define PB8  28
+#define PB7  29
+#define PB6  30
+#define PB5  31
+#define PB4  32
+#define PB3  33
+#define PD2  34
+#define PC12 35
+#define PC11 36
+#define PC10 37
+#define PA15 38
+#define PA14 39
+#define PF7  40
+#define PF6  41
+#define PA13 42
+#define PA12 43
+#define PA11 44
+#define PA10 45
+#define PA9  46
+#define PA8  47
+#define PC9  48 // LED_GREEN (LD3)
+#define PC8  49 // LED_BLUE (LD4)
+#define PC7  50
+#define PC6  51
+#define PB15 52
+#define PB14 53
+#define PB13 54
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        71
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       16

--- a/variants/DISCO_F100RB/variant.h
+++ b/variants/DISCO_F100RB/variant.h
@@ -33,78 +33,58 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
 // P1 connector
-  PC13, //D0
-  PC0,  //D1
-  PC1,  //D2
-  PC2,  //D3
-  PC3,  //D4
-  PA0,  //D5 - User button
-  PA1,  //D6
-  PA2,  //D7
-  PA3,  //D8
-  PA4,  //D9
-  PA5,  //D10
-  PA6,  //D11
-  PA7,  //D12
-  PC4,  //D13
-  PC5,  //D14
-  PB0,  //D15
-  PB1,  //D16
-  PB2,  //D17
+#define PC13 0
+#define PC0  1  // A0
+#define PC1  2  // A1
+#define PC2  3  // A2
+#define PC3  4  // A3
+#define PA0  5  // A4/User button
+#define PA1  6  // A5
+#define PA2  7  // A6
+#define PA3  8  // A7
+#define PA4  9  // A8
+#define PA5  10 // A9
+#define PA6  11 // A10
+#define PA7  12 // A11
+#define PC4  13 // A12
+#define PC5  14 // A13
+#define PB0  15 // A14
+#define PB1  16 // A15
+#define PB2  17
 // P2 connector
-  PC6,  //D18
-  PC7,  //D19
-  PC8,  //D20 - LED blue
-  PC9,  //D21 - LED green
-  PA8,  //D22
-  PA9,  //D23
-  PA10, //D24
-  PA11, //D25
-  PA12, //D26
-  PA13, //D27
-  PA14, //D28
-  PA15, //D29
-  PC10, //D30
-  PC11, //D31
-  PC12, //D32
-  PD2,  //D33
-  PB3,  //D34
-  PB4,  //D35
-  PB5,  //D36 - I2C SCL
-  PB6,  //D37 - I2C SDA
-  PB7,  //D38
-  PB8,  //D39
-  PB9,  //D40
+#define PC6  18
+#define PC7  19
+#define PC8  20 // LED blue
+#define PC9  21 // LED green
+#define PA8  22
+#define PA9  23
+#define PA10 24
+#define PA11 25
+#define PA12 26
+#define PA13 27
+#define PA14 28
+#define PA15 29
+#define PC10 30
+#define PC11 31
+#define PC12 32
+#define PD2  33
+#define PB3  34
+#define PB4  35
+#define PB5  36 // I2C SCL
+#define PB6  37 // I2C SDA
+#define PB7  38
+#define PB8  39
+#define PB9  40
 // P3 connector
-  PB10, //D41
-  PB11, //D42
-  PB12, //D43 - SPI SS
-  PB13, //D44 - SPI SCLK
-  PB14, //D45 - SPI MISO
-  PB15, //D46 - SPI MOSI
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PC0_2,//D47/A0 = D0
-  PC1_2,//D48/A1 = D1
-  PC2_2,//D49/A2 = D2
-  PC3_2,//D50/A3 = D3
-  PA0_2,//D51/A4 = D4
-  PA1_2,//D52/A5 = D5
-  PA2_2,//D53/A6 = D6
-  PA3_2,//D54/A7 = D7
-  PA4_2,//D55/A8 = D8
-  PA5_2,//D56/A9 = D9
-  PA6_2,//D57/A10 = D10
-  PA7_2,//D58/A11 = D11
-  PC4_2,//D59/A12 = D12
-  PC5_2,//D60/A13 = D13
-  PB0_2,//D61/A14 = D14
-  PB1_2,//D62/A15 = D15
-  PEND
-};
+#define PB10 41
+#define PB11 42
+#define PB12 43 // SPI SS
+#define PB13 44 // SPI SCLK
+#define PB14 45 // SPI MISO
+#define PB15 46 // SPI MOSI
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        63
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       16

--- a/variants/DISCO_F407VG/variant.h
+++ b/variants/DISCO_F407VG/variant.h
@@ -33,104 +33,91 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
 //P1 connector Right side
-  PC0,  //D0
-  PC2,  //D1
-  PA0,  //D2
-  PA2,  //D3
-  PA4,  //D4
-  PA6,  //D5
-  PC4,  //D6
-  PB0,  //D7
-  PB2,  //D8
-  PE8,  //D9
-  PE10, //D10
-  PE12, //D11
-  PE14, //D12
-  PB10, //D13
-  PB12, //D14
-  PB14, //D15
-  PD8,  //D16
-  PD10, //D17
-  PD12, //D18
-  PD14, //D19
+#define PC0  0
+#define PC2  1  // A0
+#define PA0  2
+#define PA2  3
+#define PA4  4
+#define PA6  5
+#define PC4  6  // A1
+#define PB0  7  // A2
+#define PB2  8
+#define PE8  9
+#define PE10 10
+#define PE12 11
+#define PE14 12
+#define PB10 13
+#define PB12 14
+#define PB14 15
+#define PD8  16
+#define PD10 17
+#define PD12 18
+#define PD14 19
 //P2 connector Left side
-  PH0,  //D20
-  PC14, //D21
-  PE6,  //D22
-  PE4,  //D23
-  PE2,  //D24
-  PE0,  //D25
-  PB8,  //D26
-  PB6,  //D27
-  PB4,  //D28
-  PD7,  //D29
-  PD5,  //D30
-  PD3,  //D31
-  PD1,  //D32
-  PC12, //D33
-  PC10, //D34
-  PA10, //D35
-  PA8,  //D36
-  PC8,  //D37
-  PC6,  //D38
+#define PH0  20
+#define PC14 21
+#define PE6  22
+#define PE4  23
+#define PE2  24
+#define PE0  25
+#define PB8  26
+#define PB6  27
+#define PB4  28
+#define PD7  29
+#define PD5  30
+#define PD3  31
+#define PD1  32
+#define PC12 33
+#define PC10 34
+#define PA10 35
+#define PA8  36
+#define PC8  37
+#define PC6  38
 //P1 Connector Left Side
-  PC1,  //D39
-  PC3,  //D40
-  PA1,  //D41
-  PA3,  //D42
-  PA5,  //D43
-  PA7,  //D44
-  PC5,  //D45
-  PB1,  //D46
-  PE7,  //D47
-  PE9,  //D48
-  PE11, //D49
-  PE13, //D50
-  PE15, //D51
-  PB11, //D52
-  PB13, //D53
-  PB15, //D54
-  PD9,  //D55
-  PD11, //D56
-  PD13, //D57
-  PD15, //D58
+#define PC1  39 // A3
+#define PC3  40 // A4
+#define PA1  41 // A5
+#define PA3  42
+#define PA5  43
+#define PA7  44
+#define PC5  45 // A6
+#define PB1  46 // A7
+#define PE7  47
+#define PE9  48
+#define PE11 49
+#define PE13 50
+#define PE15 51
+#define PB11 52
+#define PB13 53
+#define PB15 54
+#define PD9  55
+#define PD11 56
+#define PD13 57
+#define PD15 58
 //P2 connector Right side
-  PH1,  //D59
-  PC15, //D60
-  PC13, //D61
-  PE5,  //D62
-  PE3,  //D63
-  PE1,  //D64
-  PB9,  //D65
-  PB7,  //D66
-  PB5,  //D67
-  PB3,  //D68
-  PD6,  //D69
-  PD4,  //D70
-  PD2,  //D71
-  PD0,  //D72
-  PC11, //D73
-  PA15, //D74
-  PA13, //D75
-  PA9,  //D76
-  PC9,  //D77
-  PC7,  //D78
-//Duplicated to have A0-A5 as F407 do not have Uno like connector
-// and to be aligned with PinMap_ADC
-  PC2_2,//D79/A0 = D1
-  PC4_2,//D80/A1 = D6
-  PB0_2,//D81/A2 = D7
-  PC1_2,//D82/A3 = D39
-  PC3_2,//D83/A4 = D40
-  PA1_2,//D84/A5 = D41
-  PC5_2,//D85/A6 = D45
-  PB1_2,//D86/A7 = D46
-  PEND
-};
+#define PH1  59
+#define PC15 60
+#define PC13 61
+#define PE5  62
+#define PE3  63
+#define PE1  64
+#define PB9  65
+#define PB7  66
+#define PB5  67
+#define PB3  68
+#define PD6  69
+#define PD4  70
+#define PD2  71
+#define PD0  72
+#define PC11 73
+#define PA15 74
+#define PA13 75
+#define PA9  76
+#define PC9  77
+#define PC7  78
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        87
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       8
@@ -193,7 +180,7 @@ enum {
 // SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
 //                            pins are NOT connected to anything by default.
 #define SERIAL_PORT_MONITOR     Serial // Require connections for ST-LINK VCP on U2 pin 12 and 13.
-                                   // See UM ง6.1.3 ST-LINK/V2-A VCP configuration)
+                                   // See UM ยง6.1.3 ST-LINK/V2-A VCP configuration)
 #define SERIAL_PORT_HARDWARE_OPEN  Serial
 #endif
 

--- a/variants/DISCO_F746NG/variant.h
+++ b/variants/DISCO_F746NG/variant.h
@@ -33,37 +33,34 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PC7,  //D0
-  PC6,  //D1
-  PG6,  //D2
-  PB4,  //D3
-  PG7,  //D4
-  PI0,  //D5
-  PH6,  //D6
-  PI3,  //D7
-  PI2,  //D8
-  PA15, //D9
-  PA8,  //D10
-  PB15, //D11
-  PB14, //D12
-  PI1,  //D13
-  PB9,  //D14
-  PB8,  //D15
-  PA0,  //D16/A0
-  PF10, //D17/A1
-  PF9,  //D18/A2
-  PF8,  //D19/A3
-  PF7,  //D20/A4
-  PF6,  //D21/A5
-  PI11, //D22 User btn
-  PB7,  //D23 ST-Link Rx
-  PA9,  //D24 ST-Link Tx
-  PC13, //D25 SD detect
-  PEND
-};
+#define PC7  0
+#define PC6  1
+#define PG6  2
+#define PB4  3
+#define PG7  4
+#define PI0  5
+#define PH6  6
+#define PI3  7
+#define PI2  8
+#define PA15 9
+#define PA8  10
+#define PB15 11
+#define PB14 12
+#define PI1  13
+#define PB9  14
+#define PB8  15
+#define PA0  16 // A0
+#define PF10 17 // A1
+#define PF9  18 // A2
+#define PF8  19 // A3
+#define PF7  20 // A4
+#define PF6  21 // A5
+#define PI11 22 // User btn
+#define PB7  23 // ST-Link Rx
+#define PA9  24 // ST-Link Tx
+#define PC13 25 // SD detect
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        26
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       6

--- a/variants/DISCO_L072CZ_LRWAN1/variant.h
+++ b/variants/DISCO_L072CZ_LRWAN1/variant.h
@@ -33,55 +33,51 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB13, //D3
-  PB5,  //D4
-  PB7,  //D5
-  PB2,  //D6
-  PA8,  //D7
-  PA9,  //D8
-  PB12, //D9
-  PB6,  //D10
-  PB15, //D11
-  PB14, //D12
-  PB13_2, //D13 - default SB2 is closed
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB13 3
+#define PB5  4
+#define PB7  5
+#define PB2  6
+#define PA8  7
+#define PA9  8
+#define PB12 9
+#define PB6  10
+#define PB15 11
+#define PB14 12
+// 13 is PB13 (3) as default SB2 is closed
+#define PB9  14 // A4 - requires closing solder bridge SB11
+#define PB8  15 // A5 - requires closing solder bridge SB12
 // Connector CN2
-  NC_1, //D16 - BOOT0
-  PA13, //D17 - SWD
-  PA14, //D18 - SWD
-  PH1,  //D19
-  PH0,  //D20
+// 16 is NC - BOOT0
+#define PA13 17 // SWD
+#define PA14 18 // SWD
+#define PH1  19
+#define PH0  20
 // Connector CN3
-  PA1,  //D21
-  PC2,  //D22
-  PC1,  //D23
-  PA12, //D24
-  PA11, //D25
-  PA0,  //D26/A0
-  PA0_2,//D27/A1 - alias for A0 - requires closing solder bridge SB7
-  PA4,  //D28/A2 - RADIO_DIO_5_PORT
-  PA4_2,//D29/A3 - alias for A2 - requires closing solder bridge SB8
-  PB9_2,//D30/A4 - requires closing solder bridge SB11
-  PB8_2,//D31/A5 - requires closing solder bridge SB12
-  PA5,  //D32/A6 - RADIO_DIO_4_PORT
-  PC0,  //D33 - RADIO_RESET_PORT
-  PA7,  //D34 - RADIO_MOSI_PORT
-  PA6,  //D35 - RADIO_MISO_PORT
-  PB3,  //D36 - RADIO_SCLK_PORT
-  PA15, //D37 - RADIO_NSS_PORT
-  PB4,  //D38 - RADIO_DIO_0_PORT
-  PB1,  //D39 - RADIO_DIO_1_PORT
-  PB0,  //D40 - RADIO_DIO_2_PORT
-  PC13, //D41 - RADIO_DIO_3_PORT
-  PEND
-};
+#define PA1  21
+#define PC2  22
+#define PC1  23
+#define PA12 24
+#define PA11 25
+#define PA0  26 // A0/A1
+// 27 is A1 an alias for A0 - requires closing solder bridge SB7
+#define PA4  28 // A2/A3 - RADIO_DIO_5_PORT
+// 29 is A3 an alias for A2 - requires closing solder bridge SB8
+// 30 is A4 - requires closing solder bridge SB11
+// 31 is A5 - requires closing solder bridge SB12
+#define PA5  32 // A6 - RADIO_DIO_4_PORT
+#define PC0  33 // RADIO_RESET_PORT
+#define PA7  34 // RADIO_MOSI_PORT
+#define PA6  35 // RADIO_MISO_PORT
+#define PB3  36 // RADIO_SCLK_PORT
+#define PA15 37 // RADIO_NSS_PORT
+#define PB4  38 // RADIO_DIO_0_PORT
+#define PB1  39 // RADIO_DIO_1_PORT
+#define PB0  40 // RADIO_DIO_2_PORT
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        42
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       7

--- a/variants/DISCO_L475VG_IOT/variant.h
+++ b/variants/DISCO_L475VG_IOT/variant.h
@@ -33,105 +33,91 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
 // CN3 connector
-  PA1,  //D0 - UART4_RX
-  PA0,  //D1 - UART4_TX
-  PD14, //D2
-  PB0,  //D3 - PWM
-  PA3,  //D4
-  PB4,  //D5 - PWM
-  PB1,  //D6 - PWM
-  PA4,  //D7
+#define PA1  0  // A6/UART4_RX
+#define PA0  1  // A7/UART4_TX
+#define PD14 2
+#define PB0  3  // A8/PWM
+#define PA3  4  // A9
+#define PB4  5  // PWM
+#define PB1  6  // A10/PWM
+#define PA4  7  // A11
 // CN1 connector
-  PB2,  //D8
-  PA15, //D9 - PWM
-  PA2,  //D10 - SPI_SSN/PWM
-  PA7,  //D11 - SPI1_MOSI/PWM
-  PA6,  //D12 - SPI1_MISO
-  PA5,  //D13 - SPI1_SCK/LED1
-  PB9,  //D14 - I2C1_SDA
-  PB8,  //D15 - I2C1_SCL
+#define PB2  8
+#define PA15 9  // PWM
+#define PA2  10 // A12/SPI_SSN/PWM
+#define PA7  11 // A13/SPI1_MOSI/PWM
+#define PA6  12 // A14/SPI1_MISO
+#define PA5  13 // A15/SPI1_SCK/LED1
+#define PB9  14 // I2C1_SDA
+#define PB8  15 // I2C1_SCL
 // Not on connector
-  PB14, //D16 - LED2
-  PC13, //D17 - USER_BTN
+#define PB14 16 // LED2
+#define PC13 17 // USER_BTN
 // ST-LINK
-  PB6,  //D18 - ST-LINK-UART1_TX
-  PB7,  //D19 - ST-LINK-UART1_RX
+#define PB6  18 // ST-LINK-UART1_TX
+#define PB7  19 // ST-LINK-UART1_RX
 // CN9 USB OTG FS connector
-  PA9,  //D20 - USB_OTG_FS_VBUS
-  PA10, //D21 - USB_OTG_FS_ID
-  PA11, //D22 - USB_OTG_FS_DM
-  PA12, //D23 - USB_OTG_FS_DP
-  PD12, //D24 - USB_OTG_FS_PWR_EN
-  PE3,  //D25 - USB_OTG_OVRCR_EXTI3
+#define PA9  20 // USB_OTG_FS_VBUS
+#define PA10 21 // USB_OTG_FS_ID
+#define PA11 22 // USB_OTG_FS_DM
+#define PA12 23 // USB_OTG_FS_DP
+#define PD12 24 // USB_OTG_FS_PWR_EN
+#define PE3  25 // USB_OTG_OVRCR_EXTI3
 // CN10 PMOD connector
-  PD0,  //D26 - PMOD-RESET
-  PD1,  //D27 - PMOD-SPI2_SCK
-  PD2,  //D28 - PMOD-IRQ_EXTI2
-  PD3,  //D29 - PMOD-UART2_CTS/SPI2_MISO
-  PD4,  //D30 - PMOD-UART2_RTS/SPI2_MOSI
-  PD5,  //D31 - PMOD-UART2_TX/SPI2_CSN
-  PD6,  //D32 - PMOD-UART2_RX
+#define PD0  26 // PMOD-RESET
+#define PD1  27 // PMOD-SPI2_SCK
+#define PD2  28 // PMOD-IRQ_EXTI2
+#define PD3  29 // PMOD-UART2_CTS/SPI2_MISO
+#define PD4  30 // PMOD-UART2_RTS/SPI2_MOSI
+#define PD5  31 // PMOD-UART2_TX/SPI2_CSN
+#define PD6  32 // PMOD-UART2_RX
 // Sensors / modules pins
-  PA8,  //D33 - SPBTLE-RF-RST
-  PB5,  //D34 - SPSGRF-915-SPI3_CSN
-  PB10, //D35 - INTERNAL-I2C2_SCL
-  PB11, //D36 - INTERNAL-I2C2_SDA
-  PB12, //D37 - ISM43362-BOOT0
-  PB13, //D38 - ISM43362-WAKEUP
-  PB15, //D39 - SPSGRF-915-SDN
-  PC6,  //D40 - VL53L0X_XSHUT
-  PC7,  //D41 - VL53L0X_GPIO1_EXTI7
-  PC8,  //D42 - LIS3MDL_DRDY_EXTI8
-  PC9,  //D43 - LED3 (WIFI) & LED4 (BLE)
-  PC10, //D44 - INTERNAL-SPI3_SCK
-  PC11, //D45 - INTERNAL-SPI3_MISO
-  PC12, //D46 - INTERNAL-SPI3_MOSI
-  PD7,  //D47 - STSAFE-A100-RESET
-  PD8,  //D48 - INTERNAL-UART3_TX
-  PD9,  //D49 - INTERNAL-UART3_RX
-  PD10, //D50 - LPS22HB_INT_DRDY_EXTI10
-  PD11, //D51 - LSM6DSL_INT1_EXTI11
-  PD13, //D52 - SPBTLE-RF-SPI3_CSN
-  PD15, //D53 - HTS221_DRDY_EXTI15
-  PE0,  //D54 - ISM43362-SPI3_CSN
-  PE1,  //D55 - ISM43362-DRDY_EXTI1
-  PE2,  //D56 - M24SR64-Y-RF_DISABLE
-  PE4,  //D57 - M24SR64-Y-GPO
-  PE5,  //D58 - SPSGRF-915-GPIO3_EXTI5
-  PE6,  //D59 - SPBTLE-RF-IRQ_EXTI6
-  PE7,  //D60 - DFSDM1_DATIN2
-  PE8,  //D61 - ISM43362-RST
-  PE9,  //D62 - DFSDM1_CKOUT
-  PE10, //D63 - QUADSPI_CLK
-  PE11, //D64 - QUADSPI_NCS
-  PE12, //D65 - QUADSPI_BK1_IO0
-  PE13, //D66 - QUADSPI_BK1_IO1
-  PE14, //D67 - QUADSPI_BK1_IO2
-  PE15, //D68 - QUADSPI_BK1_IO3
+#define PA8  33 // SPBTLE-RF-RST
+#define PB5  34 // SPSGRF-915-SPI3_CSN
+#define PB10 35 // INTERNAL-I2C2_SCL
+#define PB11 36 // INTERNAL-I2C2_SDA
+#define PB12 37 // ISM43362-BOOT0
+#define PB13 38 // ISM43362-WAKEUP
+#define PB15 39 // SPSGRF-915-SDN
+#define PC6  40 // VL53L0X_XSHUT
+#define PC7  41 // VL53L0X_GPIO1_EXTI7
+#define PC8  42 // LIS3MDL_DRDY_EXTI8
+#define PC9  43 // LED3 (WIFI) & LED4 (BLE)
+#define PC10 44 // INTERNAL-SPI3_SCK
+#define PC11 45 // INTERNAL-SPI3_MISO
+#define PC12 46 // INTERNAL-SPI3_MOSI
+#define PD7  47 // STSAFE-A100-RESET
+#define PD8  48 // INTERNAL-UART3_TX
+#define PD9  49 // INTERNAL-UART3_RX
+#define PD10 50 // LPS22HB_INT_DRDY_EXTI10
+#define PD11 51 // LSM6DSL_INT1_EXTI11
+#define PD13 52 // SPBTLE-RF-SPI3_CSN
+#define PD15 53 // HTS221_DRDY_EXTI15
+#define PE0  54 // ISM43362-SPI3_CSN
+#define PE1  55 // ISM43362-DRDY_EXTI1
+#define PE2  56 // M24SR64-Y-RF_DISABLE
+#define PE4  57 // M24SR64-Y-GPO
+#define PE5  58 // SPSGRF-915-GPIO3_EXTI5
+#define PE6  59 // SPBTLE-RF-IRQ_EXTI6
+#define PE7  60 // DFSDM1_DATIN2
+#define PE8  61 // ISM43362-RST
+#define PE9  62 // DFSDM1_CKOUT
+#define PE10 63 // QUADSPI_CLK
+#define PE11 64 // QUADSPI_NCS
+#define PE12 65 // QUADSPI_BK1_IO0
+#define PE13 66 // QUADSPI_BK1_IO1
+#define PE14 67 // QUADSPI_BK1_IO2
+#define PE15 68 // QUADSPI_BK1_IO3
 // CN4 connector
-  PC5,  //D69/A0
-  PC4,  //D70/A1
-  PC3,  //D71/A2
-  PC2,  //D72/A3
-  PC1,  //D73/A4
-  PC0,  //D74/A5
-// Duplicated pins in order to be aligned with PinMap_ADC
-  PA1_2, //D75/A6
-  PA0_2, //D76/A7
-  PB0_2, //D77/A8
-  PA3_2, //D78/A9
-  PB1_2, //D79/A10
-  PA4_2, //D80/A11
-  PA2_2, //D81/A12
-  PA7_2, //D82/A13
-  PA6_2, //D83/A14
-  PA5_2, //D84/A15
-  PEND
-};
+#define PC5  69 // A0
+#define PC4  70 // A1
+#define PC3  71 // A2
+#define PC2  72 // A3
+#define PC1  73 // A4
+#define PC0  74 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        85
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       16

--- a/variants/MAPLEMINI_F103CB/variant.h
+++ b/variants/MAPLEMINI_F103CB/variant.h
@@ -44,60 +44,46 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
 // Right side
-  PB11, //D0
-  PB10, //D1
-  PB2,  //D2
-  PB0,  //D3
-  PA7,  //D4
-  PA6,  //D5
-  PA5,  //D6
-  PA4,  //D7
-  PA3,  //D8
-  PA2,  //D9
-  PA1,  //D10
-  PA0,  //D11
-  PC15, //D12
-  PC14, //D13
-  PC13, //D14
+#define PB11 0
+#define PB10 1
+#define PB2  2
+#define PB0  3  // A0
+#define PA7  4  // A1
+#define PA6  5  // A2
+#define PA5  6  // A3
+#define PA4  7  // A4
+#define PA3  8  // A5
+#define PA2  9  // A6
+#define PA1  10 // A7
+#define PA0  11 // A8
+#define PC15 12
+#define PC14 13
+#define PC13 14
 // Left side
-  PB7,  //D15
-  PB6,  //D16
-  PB5,  //D17
-  PB4,  //D18
-  PB3,  //D19
-  PA15, //D20
-  PA14, //D21 - SWCLK
-  PA13, //D22 - SWDI0
-  PA12, //D23 - USB DP
-  PA11, //D24 - USB DM
-  PA10, //D25
-  PA9,  //D26
-  PA8,  //D27
-  PB15, //D28
-  PB14, //D29
-  PB13, //D30
-  PB12, //D31
+#define PB7  15
+#define PB6  16
+#define PB5  17
+#define PB4  18
+#define PB3  19
+#define PA15 20
+#define PA14 21 // SWCLK
+#define PA13 22 // SWDI0
+#define PA12 23 // USB DP
+#define PA11 24 // USB DM
+#define PA10 25
+#define PA9  26
+#define PA8  27
+#define PB15 28
+#define PB14 29
+#define PB13 30
+#define PB12 31
 // Other
-  PB8,  //D32 - BOOT0 - User buttons
-  PB1,  //D33 - LED
-  PB9,  //D34 - USB DISC
-// Duplicated pins to avoid issue with analogRead
-// A0 have to be greater than NUM_ANALOG_INPUTS
-  PB0_2,//D35/A0 = D3
-  PA7_2,//D36/A1 = D4
-  PA6_2,//D37/A2 = D5
-  PA5_2,//D38/A3 = D6
-  PA4_2,//D39/A4 = D7
-  PA3_2,//D40/A5 = D8
-  PA2_2,//D41/A6 = D9
-  PA1_2,//D42/A7 = D10
-  PA0_2,//D43/A8 = D11
-  PEND
-};
+#define PB8  32 // BOOT0 - User buttons
+#define PB1  33 // LED
+#define PB9  34 // USB DISC
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        44
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       9

--- a/variants/NUCLEO_F030R8/variant.h
+++ b/variants/NUCLEO_F030R8/variant.h
@@ -33,78 +33,68 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3 - no PWM
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6 - no PWM
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3  // no PWM
+#define PB5  4
+#define PB4  5
+#define PB10 6  // no PWM
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  PF6,  //D18
-  PF7,  //D19
-  PA13, //D20 - SWD
-  PA14, //D21 - SWD
-  PA15, //D22
-  PB7,  //D23
-  PC13, //D24
-  PC14, //D25
-  PC15, //D26
-  PF0,  //D27
-  PF1,  //D28
-  PC2,  //D29
-  PC3,  //D30
+#define PC10 16
+#define PC12 17
+#define PF6  18
+#define PF7  19
+#define PA13 20 // SWD
+#define PA14 21 // SWD
+#define PA15 22
+#define PB7  23
+#define PC13 24
+#define PC14 25
+#define PC15 26
+#define PF0  27
+#define PF1  28
+#define PC2  29 // A8
+#define PC3  30 // A9
 // CN7 Right Side
-  PC11, //D31
-  PD2,  //D32
+#define PC11 31
+#define PD2  32
 // CN10 Left Side
-  PC9,  //D33
+#define PC9  33
 // CN10 Right side
-  PC8,  //D34
-  PC6,  //D35
-  PC5,  //D36
-  PA12, //D37
-  PA11, //D38
-  PB12, //D39
-  PB11, //D40
-  PB2,  //D41
-  PB1,  //D42
-  PB15, //D43
-  PB14, //D44
-  PB13, //D45
-  PC4,  //D46
-  PF5,  //D47
-  PF4,  //D48
-  PA0,  //D49/A0
-  PA1,  //D50/A1
-  PA4,  //D51/A2
-  PB0,  //D52/A3
-  PC1,  //D53/A4
-  PC0,  //D54/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_2,//D55/A6  = D11
-  PA6_2,//D56/A7  = D12
-  PC2_2,//D57/A8  = D29
-  PC3_2,//D58/A9  = D30
-  PC5_2,//D59/A10 = D36
-  PC4_2,//D60/A11 = D46
-  PEND
-};
+#define PC8  34
+#define PC6  35
+#define PC5  36 // A10
+#define PA12 37
+#define PA11 38
+#define PB12 39
+#define PB11 40
+#define PB2  41
+#define PB1  42
+#define PB15 43
+#define PB14 44
+#define PB13 45
+#define PC4  46 // A11
+#define PF5  47
+#define PF4  48
+#define PA0  49 // A0
+#define PA1  50 // A1
+#define PA4  51 // A2
+#define PB0  52 // A3
+#define PC1  53 // A4
+#define PC0  54 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        61
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12

--- a/variants/NUCLEO_F091RC/variant.h
+++ b/variants/NUCLEO_F091RC/variant.h
@@ -33,75 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  PF11, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PF0,  //D26
-  PF1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10 16
+#define PC12 17
+#define PF11 18 // BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PF0  26
+#define PF1  27
+#define PC2  28 // A8
+#define PC3  29 // A9
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11 30
+#define PD2  31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9  32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_2,//D52/A6  = D11
-  PA6_2,//D53/A7  = D12
-  PC2_2,//D54/A8  = D28
-  PC3_2,//D55/A9  = D29
-  PC5_2,//D56/A10 = D35
-  PC4_2,//D57/A11 = D45
-  PEND
-};
+#define PC8  33
+#define PC6  34
+#define PC5  35 // A10
+#define PA12 36
+#define PA11 37
+#define PB12 38
+#define PB11 39
+#define PB2  40
+#define PB1  41
+#define PB15 42
+#define PB14 43
+#define PB13 44
+#define PC4  45 // A11
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        58
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12

--- a/variants/NUCLEO_F103RB/variant.h
+++ b/variants/NUCLEO_F103RB/variant.h
@@ -33,77 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13 - LED
-  PB9,  //D14
-  PB8,  //D15
-  // ST Morpho
-  // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  NC_1, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PD0,  //D26
-  PD1,  //D27
-  PC2,  //D28
-  PC3,  //D29
-  // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
-  // CN10 Left Side
-  PC9,  //D32
-  // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_2,//D52/A6 = D11
-  PA6_2,//D53/A7 = D12
-  PA5_2,//D54/A8 = D13
-  PC2_2,//D55/A9 = D28
-  PC3_2,//D56/A10 = D29
-  PB1_2,//D57/A11 = D41
-  PC4_2,//D58/A12 = D45
-  PC5_2,//D59/A13 = D35
-  PEND
-};
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13 // A8 - LED
+#define PB9  14
+#define PB8  15
+// ST Morpho
+// CN7 Left Side
+#define PC10 16
+#define PC12 17
+// 18 is NC - BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PD0  26
+#define PD1  27
+#define PC2  28 // A9
+#define PC3  29 // A10
+// CN7 Right Side
+#define PC11 30
+#define PD2  31
+// CN10 Left Side
+#define PC9  32
+// CN10 Right side
+#define PC8  33
+#define PC6  34
+#define PC5  35 // A13
+#define PA12 36
+#define PA11 37
+#define PB12 38
+#define PB11 39
+#define PB2  40
+#define PB1  41 // A11
+#define PB15 42
+#define PB14 43
+#define PB13 44
+#define PC4  45 // A12
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        60
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       14

--- a/variants/NUCLEO_F207ZG/variant.h
+++ b/variants/NUCLEO_F207ZG/variant.h
@@ -45,109 +45,96 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-// Enum defining Arduino style alias for digital pin number --> Dx
-enum {
-  PG9,  //D0
-  PG14, //D1
-  PF15, //D2
-  PE13, //D3
-  PF14, //D4
-  PE11, //D5
-  PE9,  //D6
-  PF13, //D7
-  PF12, //D8
-  PD15, //D9
-  PD14, //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
-  PC6,  //D16
-  PB15, //D17
-  PB13, //D18
-  PB12, //D19
-  PA15, //D20
-  PC7,  //D21
-  PB5,  //D22
-  PB3,  //D23
-  PA4,  //D24
-  PB4,  //D25
-  PB6,  //D26
-  PB2,  //D27
-  PD13, //D28
-  PD12, //D29
-  PD11, //D30
-  PE2,  //D31
-  PA0,  //D32
-  PB0,  //D33 - LED1
-  PE0,  //D34
-  PB11, //D35
-  PB10, //D36
-  PE15, //D37
-  PE14, //D38
-  PE12, //D39
-  PE10, //D40
-  PE7,  //D41
-  PE8,  //D42
-  PC8,  //D43
-  PC9,  //D44
-  PC10, //D45
-  PC11, //D46
-  PC12, //D47
-  PD2,  //D48
-  PG2,  //D49
-  PG3,  //D50
-  PD7,  //D51
-  PD6,  //D52
-  PD5,  //D53
-  PD4,  //D54
-  PD3,  //D55
-  PE2_2,//D56
-  PE4,  //D57
-  PE5,  //D58
-  PE6,  //D59
-  PE3,  //D60
-  PF8,  //D61
-  PF7,  //D62
-  PF9,  //D63
-  PG1,  //D64
-  PG0,  //D65
-  PD1,  //D66
-  PD0,  //D67
-  PF0,  //D68
-  PF1,  //D69
-  PF2,  //D70
-  PA7_2,//D71
-  NC_1, //D72
-  PB7,  //D73 - LED_BLUE
-  PB14, //D74 - LED_RED
-  PC13, //D75 - USER_BTN
-  PD9,  //D76 - Serial Rx
-  PD8,  //D77 - Serial Tx
-  PA3,  //D78/A0
-  PC0,  //D79/A1
-  PC3,  //D80/A2
-  PF3,  //D81/A3
-  PF5,  //D82/A4
-  PF10, //D83/A5
-  PB1,  //D84/A6
-  PC2,  //D85/A7
-  PF4,  //D86/A8
-  PF6,  //D87/A9
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_3,//D88/A10 = D11/D71
-  PA6_2,//D89/A11 = D12
-  PA5_2,//D90/A12 = D13
-  PA4_2,//D91/A13 = D24
-  PA0_2,//D92/A14 = D32
-  PF8_2,//D93/A15 = D61
-  PF7_2,//D94/A16 = D62
-  PF9_2,//D95/A17 = D63
-  PEND
-};
+#define PG9  0
+#define PG14 1
+#define PF15 2
+#define PE13 3
+#define PF14 4
+#define PE11 5
+#define PE9  6
+#define PF13 7
+#define PF12 8
+#define PD15 9
+#define PD14 10
+#define PA7  11 // A10
+#define PA6  12 // A11
+#define PA5  13 // A12
+#define PB9  14
+#define PB8  15
+#define PC6  16
+#define PB15 17
+#define PB13 18
+#define PB12 19
+#define PA15 20
+#define PC7  21
+#define PB5  22
+#define PB3  23
+#define PA4  24 // A13
+#define PB4  25
+#define PB6  26
+#define PB2  27
+#define PD13 28
+#define PD12 29
+#define PD11 30
+#define PE2  31
+#define PA0  32 // A14
+#define PB0  33 // LED1
+#define PE0  34
+#define PB11 35
+#define PB10 36
+#define PE15 37
+#define PE14 38
+#define PE12 39
+#define PE10 40
+#define PE7  41
+#define PE8  42
+#define PC8  43
+#define PC9  44
+#define PC10 45
+#define PC11 46
+#define PC12 47
+#define PD2  48
+#define PG2  49
+#define PG3  50
+#define PD7  51
+#define PD6  52
+#define PD5  53
+#define PD4  54
+#define PD3  55
+// 56 is PE2 (31)
+#define PE4  57
+#define PE5  58
+#define PE6  59
+#define PE3  60
+#define PF8  61 // A15
+#define PF7  62 // A16
+#define PF9  63 // A17
+#define PG1  64
+#define PG0  65
+#define PD1  66
+#define PD0  67
+#define PF0  68
+#define PF1  69
+#define PF2  70
+// 71 is PA7 (11)
+// 72 is NC
+#define PB7  73 // LED_BLUE
+#define PB14 74 // LED_RED
+#define PC13 75 // USER_BTN
+#define PD9  76 // Serial Rx
+#define PD8  77 // Serial Tx
+#define PA3  78 // A0
+#define PC0  79 // A1
+#define PC3  80 // A2
+#define PF3  81 // A3
+#define PF5  82 // A4
+#define PF10 83 // A5
+#define PB1  84 // A6
+#define PC2  85 // A7
+#define PF4  86 // A8
+#define PF6  87 // A9
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        96
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       18

--- a/variants/NUCLEO_F302R8/variant.h
+++ b/variants/NUCLEO_F302R8/variant.h
@@ -33,75 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PB15,//D11
-  PB14,//D12
-  PB13,//D13
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PB15 11
+#define PB14 12
+#define PB13 13
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  PF11, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PF0,  //D26
-  PF1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10 16
+#define PC12 17
+#define PF11 18 // BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PF0  26
+#define PF1  27
+#define PC2  28 // A6
+#define PC3  29 // A7
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11 30
+#define PD2  31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9  32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PA7,  //D42
-  PA6,  //D43
-  PA5,  //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PC2_2,//D52/A6  = D28
-  PC3_2,//D53/A7  = D29
-  PB11_2,//D54/A8 = D39
-  PB1_2,//D55/A9  = D41
-  PA7_2,//D56/A10 = D42
-  PA6_2,//D57/A11 = D43
-  PEND
-};
+#define PC8  33
+#define PC6  34
+#define PC5  35
+#define PA12 36
+#define PA11 37
+#define PB12 38
+#define PB11 39 // A8
+#define PB2  40
+#define PB1  41 // A9
+#define PA7  42 // A10
+#define PA6  43 // A11
+#define PA5  44
+#define PC4  45
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        58
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12

--- a/variants/NUCLEO_F303K8/variant.h
+++ b/variants/NUCLEO_F303K8/variant.h
@@ -33,34 +33,31 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA10, //D0
-  PA9,  //D1
-  PA12, //D2
-  PB0,  //D3
-  PB7,  //D4
-  PB6,  //D5
-  PB1,  //D6
-  PF0,  //D7
-  PF1,  //D8
-  PA8,  //D9
-  PA11, //D10
-  PB5,  //D11
-  PB4,  //D12
-  PB3,  //D13 - LED
-  PA0,  //D14/A0
-  PA1,  //D15/A1
-  PA3,  //D16/A2
-  PA4,  //D17/A3
-  PA5,  //D18/A4 - if SB18 ON (default) connected to PB7
-  PA6,  //D19/A5 - if SB16 ON (default) connected to PB6
-  PA7,  //D20/A6
-  PA2,  //D21/A7 - STLink Tx
-  PA15, //D22    - STLink Rx
-  PEND
-};
+#define PA10 0
+#define PA9  1
+#define PA12 2
+#define PB0  3
+#define PB7  4
+#define PB6  5
+#define PB1  6
+#define PF0  7
+#define PF1  8
+#define PA8  9
+#define PA11 10
+#define PB5  11
+#define PB4  12
+#define PB3  13 // LED
+#define PA0  14 // A0
+#define PA1  15 // A1
+#define PA3  16 // A2
+#define PA4  17 // A3
+#define PA5  18 // A4 - if SB18 ON (default) connected to PB7
+#define PA6  19 // A5 - if SB16 ON (default) connected to PB6
+#define PA7  20 // A6
+#define PA2  21 // A7 - STLink Tx
+#define PA15 22 // STLink Rx
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        23
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       7

--- a/variants/NUCLEO_F303RE/variant.h
+++ b/variants/NUCLEO_F303RE/variant.h
@@ -33,77 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  PF11, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PF0,  //D26
-  PF1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10 16
+#define PC12 17
+#define PF11 18 // BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PF0  26
+#define PF1  27
+#define PC2  28 // A8
+#define PC3  29 // A9
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11 30
+#define PD2  31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9  32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_2, //D52/A6  = D11
-  PA6_2, //D53/A7  = D12
-  PC2_2, //D54/A8  = D28
-  PC3_2, //D55/A9  = D29
-  PC5_2, //D56/A10 = D35
-  PB11_2,//D57/A11 = D39
-  PB2_2, //D58/A12 = D40
-  PC4_2, //D59/A13 = D45
-  PEND
-};
+#define PC8  33
+#define PC6  34
+#define PC5  35 // A10
+#define PA12 36
+#define PA11 37
+#define PB12 38
+#define PB11 39 // A11
+#define PB2  40 // A12
+#define PB1  41
+#define PB15 42
+#define PB14 43
+#define PB13 44
+#define PC4  45 // A13
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        60
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       14

--- a/variants/NUCLEO_F401RE/variant.h
+++ b/variants/NUCLEO_F401RE/variant.h
@@ -33,76 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  NC_1, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PH0,  //D26
-  PH1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10 16
+#define PC12 17
+// 18 is NC - BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PH0  26
+#define PH1  27
+#define PC2  28 // A8
+#define PC3  29 // A9
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11 30
+#define PD2  31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9  32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_2,//D52/A6  = D11
-  PA6_2,//D53/A7  = D12
-  PC2_2,//D54/A8  = D28
-  PC3_2,//D55/A9  = D29
-  PC5_2,//D56/A10 = D35
-  PB1_2,//D57/A11 = D41
-  PC4_2,//D58/A12 = D45
-  PEND
-};
+#define PC8  33
+#define PC6  34
+#define PC5  35 // A10
+#define PA12 36
+#define PA11 37
+#define PB12 38
+#define PB11 39
+#define PB2  40
+#define PB1  41 // A11
+#define PB15 42
+#define PB14 43
+#define PB13 44
+#define PC4  45 // A12
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        59
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       13

--- a/variants/NUCLEO_F411RE/variant.h
+++ b/variants/NUCLEO_F411RE/variant.h
@@ -33,76 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  NC_1,   //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PH0,  //D26
-  PH1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10 16
+#define PC12 17
+// 18 is NC - BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PH0  26
+#define PH1  27
+#define PC2  28 // A8
+#define PC3  29 // A9
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11 30
+#define PD2  31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9  32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMapADC
-  PA7_2,//D52/A6  = D11
-  PA6_2,//D53/A7  = D12
-  PC2_2,//D54/A8  = D28
-  PC3_2,//D55/A9  = D29
-  PC5_2,//D56/A10 = D35
-  PB1_2,//D57/A11 = D41
-  PC4_2,//D58/A12 = D45
-  PEND
-};
+#define PC8  33
+#define PC6  34
+#define PC5  35 // A10
+#define PA12 36
+#define PA11 37
+#define PB12 38
+#define PB11 39
+#define PB2  40
+#define PB1  41 // A11
+#define PB15 42
+#define PB14 43
+#define PB13 44
+#define PC4  45 // A12
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        59
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       13

--- a/variants/NUCLEO_F429ZI/variant.h
+++ b/variants/NUCLEO_F429ZI/variant.h
@@ -33,108 +33,96 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PG9,  //D0
-  PG14, //D1
-  PF15, //D2
-  PE13, //D3
-  PF14, //D4
-  PE11, //D5
-  PE9,  //D6
-  PF13, //D7
-  PF12, //D8
-  PD15, //D9
-  PD14, //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
-  PC6,  //D16
-  PB15, //D17
-  PB13, //D18
-  PB12, //D19
-  PA15, //D20
-  PC7,  //D21
-  PB5,  //D22
-  PB3,  //D23
-  PA4,  //D24
-  PB4,  //D25
-  PB6,  //D26
-  PB2,  //D27
-  PD13, //D28
-  PD12, //D29
-  PD11, //D30
-  PE2,  //D31
-  PA0,  //D32
-  PB0,  //D33 - LEDGREEN
-  PE0,  //D34
-  PB11, //D35
-  PB10, //D36
-  PE15, //D37
-  PE14, //D38
-  PE12, //D39
-  PE10, //D40
-  PE7,  //D41
-  PE8,  //D42
-  PC8,  //D43
-  PC9,  //D44
-  PC10, //D45
-  PC11, //D46
-  PC12, //D47
-  PD2,  //D48
-  PG2,  //D49
-  PG3,  //D50
-  PD7,  //D51
-  PD6,  //D52
-  PD5,  //D53
-  PD4,  //D54
-  PD3,  //D55
-  PE2_2,//D56
-  PE4,  //D57
-  PE5,  //D58
-  PE6,  //D59
-  PE3,  //D60
-  PF8,  //D61
-  PF7,  //D62
-  PF9,  //D63
-  PG1,  //D64
-  PG0,  //D65
-  PD1,  //D66
-  PD0,  //D67
-  PF0,  //D68
-  PF1,  //D69
-  PF2,  //D70
-  PA7_2,//D71
-  NC_1, //D72
-  PB7,  //D73 - LEDBLUE
-  PB14, //D74 - LEDRED
-  PC13, //D75 - USERBTN
-  PD9,  //D76 - Serial Rx
-  PD8,  //D77 - Serial Tx
-  PA3,  //D78/A0
-  PC0,  //D79/A1
-  PC3,  //D80/A2
-  PF3,  //D81/A3
-  PF5,  //D82/A4
-  PF10, //D83/A5
-  PB1,  //D84/A6
-  PC2,  //D85/A7
-  PF4,  //D86/A8
-  PF6,  //D87/A9
-  // Duplicated pins in order to be aligned with PinMapADC
-  PA7_3,  //D88/A10 = D11
-  PA6_2,  //D89/A11 = D12
-  PA5_2,  //D90/A12 = D13
-  PA4_2,  //D91/A13 = D24
-  PA0_2,  //D92/A14 = D32
-  PF8_2,  //D93/A15 = D61
-  PF7_2,  //D94/A16 = D62
-  PF9_2,  //D95/A17 = D63
-  PEND
-};
+#define PG9  0
+#define PG14 1
+#define PF15 2
+#define PE13 3
+#define PF14 4
+#define PE11 5
+#define PE9  6
+#define PF13 7
+#define PF12 8
+#define PD15 9
+#define PD14 10
+#define PA7  11 // A10
+#define PA6  12 // A11
+#define PA5  13 // A12
+#define PB9  14
+#define PB8  15
+#define PC6  16
+#define PB15 17
+#define PB13 18
+#define PB12 19
+#define PA15 20
+#define PC7  21
+#define PB5  22
+#define PB3  23
+#define PA4  24 // A13
+#define PB4  25
+#define PB6  26
+#define PB2  27
+#define PD13 28
+#define PD12 29
+#define PD11 30
+#define PE2  31
+#define PA0  32 // A14
+#define PB0  33 // LED_GREEN
+#define PE0  34
+#define PB11 35
+#define PB10 36
+#define PE15 37
+#define PE14 38
+#define PE12 39
+#define PE10 40
+#define PE7  41
+#define PE8  42
+#define PC8  43
+#define PC9  44
+#define PC10 45
+#define PC11 46
+#define PC12 47
+#define PD2  48
+#define PG2  49
+#define PG3  50
+#define PD7  51
+#define PD6  52
+#define PD5  53
+#define PD4  54
+#define PD3  55
+// 56 is PE2 (31)
+#define PE4  57
+#define PE5  58
+#define PE6  59
+#define PE3  60
+#define PF8  61 // A15
+#define PF7  62 // A16
+#define PF9  63 // A17
+#define PG1  64
+#define PG0  65
+#define PD1  66
+#define PD0  67
+#define PF0  68
+#define PF1  69
+#define PF2  70
+// 71 is PA7 (11)
+// 72 is NC
+#define PB7  73 // LED_BLUE
+#define PB14 74 // LED_RED
+#define PC13 75 // USER_BTN
+#define PD9  76 // Serial Rx
+#define PD8  77 // Serial Tx
+#define PA3  78 // A0
+#define PC0  79 // A1
+#define PC3  80 // A2
+#define PF3  81 // A3
+#define PF5  82 // A4
+#define PF10 83 // A5
+#define PB1  84 // A6
+#define PC2  85 // A7
+#define PF4  86 // A8
+#define PF6  87 // A9
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        96
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       18

--- a/variants/NUCLEO_F446RE/variant.h
+++ b/variants/NUCLEO_F446RE/variant.h
@@ -33,77 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13 - LD2
-  PB9,  //D14
-  PB8,  //D15
+#define PA3   0
+#define PA2   1
+#define PA10  2
+#define PB3   3
+#define PB5   4
+#define PB4   5
+#define PB10  6
+#define PA8   7
+#define PA9   8
+#define PC7   9
+#define PB6   10
+#define PA7   11 // A6
+#define PA6   12 // A7
+#define PA5   13 // A8 - LD2
+#define PB9   14
+#define PB8   15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  NC_1, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23 - USER_BTN
-  PC14, //D24 - NC by default SB49 opened
-  PC15, //D25 - NC by default SB48 opened
-  PH0,  //D26 - NC by default SB55 opened
-  PH1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10  16
+#define PC12  17
+// 18 is NC - BOOT0
+#define PA13  19 // SWD
+#define PA14  20 // SWD
+#define PA15  21
+#define PB7   22
+#define PC13  23 // USER_BTN
+#define PC14  24 // NC by default SB49 opened
+#define PC15  25 // NC by default SB48 opened
+#define PH0   26 // NC by default SB55 opened
+#define PH1   27
+#define PC2   28 // A9
+#define PC3   29 // A10
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11  30
+#define PD2   31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9   32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  NC_2, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMapADC
-  PA7_2,//D52/A6  = D11
-  PA6_2,//D53/A7  = D12
-  PA5_2,//D54/A8  = D13
-  PC2_2,//D55/A9  = D28
-  PC3_2,//D56/A10 = D29
-  PC5_2,//D57/A11 = D35
-  PB1_2,//D58/A12 = D41
-  PC4_2,//D59/A13 = D45
-  PEND
-};
+#define PC8   33
+#define PC6   34
+#define PC5   35 // A11
+#define PA12  36
+#define PA11  37
+#define PB12  38
+// 39 is NC
+#define PB2   40
+#define PB1   41 // A12
+#define PB15  42
+#define PB14  43
+#define PB13  44
+#define PC4   45 // A13
+#define PA0   46 // A0
+#define PA1   47 // A1
+#define PA4   48 // A2
+#define PB0   49 // A3
+#define PC1   50 // A4
+#define PC0   51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        60
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       14

--- a/variants/NUCLEO_F767ZI/variant.h
+++ b/variants/NUCLEO_F767ZI/variant.h
@@ -33,108 +33,96 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PG9,  //D0
-  PG14, //D1
-  PF15, //D2
-  PE13, //D3
-  PF14, //D4
-  PE11, //D5
-  PE9,  //D6
-  PF13, //D7
-  PF12, //D8
-  PD15, //D9
-  PD14, //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
-  PC6,  //D16
-  PB15, //D17
-  PB13, //D18
-  PB12, //D19
-  PA15, //D20
-  PC7,  //D21
-  PB5,  //D22
-  PB3,  //D23
-  PA4,  //D24
-  PB4,  //D25
-  PB6,  //D26
-  PB2,  //D27
-  PD13, //D28
-  PD12, //D29
-  PD11, //D30
-  PE2,  //D31
-  PA0,  //D32
-  PB0,  //D33 - LED_GREEN
-  PE0,  //D34
-  PB11, //D35
-  PB10, //D36
-  PE15, //D37
-  PE14, //D38
-  PE12, //D39
-  PE10, //D40
-  PE7,  //D41
-  PE8,  //D42
-  PC8,  //D43
-  PC9,  //D44
-  PC10, //D45
-  PC11, //D46
-  PC12, //D47
-  PD2,  //D48
-  PG2,  //D49
-  PG3,  //D50
-  PD7,  //D51
-  PD6,  //D52
-  PD5,  //D53
-  PD4,  //D54
-  PD3,  //D55
-  PE2_2,//D56
-  PE4,  //D57
-  PE5,  //D58
-  PE6,  //D59
-  PE3,  //D60
-  PF8,  //D61
-  PF7,  //D62
-  PF9,  //D63
-  PG1,  //D64
-  PG0,  //D65
-  PD1,  //D66
-  PD0,  //D67
-  PF0,  //D68
-  PF1,  //D69
-  PF2,  //D70
-  PA7_2,//D71
-  NC_1, //D72
-  PB7,  //D73 - LED_BLUE
-  PB14, //D74 - LED_RED
-  PC13, //D75 - USER_BTN
-  PD9,  //D76 - Serial Rx
-  PD8,  //D77 - Serial Tx
-  PA3,  //D78/A0
-  PC0,  //D79/A1
-  PC3,  //D80/A2
-  PF3,  //D81/A3
-  PF5,  //D82/A4
-  PF10, //D83/A5
-  PB1,  //D84/A6
-  PC2,  //D85/A7
-  PF4,  //D86/A8
-  PF6,  //D87/A9
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_3,  //D88/A10 = D11
-  PA6_2,  //D89/A11 = D12
-  PA5_2,  //D90/A12 = D13
-  PA4_2,  //D91/A13 = D24
-  PA0_2,  //D92/A14 = D32
-  PF8_2,  //D93/A15 = D61
-  PF7_2,  //D94/A16 = D62
-  PF9_2,  //D95/A17 = D63
-  PEND
-};
+#define PG9  0
+#define PG14 1
+#define PF15 2
+#define PE13 3
+#define PF14 4
+#define PE11 5
+#define PE9  6
+#define PF13 7
+#define PF12 8
+#define PD15 9
+#define PD14 10 // A10
+#define PA7  11 // A11
+#define PA6  12 // A12
+#define PA5  13
+#define PB9  14
+#define PB8  15
+#define PC6  16
+#define PB15 17
+#define PB13 18
+#define PB12 19
+#define PA15 20
+#define PC7  21
+#define PB5  22
+#define PB3  23
+#define PA4  24 // A13
+#define PB4  25
+#define PB6  26
+#define PB2  27
+#define PD13 28
+#define PD12 29
+#define PD11 30
+#define PE2  31
+#define PA0  32 // A14
+#define PB0  33 // LED_GREEN
+#define PE0  34
+#define PB11 35
+#define PB10 36
+#define PE15 37
+#define PE14 38
+#define PE12 39
+#define PE10 40
+#define PE7  41
+#define PE8  42
+#define PC8  43
+#define PC9  44
+#define PC10 45
+#define PC11 46
+#define PC12 47
+#define PD2  48
+#define PG2  49
+#define PG3  50
+#define PD7  51
+#define PD6  52
+#define PD5  53
+#define PD4  54
+#define PD3  55
+// 56 is PE2 (31)
+#define PE4  57
+#define PE5  58
+#define PE6  59
+#define PE3  60
+#define PF8  61 // A15
+#define PF7  62 // A16
+#define PF9  63 // A17
+#define PG1  64
+#define PG0  65
+#define PD1  66
+#define PD0  67
+#define PF0  68
+#define PF1  69
+#define PF2  70
+// 71 is PA7 (11)
+// 72 is NC
+#define PB7  73 // LED_BLUE
+#define PB14 74 // LED_RED
+#define PC13 75 // USER_BTN
+#define PD9  76 // Serial Rx
+#define PD8  77 // Serial Tx
+#define PA3  78 // A0
+#define PC0  79 // A1
+#define PC3  80 // A2
+#define PF3  81 // A3
+#define PF5  82 // A4
+#define PF10 83 // A5
+#define PB1  84 // A6
+#define PC2  85 // A7
+#define PF4  86 // A8
+#define PF6  87 // A9
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        96
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       18

--- a/variants/NUCLEO_L031K6/variant.h
+++ b/variants/NUCLEO_L031K6/variant.h
@@ -45,34 +45,31 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA10, //D0
-  PA9,  //D1
-  PA12, //D2
-  PB0,  //D3
-  PB7,  //D4
-  PB6,  //D5
-  PB1,  //D6
-  PC14, //D7
-  PC15, //D8
-  PA8,  //D9
-  PA11, //D10
-  PB5,  //D11
-  PB4,  //D12
-  PB3,  //D13 - LED
-  PA0,  //D14/A0
-  PA1,  //D15/A1
-  PA3,  //D16/A2
-  PA4,  //D17/A3
-  PA5,  //D18/A4
-  PA6,  //D19/A5
-  PA7,  //D20/A6
-  PA2,  //D21/A7 - STLink Tx
-  PA15, //D22 - STLink Rx
-  PEND
-};
+#define PA10 0
+#define PA9  1
+#define PA12 2
+#define PB0  3
+#define PB7  4
+#define PB6  5
+#define PB1  6
+#define PC14 7
+#define PC15 8
+#define PA8  9
+#define PA11 10
+#define PB5  11
+#define PB4  12
+#define PB3  13 // LED
+#define PA0  14 // A0
+#define PA1  15 // A1
+#define PA3  16 // A2
+#define PA4  17 // A3
+#define PA5  18 // A4
+#define PA6  19 // A5
+#define PA7  20 // A6
+#define PA2  21 // A7 - STLink Tx
+#define PA15 22 // STLink Rx
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        23
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       7

--- a/variants/NUCLEO_L053R8/variant.h
+++ b/variants/NUCLEO_L053R8/variant.h
@@ -33,75 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  NC_1, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PH0,  //D26
-  PH1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10 16
+#define PC12 17
+// 18 is NC - BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PH0  26
+#define PH1  27
+#define PC2  28 // A8
+#define PC3  29 // A9
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11 30
+#define PD2  31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9  32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_2,//D52/A6  = D11
-  PA6_2,//D53/A7  = D12
-  PC2_2,//D54/A8  = D28
-  PC3_2,//D55/A9  = D29
-  PC5_2,//D56/A10 = D35
-  PC4_2,//D57/A11 = D45
-  PEND
-};
+#define PC8  33
+#define PC6  34
+#define PC5  35 // A10
+#define PA12 36
+#define PA11 37
+#define PB12 38
+#define PB11 39
+#define PB2  40
+#define PB1  41
+#define PB15 42
+#define PB14 43
+#define PB13 44
+#define PC4  45 // A11
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        58
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12

--- a/variants/NUCLEO_L073RZ/variant.h
+++ b/variants/NUCLEO_L073RZ/variant.h
@@ -45,76 +45,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-// Enum defining pin names to match digital pin number --> Dx
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10 - PWM is not supported by D10 as no timer on PB6
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10 // PWM is not supported by D10 as no timer on PB6
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  NC_1, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PH0,  //D26
-  PH1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10 16
+#define PC12 17
+// 18 is NC - BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PH0  26
+#define PH1  27
+#define PC2  28 // A8
+#define PC3  29 // A9
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11 30
+#define PD2  31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9   32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4 - SB56 ON SB51 ON on the board!
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_2,//D52/A6  = D11
-  PA6_2,//D53/A7  = D12
-  PC2_2,//D54/A8  = D28
-  PC3_2,//D55/A9  = D29
-  PC5_2,//D56/A10 = D35
-  PC4_2,//D57/A11 = D45
-  PEND
-};
+#define PC8  33
+#define PC6  34
+#define PC5  35 // A10
+#define PA12 36
+#define PA11 37
+#define PB12 38
+#define PB11 39
+#define PB2  40
+#define PB1  41
+#define PB15 42
+#define PB14 43
+#define PB13 44
+#define PC4  45 // A11
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4 - SB56 ON SB51 ON on the board!
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        58
 
 // This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS

--- a/variants/NUCLEO_L152RE/variant.h
+++ b/variants/NUCLEO_L152RE/variant.h
@@ -33,80 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  NC_1, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PH0,  //D26
-  PH1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10 16
+#define PC12 17
+// 18 is NC - BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PH0  26
+#define PH1  27
+#define PC2  28 // A8
+#define PC3  29 // A9
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11 30
+#define PD2  31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9  32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_2,//D52/A6  = D11
-  PA6_2,//D53/A7  = D12
-  PC2_2,//D54/A8  = D28
-  PC3_2,//D55/A9  = D29
-  PC5_2,//D56/A10 = D35
-  PB12_2,//D57/A11 = D38
-  PB1_2,//D58/A12 = D41
-  PB15_2,//D59/A13 = D42
-  PB14_2,//D60/A14 = D43
-  PB13_2,//D61/A15 = D44
-  PC4_2, //D62/A16 = D45
-  PEND
-};
+#define PC8  33
+#define PC6  34
+#define PC5  35 // A10
+#define PA12 36
+#define PA11 37
+#define PB12 38 // A11
+#define PB11 39
+#define PB2  40
+#define PB1  41 // A12
+#define PB15 42 // A13
+#define PB14 43 // A14
+#define PB13 44 // A15
+#define PC4  45 // A16
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        63
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       17

--- a/variants/NUCLEO_L432KC/variant.h
+++ b/variants/NUCLEO_L432KC/variant.h
@@ -33,34 +33,31 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA10, //D0
-  PA9,  //D1
-  PA12, //D2
-  PB0,  //D3
-  PB7,  //D4
-  PB6,  //D5
-  PB1,  //D6
-  PC14, //D7
-  PC15, //D8
-  PA8,  //D9
-  PA11, //D10
-  PB5,  //D11
-  PB4,  //D12
-  PB3,  //D13 - LED
-  PA0,  //D14/A0
-  PA1,  //D15/A1
-  PA3,  //D16/A2
-  PA4,  //D17/A3
-  PA5,  //D18/A4
-  PA6,  //D19/A5
-  PA7,  //D20/A6
-  PA2,  //D21/A7 - STLink Tx
-  PA15, //D22 - STLink Rx
-  PEND
-};
+#define PA10 0
+#define PA9  1
+#define PA12 2
+#define PB0  3
+#define PB7  4
+#define PB6  5
+#define PB1  6
+#define PC14 7
+#define PC15 8
+#define PA8  9
+#define PA11 10
+#define PB5  11
+#define PB4  12
+#define PB3  13 // LED
+#define PA0  14 // A0
+#define PA1  15 // A1
+#define PA3  16 // A2
+#define PA4  17 // A3
+#define PA5  18 // A4
+#define PA6  19 // A5
+#define PA7  20 // A6
+#define PA2  21 // A7 - STLink Tx
+#define PA15 22 // STLink Rx
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        23
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       7

--- a/variants/NUCLEO_L476RG/variant.h
+++ b/variants/NUCLEO_L476RG/variant.h
@@ -33,75 +33,65 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA3,  //D0
-  PA2,  //D1
-  PA10, //D2
-  PB3,  //D3
-  PB5,  //D4
-  PB4,  //D5
-  PB10, //D6
-  PA8,  //D7
-  PA9,  //D8
-  PC7,  //D9
-  PB6,  //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13 - LED
-  PB9,  //D14
-  PB8,  //D15
+#define PA3  0
+#define PA2  1
+#define PA10 2
+#define PB3  3
+#define PB5  4
+#define PB4  5
+#define PB10 6
+#define PA8  7
+#define PA9  8
+#define PC7  9
+#define PB6  10
+#define PA7  11 // A6
+#define PA6  12 // A7
+#define PA5  13 // LED
+#define PB9  14
+#define PB8  15
 // ST Morpho
 // CN7 Left Side
-  PC10, //D16
-  PC12, //D17
-  NC_1, //D18 - BOOT0
-  PA13, //D19 - SWD
-  PA14, //D20 - SWD
-  PA15, //D21
-  PB7,  //D22
-  PC13, //D23
-  PC14, //D24
-  PC15, //D25
-  PH0,  //D26
-  PH1,  //D27
-  PC2,  //D28
-  PC3,  //D29
+#define PC10 16
+#define PC12 17
+// 18 is NC - BOOT0
+#define PA13 19 // SWD
+#define PA14 20 // SWD
+#define PA15 21
+#define PB7  22
+#define PC13 23
+#define PC14 24
+#define PC15 25
+#define PH0  26
+#define PH1  27
+#define PC2  28 // A8
+#define PC3  29 // A9
 // CN7 Right Side
-  PC11, //D30
-  PD2,  //D31
+#define PC11 30
+#define PD2  31
 // CN10 Left Side
-  PC9,  //D32
+#define PC9  32
 // CN10 Right side
-  PC8,  //D33
-  PC6,  //D34
-  PC5,  //D35
-  PA12, //D36
-  PA11, //D37
-  PB12, //D38
-  PB11, //D39
-  PB2,  //D40
-  PB1,  //D41
-  PB15, //D42
-  PB14, //D43
-  PB13, //D44
-  PC4,  //D45
-  PA0,  //D46/A0
-  PA1,  //D47/A1
-  PA4,  //D48/A2
-  PB0,  //D49/A3
-  PC1,  //D50/A4
-  PC0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA7_2,//D52/A6  = D11
-  PA6_2,//D53/A7  = D12
-  PC2_2,//D54/A8  = D28
-  PC3_2,//D55/A9  = D29
-  PC5_2,//D56/A10 = D35
-  PC4_2,//D57/A11 = D45
-  PEND
-};
+#define PC8  33
+#define PC6  34
+#define PC5  35 // A10
+#define PA12 36
+#define PA11 37
+#define PB12 38
+#define PB11 39
+#define PB2  40
+#define PB1  41
+#define PB15 42
+#define PB14 43
+#define PB13 44
+#define PC4  45 // A11
+#define PA0  46 // A0
+#define PA1  47 // A1
+#define PA4  48 // A2
+#define PB0  49 // A3
+#define PC1  50 // A4
+#define PC0  51 // A5
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        58
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12

--- a/variants/NUCLEO_L496ZG/variant.h
+++ b/variants/NUCLEO_L496ZG/variant.h
@@ -47,154 +47,137 @@ extern const PinName digitalPin[];
 
 // Match Table 11. NUCLEO-L496ZG, NUCLEO-L496ZG-P pin assignments
 // from UM2179 STM32 Nucleo-144 board
-enum {
-  PD9,  //D0
-  PD8,  //D1
-  PF15, //D2
-  PE13, //D3
-  PF14, //D4
-  PE11, //D5
-  PE9,  //D6
-  PF13, //D7
-  PF12, //D8
-  PD15, //D9
-  PD14, //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
-  PC6,  //D16
-  PB15, //D17
-  PB13, //D18
-  PB12, //D19
-  PA4,  //D20
-  PB4,  //D21
-  PB5,  //D22
-  PB3,  //D23
-  PA4_2,//D24
-  PB4_2,//D25
-  PA2,  //D26
-  PB10, //D27
-  PE15, //D28
-  PB0,  //D29
-  PE12, //D30
-  PE14, //D31
-  PA0,  //D32
-  PB0_2,//D33
-  PE0,  //D34
+#define PD9  0
+#define PD8  1
+#define PF15 2
+#define PE13 3
+#define PF14 4
+#define PE11 5
+#define PE9  6
+#define PF13 7
+#define PF12 8
+#define PD15 9
+#define PD14 10
+#define PA7  11 // A11
+#define PA6  12 // A12
+#define PA5  13 // A13
+#define PB9  14
+#define PB8  15
+#define PC6  16
+#define PB15 17
+#define PB13 18
+#define PB12 19
+#define PA4  20 // A14
+#define PB4  21
+#define PB5  22
+#define PB3  23
+// 24 is PA4 (20)
+// 25 is PB4 (21)
+#define PA2  26 // A15
+#define PB10 27
+#define PE15 28
+#define PB0  29 // A16
+#define PE12 30
+#define PE14 31
+#define PA0  32 // A17
+// 32 is PB0 (29)
+#define PE0  34
 #ifdef ARDUINO_NUCLEO_L496ZG
-  PB11, //D35
-#else
-  NC_1, //D35
+#define PB11 35
+//else 35 is NC
 #endif
-  PB10_2,//D36
-  PE15_2,//D37
-  PE14_2,//D38
-  PE12_2,//D39
-  PE10, //D40
-  PE7,  //D41
-  PE8,  //D42
-  PC8,  //D43
-  PC9,  //D44
-  PC10, //D45
-  PC11, //D46
-  PC12, //D47
-  PD2,  //D48
-  PF3,  //D49
-  PF5,  //D50
-  PD7,  //D51
-  PD6,  //D52
-  PD5,  //D53
-  PD4,  //D54
-  PD3,  //D55
-  PE2,  //D56
-  PE4,  //D57
-  PE5,  //D58
-  PE6,  //D59
-  PE3,  //D60
-  PF8,  //D61
-  PF7,  //D62
-  PF9,  //D63
-  PG1,  //D64
-  PG0,  //D65
-  PD1,  //D66
-  PD0,  //D67
-  PF0,  //D68
-  PF1,  //D69
-  PF2,  //D70
-  PB6,  //D71
-  PB2,  //D72
+// 36 is PB10 (27)
+// 37 is PE15 (28)
+// 38 is PE14 (31)
+// 39 is PE12 (30)
+#define PE10 40
+#define PE7  41
+#define PE8  42
+#define PC8  43
+#define PC9  44
+#define PC10 45
+#define PC11 46
+#define PC12 47
+#define PD2  48
+#define PF3  49 // A18
+#define PF5  50 // A19
+#define PD7  51
+#define PD6  52
+#define PD5  53
+#define PD4  54
+#define PD3  55
+#define PE2  56
+#define PE4  57
+#define PE5  58
+#define PE6  59
+#define PE3  60
+#define PF8  61 // A20
+#define PF7  62 // A21
+#define PF9  63 // A22
+#define PG1  64
+#define PG0  65
+#define PD1  66
+#define PD0  67
+#define PF0  68
+#define PF1  69
+#define PF2  70
+#define PB6  71
+#define PB2  72
 // ST Morpho
-  PA8,  //D73
-  PA9,  //D74
-  PA10, //D75
-  PA11, //D76
-  PA12, //D77
-  PA15, //D78
-  PB7,  //D79 - LEDBLUE
-  PB14, //D80 - LEDRED
-  PC7,  //D81 - LEDGREEN
-  PC13, //D82 - USERBTN
-  PC14, //D83
-  PC15, //D84
-  PD10, //D85
-  PD11, //D86
-  PD12, //D87
-  PD13, //D88
-  PE1,  //D89
-  PF10, //D90
-  PF11, //D91
-  PG2,  //D92
-  PG3,  //D93
-  PG4,  //D94
-  PG5,  //D95
-  PG6,  //D96
-  PG7,  //D97 - Serial Tx
-  PG8,  //D98 - Serial Rx
-  PG9,  //D99
-  PG10, //D100
-  PG11, //D101
-  PG12, //D102
-  PG13, //D103
-  PG14, //D104
-  PH0,  //D105
-  PH1,  //D106
-  // Analog pins
-  PA3,  //D107/A0
-  PC0,  //D108/A1
-  PC3,  //D109/A2
-  PC1,  //D110/A3
-  PC4,  //D111/A4
-  PC5,  //D112/A5
-  PB1,  //D113/A6
-  PC2,  //D114/A7
-  PA1,  //D115/A8
-  PF4,  //D116/A9
-  PF6,  //D117/A10
-  // Duplicated pins in order to be aligned with PinMapADC
-  PA7_3, //D118/A11 = D11
-  PA6_2, //D119/A12 = D12
-  PA5_2, //D120/A13 = D13
-  PA4_3, //D121/A14 = D20
-  PA2_2, //D122/A15 = D26
-  PB0_3, //D123/A16 = D29
-  PA0_2, //D124/A17 = D32
-  PF3_2, //D125/A18 = D49
-  PF5_2, //D126/A19 = D50
-  PF8_2, //D127/A20 = D61
-  PF7_2, //D128/A21 = D62
-  PF9_2, //D129/A22 = D63
-  PF10_2,//D130/A23 = D91
+#define PA8  73
+#define PA9  74
+#define PA10 75
+#define PA11 76
+#define PA12 77
+#define PA15 78
+#define PB7  79 // LED_BLUE
+#define PB14 80 // LED_RED
+#define PC7  81 // LED_GREEN
+#define PC13 82 // USER_BTN
+#define PC14 83
+#define PC15 84
+#define PD10 85
+#define PD11 86
+#define PD12 87
+#define PD13 88
+#define PE1  89
+#define PF10 90 // A23
+#define PF11 91
+#define PG2  92
+#define PG3  93
+#define PG4  94
+#define PG5  95
+#define PG6  96
+#define PG7  97 // Serial Tx
+#define PG8  98 // Serial Rx
+#define PG9  99
+#define PG10 100
+#define PG11 101
+#define PG12 102
+#define PG13 103
+#define PG14 104
+#define PH0  105
+#define PH1  106
+// Analog pins
+#define PA3  107 // A0
+#define PC0  108 // A1
+#define PC3  109 // A2
+#define PC1  110 // A3
+#define PC4  111 // A4
+#define PC5  112 // A5
+#define PB1  113 // A6
+#define PC2  114 // A7
+#define PA1  115 // A8
+#define PF4  116 // A9
+#define PF6  117 // A10
+// 118 to 130 reserved fot A11 to A23
 #ifdef ARDUINO_NUCLEO_L496ZG
-  PG15,  //D131
+#define PG15 131
 #endif
-  // PA13 and PA14 are shared with SWD signals connected to ST-LINK/V2-1.
-  // If ST-LINK part is not cut, it is not recommended to use them as I/O pins.
-//PA13,  //D132
-//PA14,  //D133
-  PEND
-};
+// PA13 and PA14 are shared with SWD signals connected to ST-LINK/V2-1.
+// If ST-LINK part is not cut, it is not recommended to use them as I/O pins.
+//#define PA13 132
+//#define PA14 133
 
 // This must be a literal with the same value as PEND
 #ifdef ARDUINO_NUCLEO_L496ZG

--- a/variants/NUCLEO_L4R5ZI/variant.h
+++ b/variants/NUCLEO_L4R5ZI/variant.h
@@ -47,148 +47,137 @@ extern const PinName digitalPin[];
 
 // Match Table 11. NUCLEO-L4R5ZI, NUCLEO-L4R5ZI-P pin assignments
 // from UM2179 STM32 Nucleo-144 board
-enum {
-  PD9,  //D0
-  PD8,  //D1
-  PF15, //D2
-  PE13, //D3
-  PF14, //D4
-  PE11, //D5
-  PE9,  //D6
-  PF13, //D7
-  PF12, //D8
-  PD15, //D9
-  PD14, //D10
-  PA7,  //D11
-  PA6,  //D12
-  PA5,  //D13
-  PB9,  //D14
-  PB8,  //D15
-  PC6,  //D16
-  PB15, //D17
-  PB13, //D18
-  PB12, //D19
-  PA4,  //D20
-  PB4,  //D21
-  PB5,  //D22
-  PB3,  //D23
-  PA4_2,//D24
-  PB4_2,//D25
-  PA2,  //D26
-  PB10, //D27
-  PE15, //D28
-  PB0,  //D29
-  PE12, //D30
-  PE14, //D31
-  PA0,  //D32
-  PB0_2,//D33
-  PE0,  //D34
+#define PD9  0
+#define PD8  1
+#define PF15 2
+#define PE13 3
+#define PF14 4
+#define PE11 5
+#define PE9  6
+#define PF13 7
+#define PF12 8
+#define PD15 9
+#define PD14 10
+#define PA7  11 // A9
+#define PA6  12 // A10
+#define PA5  13 // A11
+#define PB9  14
+#define PB8  15
+#define PC6  16
+#define PB15 17
+#define PB13 18
+#define PB12 19
+#define PA4  20 // A12
+#define PB4  21
+#define PB5  22
+#define PB3  23
+// 24 is PA4 (20)
+// 25 is PB4 (21)
+#define PA2  26 // A13
+#define PB10 27
+#define PE15 28
+#define PB0  29 // A14
+#define PE12 30
+#define PE14 31
+#define PA0  32 // A15
+// 32 is PB0 (29)
+#define PE0  34
 #ifdef ARDUINO_NUCLEO_L4R5ZI
-  PB11, //D35
-#else
-  NC_1, //D35
+#define PB11 35
+// else 35 is NC
 #endif
-  PB10_2,//D36
-  PE15_2,//D37
-  PE14_2,//D38
-  PE12_2,//D39
-  PE10, //D40
-  PE7,  //D41
-  PE8,  //D42
-  PC8,  //D43
-  PC9,  //D44
-  PC10, //D45
-  PC11, //D46
-  PC12, //D47
-  PD2,  //D48
-  PF3,  //D49
-  PF5,  //D50
-  PD7,  //D51
-  PD6,  //D52
-  PD5,  //D53
-  PD4,  //D54
-  PD3,  //D55
-  PE2,  //D56
-  PE4,  //D57
-  PE5,  //D58
-  PE6,  //D59
-  PE3,  //D60
-  PF8,  //D61
-  PF7,  //D62
-  PF9,  //D63
-  PG1,  //D64
-  PG0,  //D65
-  PD1,  //D66
-  PD0,  //D67
-  PF0,  //D68
-  PF1,  //D69
-  PF2,  //D70
-  PB6,  //D71
-  PB2,  //D72
+// 36 is PB10 (27)
+// 37 is PE15 (28)
+// 38 is PE14 (31)
+// 39 is PE12 (30)
+#define PE10 40
+#define PE7  41
+#define PE8  42
+#define PC8  43
+#define PC9  44
+#define PC10 45
+#define PC11 46
+#define PC12 47
+#define PD2  48
+#define PF3  49
+#define PF5  50
+#define PD7  51
+#define PD6  52
+#define PD5  53
+#define PD4  54
+#define PD3  55
+#define PE2  56
+#define PE4  57
+#define PE5  58
+#define PE6  59
+#define PE3  60
+#define PF8  61
+#define PF7  62
+#define PF9  63
+#define PG1  64
+#define PG0  65
+#define PD1  66
+#define PD0  67
+#define PF0  68
+#define PF1  69
+#define PF2  70
+#define PB6  71
+#define PB2  72
 // ST Morpho
-  PA8,  //D73
-  PA9,  //D74
-  PA10, //D75
-  PA11, //D76
-  PA12, //D77
-  PA15, //D78
-  PB7,  //D79 - LEDBLUE
-  PB14, //D80 - LEDRED
-  PC7,  //D81 - LEDGREEN
-  PC13, //D82 - USERBTN
-  PC14, //D83
-  PC15, //D84
-  PD10, //D85
-  PD11, //D86
-  PD12, //D87
-  PD13, //D88
-  PE1,  //D89
-  PF10, //D90
-  PF11, //D91
-  PG2,  //D92
-  PG3,  //D93
-  PG4,  //D94
-  PG5,  //D95
-  PG6,  //D96
-  PG7,  //D97 - Serial Tx
-  PG8,  //D98 - Serial Rx
-  PG9,  //D99
-  PG10, //D100
-  PG11, //D101
-  PG12, //D102
-  PG13, //D103
-  PG14, //D104
-  PH0,  //D105
-  PH1,  //D106
-  // Analog pins
-  PA3,  //D107/A0
-  PC0,  //D108/A1
-  PC3,  //D109/A2
-  PC1,  //D110/A3
-  PC4,  //D111/A4
-  PC5,  //D112/A5
-  PB1,  //D113/A6
-  PC2,  //D114/A7
-  PA1,  //D115/A8
-  // Duplicated pins in order to be aligned with PinMapADC
-  PA7_3,  //D116/A9 = D11
-  PA6_2,  //D117/A10 = D12
-  PA5_2, //D118/A11 = D13
-  PA4_3, //D119/A12 = D20
-  PA2_2, //D120/A13 = D26
-  PB0_3, //D121/A14 = D29
-  PA0_2, //D122/A15 = D32
+#define PA8  73
+#define PA9  74
+#define PA10 75
+#define PA11 76
+#define PA12 77
+#define PA15 78
+#define PB7  79  // LED_BLUE
+#define PB14 80  // LED_RED
+#define PC7  81  // LED_GREEN
+#define PC13 82  // USER_BTN
+#define PC14 83
+#define PC15 84
+#define PD10 85
+#define PD11 86
+#define PD12 87
+#define PD13 88
+#define PE1  89
+#define PF10 90
+#define PF11 91
+#define PG2  92
+#define PG3  93
+#define PG4  94
+#define PG5  95
+#define PG6  96
+#define PG7  97  // Serial Tx
+#define PG8  98  // Serial Rx
+#define PG9  99
+#define PG10 100
+#define PG11 101
+#define PG12 102
+#define PG13 103
+#define PG14 104
+#define PH0  105
+#define PH1  106
+// Analog pins
+#define PA3  107 // A0
+#define PC0  108 // A1
+#define PC3  109 // A2
+#define PC1  110 // A3
+#define PC4  111 // A4
+#define PC5  112 // A5
+#define PB1  113 // A6
+#define PC2  114 // A7
+#define PA1  115 // A8
+// 116 to 122 reserved fot A9 to A15
 #ifdef ARDUINO_NUCLEO_L4R5ZI
-  PG15,  //D123
+#define PG15 123
 #endif
-  // PA13 and PA14 are shared with SWD signals connected to ST-LINK/V2-1.
-  // If ST-LINK part is not cut, it is not recommended to use them as I/O pins.
-//PA13,  //D124
-//PA14,  //D125
-  PEND
-};
+// PA13 and PA14 are shared with SWD signals connected to ST-LINK/V2-1.
+// If ST-LINK part is not cut, it is not recommended to use them as I/O pins.
+//#define PA13 124
+//#define PA14 125
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #ifdef ARDUINO_NUCLEO_L4R5ZI
 #define NUM_DIGITAL_PINS        124
 #else

--- a/variants/RAK811_TRACKER/variant.h
+++ b/variants/RAK811_TRACKER/variant.h
@@ -45,46 +45,43 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-enum {
-  PA0,  //D0 - GPS_PPS_PIN
-  PA8,  //D1
-  PA9,  //D2 - UART_TX
-  PA10, //D3 - UART_RX
-  PA12, //D4 - LED1
-  PA13, //D5
-  PA14, //D6
-  PA15, //D7 - GPS_POWER_ON_PIN
-  PB2,  //D8
-  PB3,  //D9
-  PB4,  //D10 - LED2
-  PB5,  //D11
-  PB8,  //D12 - I2C_SCL
-  PB9,  //D13 - I2C_SDA
-  PB10, //D14 - GPS_UART_TX
-  PB11, //D15 - GPS_UART_RX
-  PA1,  //D16/A0
-  PA2,  //D17/A1 - ADC_VBAT
-  PB12, //D18/A2
-  PB14, //D19 - LIS3DH_INT1_PIN
-  PB15, //D20 - LIS3DH_INT2_PIN
-  PB13, //D21 - RADIO_RESET
-  PH1,  //D22 - RADIO_XTAL_EN
-  PA7,  //D23 - RADIO_MOSI
-  PA6,  //D24 - RADIO_MISO
-  PA5,  //D25 - RADIO_SCLK
-  PB0,  //D26 - RADIO_NSS
-  PA11, //D27 - RADIO_DIO_0
-  PB1,  //D28 - RADIO_DIO_1
-  PA3,  //D29 - RADIO_DIO_2
-  PH0,  //D30 - RADIO_DIO_3
-  PC13, //D31 - RADIO_DIO_4
-  PB6,  //D32 - RADIO_RF_CRX_RX
-  PB7,  //D33 - RADIO_RF_CBT_HF
-  PA4,  //D34 - RADIO_RF_CTX_PA
-  PEND
-};
+#define PA0  0  // GPS_PPS_PIN
+#define PA8  1
+#define PA9  2  // UART_TX
+#define PA10 3  // UART_RX
+#define PA12 4  // LED1
+#define PA13 5
+#define PA14 6
+#define PA15 7  // GPS_POWER_ON_PIN
+#define PB2  8
+#define PB3  9
+#define PB4  10 // LED2
+#define PB5  11
+#define PB8  12 // I2C_SCL
+#define PB9  13 // I2C_SDA
+#define PB10 14 // GPS_UART_TX
+#define PB11 15 // GPS_UART_RX
+#define PA1  16 // A0
+#define PA2  17 // A1 - ADC_VBAT
+#define PB12 18 // A2
+#define PB14 19 // LIS3DH_INT1_PIN
+#define PB15 20 // LIS3DH_INT2_PIN
+#define PB13 21 // RADIO_RESET
+#define PH1  22 // RADIO_XTAL_EN
+#define PA7  23 // RADIO_MOSI
+#define PA6  24 // RADIO_MISO
+#define PA5  25 // RADIO_SCLK
+#define PB0  26 // RADIO_NSS
+#define PA11 27 // RADIO_DIO_0
+#define PB1  28 // RADIO_DIO_1
+#define PA3  29 // RADIO_DIO_2
+#define PH0  30 // RADIO_DIO_3
+#define PC13 31 // RADIO_DIO_4
+#define PB6  32 // RADIO_RF_CRX_RX
+#define PB7  33 // RADIO_RF_CBT_HF
+#define PA4  34 // RADIO_RF_CTX_PA
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 #define NUM_DIGITAL_PINS        35
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       3

--- a/variants/REMRAM_V1/variant.h
+++ b/variants/REMRAM_V1/variant.h
@@ -46,111 +46,105 @@ extern "C"
  *----------------------------------------------------------------------------*/
   extern const PinName digitalPin[];
 
-  // Enum defining pin names to match digital pin number --> Dx
-  enum
-  {
-    // USART
-    PA10, // D0 - RX
-    PA9,  // D1 - TX
+// USART
+#define PA10 0  // RX
+#define PA9  1  // TX
 
-    // SWD
-    PA14, // D2 - SWCLK
-    PA13, // D3 - SWDIO
+// SWD
+#define PA14 2  // SWCLK
+#define PA13 3  // SWDIO
 
-    // EXT3
-    PE5, // D4 - EXT_D1
-    PE4, // D5 - EXT_D2
-    PE3, // D6 - EXT_D3
-    PE2, // D7 - EXT_D4
-    PE1, // D8 - EXT_D5
+// EXT3
+#define PE5  4  // EXT_D1
+#define PE4  5  // EXT_D2
+#define PE3  6  // EXT_D3
+#define PE2  7  // EXT_D4
+#define PE1  8  // EXT_D5
 
-    // SPI
-    PB2, // D9 - SS_SDLCD
-    PC4, // D10 - SS_E
-    PA7, // D11 - MOSI
-    PA6, // D12 - MISO
-    PA5, // D13 - SCK
-    PB1, // D14 - SS_X
-    PB0, // D15 - SS_Y
-    PC5, // D16 - SS_Z
+// SPI
+#define PB2  9  // SS_SDLCD
+#define PC4  10 // SS_E
+#define PA7  11 // MOSI
+#define PA6  12 // MISO
+#define PA5  13 // SCK
+#define PB1  14 // SS_X
+#define PB0  15 // SS_Y
+#define PC5  16 // SS_Z
 
-    // I2C
-    PB6, // D17 - SCL
-    PB7, // D18 - SDA
+// I2C
+#define PB6  17 // SCL
+#define PB7  18 // SDA
 
-    // USB
-    PA12, // D19 - DD+
-    PA11, // D20 - DD-
+// USB
+#define PA12 19 // DD+
+#define PA11 20 // DD//
 
-    // LED
-    PD0, // D21 - STATUS_LED
+// LED
+#define PD0  21 // STATUS_LED
 
-    // PWM
-    // TIM2
-    PA15, // D22 - X_STEP
-    PB3,  // D23 - Y_STEP
-    PB10, // D24 - Z_STEP
-    PB11, // D25 - E_STEP
-    // TIM3
-    PB5, // D26 - PWM_EXT1
-    PB4, // D27 - PWM_EXT2
-    PC8, // D28 - PWM_EXT3
-    PC9, // D29 - PWM_EXT4
-    // TIM5
-    PA0, // D30 - PWM_FAN1
-    PA1, // D31 - PWM_BED
-    PA2, // D32 - PWM_FAN2
-    PA3, // D33 - PWM_HEAT
+// PWM
+// TIM2
+#define PA15 22 // X_STEP
+#define PB3  23 // Y_STEP
+#define PB10 24 // Z_STEP
+#define PB11 25 // E_STEP
+// TIM3
+#define PB5  26 // PWM_EXT1
+#define PB4  27 // PWM_EXT2
+#define PC8  28 // PWM_EXT3
+#define PC9  29 // PWM_EXT4
+// TIM5
+#define PA0  30 // PWM_FAN1
+#define PA1  31 // PWM_BED
+#define PA2  32 // PWM_FAN2
+#define PA3  33 // PWM_HEAT
 
-    // Stepper
-    PC12, // D34 - X_EN
-    PC10, // D35 - X_DIR
-    PC11, // D36 - X_DIAG
-    PD4,  // D37 - Y_EN
-    PD6,  // D38 - Y_DIR
-    PD5,  // D39 - Y_DIAG
-    PE15, // D40 - Z_EN
-    PE13, // D41 - Z_DIR
-    PE14, // D42 - Z_DIAG
-    PE11, // D43 - E_EN
-    PE10, // D44 - E_DIR
-    PE12, // D45 - E_DIAG
+// Stepper
+#define PC12 34 // X_EN
+#define PC10 35 // X_DIR
+#define PC11 36 // X_DIAG
+#define PD4  37 // Y_EN
+#define PD6  38 // Y_DIR
+#define PD5  39 // Y_DIAG
+#define PE15 40 // Z_EN
+#define PE13 41 // Z_DIR
+#define PE14 42 // Z_DIAG
+#define PE11 43 // E_EN
+#define PE10 44 // E_DIR
+#define PE12 45 // E_DIAG
 
-    // EXT3
-    PC6,  // D46 - LCD_BEEPER
-    PC7,  // D47 - BTN_ENC
-    PD14, // D48 - LCD_EN
-    PD15, // D49 - LCD_RS
-    PD13, // D50 - LCD_D4
-    PD12, // D51 - LCD_D5
-    PD11, // D52 - LCD_D6
-    PD10, // D53 - LCD_D7
+// EXT3
+#define PC6  46 // LCD_BEEPER
+#define PC7  47 // BTN_ENC
+#define PD14 48 // LCD_EN
+#define PD15 49 // LCD_RS
+#define PD13 50 // LCD_D4
+#define PD12 51 // LCD_D5
+#define PD11 52 // LCD_D6
+#define PD10 53 // LCD_D7
 
-    // EXT2
-    PC14, // D54 - BTN_EN1
-    PC15, // D55 - BTN_EN2
-    PC13, // D56 - SD_CARD_DET
+// EXT2
+#define PC14 54 // BTN_EN1
+#define PC15 55 // BTN_EN2
+#define PC13 56 // SD_CARD_DET
 
-    // SD Card Reader
-    PE7,  // D57 - SS_SD
+// SD Card Reader
+#define PE7  57 // SS_SD
 
-    // Endstops
-    PB12, // D58 - X_MIN
-    PB13, // D59 - X_MAX
-    PB14, // D60 - Y_MIN
-    PB15, // D61 - Y_MAX
-    PD8,  // D62 - Z_MIN
-    PD9,  // D63 - Z_MAX
+// Endstops
+#define PB12 58 // X_MIN
+#define PB13 59 // X_MAX
+#define PB14 60 // Y_MIN
+#define PB15 61 // Y_MAX
+#define PD8  62 // Z_MIN
+#define PD9  63 // Z_MAX
 
-    // ADC
-    PC0, // D64 - THERM_1
-    PC1, // D65 - THERM_2
-    PC2, // D66 - THERM_3
-    PA4, // D67 - FAN_SPEED1
-    PC3, // D68 - FAN_SPEED2
-
-    PEND
-  };
+// ADC
+#define PC0  64 // THERM_1
+#define PC1  65 // THERM_2
+#define PC2  66 // THERM_3
+#define PA4  67 // FAN_SPEED1
+#define PC3  68 // FAN_SPEED2
 
 // PIN definition
 #define NUM_DIGITAL_PINS 69

--- a/variants/board_template/variant.h
+++ b/variants/board_template/variant.h
@@ -45,19 +45,30 @@ extern "C"{
  *----------------------------------------------------------------------------*/
 extern const PinName digitalPin[];
 
-// Enum defining pin names to match digital pin number --> Dx
+// Define pin names to match digital pin number --> Dx
+// It could be used with preprocessor tests (e.g. #if PXn == 3)
+// so an enum will not work.
 // !!!
-// !!! Copy the digitalPin[] array in variant.cpp
+// !!! Copy the digitalPin[] array from the variant.cpp
 // !!! and remove all '_': PX_n --> PXn
-// !!! For NC, suffix by _x where x is the number of NC:
-// !!!   NC_1, NC_2,...
-// !!! For duplicated pin name, suffix by _x where x is the number of pin:
-// !!! PA7, PA7_2, PA7_3,...
-enum {
-  PEND
-};
+// !!! For NC, comment the line to warn x pin number is NC
+// !!! // x is NC
+// !!! For duplicated pin name, comment the line to warn x pin number
+// !!! is PXn which is already defined with y pin number
+// !!! // x is PXn (y)
+// !!! Ex:
+// !!! ...
+// !!! #define PA4  20 // A14
+// !!! #define PB4  21
+// !!! #define PB5  22
+// !!! #define PB3  23
+// !!! // 24 is PA4 (20)
+// !!! // 25 is PB4 (21)// #define PXn x
+// !!! #define PA2  26 // A15
+// !!! ...
+//#define PXn x
 
-// This must be a literal with the same value as PEND
+// This must be a literal
 // It is used with preprocessor tests (e.g. #if NUM_DIGITAL_PINS > 3)
 // so an enum will not work.
 #define NUM_DIGITAL_PINS        0


### PR DESCRIPTION
This PR is based on #309 thanks @ghent360
This squash the #309 and rebase it on master.
Include:
 * Update 2 variants merged recently: REMRAM and RAK811.
 * Remove PEND as no more relevant
 * Remove duplicated pins which is not required anymore as PEND removed (even if in fact it was not required before)
 * Cosmetic update (comments, space, ...)

Note: https://github.com/stm32duino/wiki/wiki/Add-a-new-variant-(board) updated

