### PR TITLE
Astyle deployement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.orig
 *.swp
 .DS_Store
+astyle.out
 boards.local.txt
 platform.local.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,40 @@ os:
   - linux
 matrix:
   include:
+#
+# Astyle check
+#
   - env:
-      - NAME= arduinoCI
+      - NAME=Astyle
+    install:
+      - curl -L0 https://fossies.org/linux/misc/astyle_3.1_linux.tar.gz --output astyle.tar.gz;
+        mkdir -p BUILD && tar xf astyle.tar.gz -C BUILD;
+        pushd BUILD/astyle/build/gcc;
+        make;
+        export PATH=$PWD/bin:$PATH;
+        popd;
+      - astyle --version
+    before_script:
+      - cd $TRAVIS_BUILD_DIR/CI/astyle/
+    script:
+        # Check coding style only on changed files for PR or all for master
+        - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then python astyle.py; fi
+        - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then python astyle.py -b $TRAVIS_BRANCH; fi
+        - TEST=$([[ -f astyle.out ]] && cat astyle.out | grep Formatted | wc -l || echo 0)
+        - |
+          if [[ $TEST -ne 0 ]]; then
+            cat astyle.out | grep Formatted
+            git --no-pager diff
+            echo "AStyle check failed, please fix style issues as shown above"
+            exit 1
+          else
+            echo "Coding style check OK";
+          fi
+#
+# Build test
+#
+  - env:
+      - NAME=arduinoCI
       - IDE_VERSION=1.8.8
     # Use in CI/build/conf/path_config_travis.json
       - ARDUINO_IDE_PATH=$HOME/IDE/arduino

--- a/CI/astyle/.astyleignore
+++ b/CI/astyle/.astyleignore
@@ -1,0 +1,3 @@
+.git
+CI
+system

--- a/CI/astyle/.astylerc
+++ b/CI/astyle/.astylerc
@@ -1,0 +1,45 @@
+# STM32duino code style definition file for astyle
+
+# Don't create backup files, let git handle it
+suffix=none
+
+# K&R style
+style=kr
+
+# 1 TBS addition to k&r, add braces to one liners
+# Use -j as it was changed in astyle from brackets to braces, this way it is compatible with older astyle versions
+-j
+
+# 2 spaces, convert tabs to spaces
+indent=spaces=2
+convert-tabs
+
+# Indent switches and cases
+indent-classes
+indent-switches
+indent-cases
+indent-col1-comments
+
+# Remove spaces in and around parentheses
+unpad-paren
+
+# Insert a space after if, while, for, and around operators
+pad-header
+pad-oper
+
+# Pointer/reference operators go next to the name (on the right)
+align-pointer=name
+align-reference=name
+
+# Attach { for classes and namespaces
+attach-namespaces
+attach-classes
+
+# Extend longer lines, define maximum 120 value. This results in aligned code,
+# otherwise the lines are broken and not consistent 
+max-continuation-indent=120
+
+# if you like one-liners, keep them
+keep-one-line-statements
+
+#remove-comment-prefix

--- a/CI/astyle/.flake8
+++ b/CI/astyle/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/CI/astyle/astyle.py
+++ b/CI/astyle/astyle.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+
+# File name            : astyle.py
+# Author               : Frederic PILLON <frederic.pillon@st.com>
+# Created              : 11/16/2018
+# Python Version       :
+# Requirements         : Artistic Style Version 3.1
+# Description          : Launch astyle on found source files
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+script_path = os.path.dirname(os.path.abspath(__file__))
+ignore_filename = ".astyleignore"
+def_filename = ".astylerc"
+astyle_out_filename = "astyle.out"
+if os.getcwd() != script_path:
+    src_path = os.getcwd()
+else:
+    src_path = os.path.realpath(os.path.join("..", ".."))
+ignore_path = os.path.join(script_path, ignore_filename)
+def_path = os.path.join(script_path, def_filename)
+astyle_out_path = astyle_out_filename
+git_branch = "remotes/origin/master"
+
+astyle_major = 3
+astyle_minor = 1
+astyle_path = ""
+if sys.platform.startswith("win32"):
+    astyle_cmd = "astyle.exe"
+elif sys.platform.startswith("linux") or sys.platform.startswith("darwin"):
+    astyle_cmd = "astyle"
+else:
+    print("Platform unknown.")
+    sys.exit(1)
+
+# List
+source_list = []
+exclude_list = []
+
+
+# Check if path exists
+def checkPath(path, msg):
+    if not os.path.exists(path):
+        print(msg)
+        sys.exit(1)
+
+
+# Check Astyle exists and version
+def checkAstyle():
+    try:
+        output = subprocess.check_output(
+            [os.path.join(astyle_path, astyle_cmd), "--version"],
+            stderr=subprocess.STDOUT,
+        )
+
+        res = re.match("\\D*(\\d+)\\.(\\d+)\\.*(\\d*)", output.decode("utf-8"))
+        if res:
+            major = int(res.group(1))
+            minor = int(res.group(2))
+            if major >= astyle_major and minor >= astyle_minor:
+                print(output.decode("utf-8").rstrip())
+            else:
+                print(
+                    "Required Astyle version {}.{} (Current: {}.{})".format(
+                        astyle_major, astyle_minor, major, minor
+                    )
+                )
+                sys.exit(1)
+        else:
+            raise subprocess.CalledProcessError(1, "No version found")
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        sys.exit(1)
+
+
+# Find changes files in source root path
+def gitdiff_files():
+    try:
+        output = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], stderr=subprocess.STDOUT
+        )
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        sys.exit(1)
+
+    gitroot = output.decode("utf-8").rstrip()
+    rel_src = re.sub("^[/\\]+]", "", re.sub(gitroot, "", src_path))
+
+    cmd = []
+    cmd.append("git")
+    cmd.append("diff")
+    cmd.append("--name-only")
+    cmd.append("--diff-filter=d")
+    cmd.append(git_branch)
+    cmd.append("--relative=" + rel_src)
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    while True:
+        line = proc.stdout.readline().decode("utf-8").rstrip()
+        if line == "" and proc.poll() is not None:
+            break
+        if line:
+            if line.endswith((".h", ".c", ".hpp", ".cpp")):
+                source_list.append(os.path.join(gitroot, line.rstrip()))
+    if proc.poll() != 0:
+        sys.exit(1)
+    source_list.sort()
+
+
+# Find all files in source root path
+def find_files():
+    for root, dirs, files in os.walk(src_path, followlinks=True):
+        for f in files:
+            if f.endswith((".h", ".c", ".hpp", ".cpp")):
+                source_list.append(os.path.join(root, f))
+    source_list.sort()
+
+
+# Filter source files list
+def manage_exclude_list():
+    with open(ignore_path, "r") as f:
+        for line in f.readlines():
+            if line.rstrip():
+                exclude_list.append(line.rstrip())
+    if exclude_list:
+        for pattern in exclude_list:
+            exclude_pattern = re.compile(os.path.join(src_path, pattern) + ".*")
+            for s in reversed(source_list):
+                if exclude_pattern.search(s):
+                    source_list.remove(s)
+
+
+# Launch Astyle on all source files
+def astyle():
+    cmd = []
+    cmd.append(os.path.join(astyle_path, astyle_cmd))
+    cmd.append("-n")
+    cmd.append("--options=" + def_path)
+    cmd.append("dummy_file")
+
+    stddout_name = astyle_out_path
+
+    for s in source_list:
+        cmd[-1] = s
+        with open(stddout_name, "a") as stdout:
+            res = subprocess.Popen(cmd, stdout=stdout, stderr=subprocess.STDOUT)
+            res.wait()
+            # res.returncode
+
+
+# Parser
+parser = argparse.ArgumentParser(
+    description="Launch astyle on source files found at specified root path."
+)
+
+parser.add_argument(
+    "-d",
+    "--definition",
+    metavar="<code style definition file>",
+    help="Code style definition file for Astyle. Default: " + def_path,
+)
+g0 = parser.add_mutually_exclusive_group()
+g0.add_argument(
+    "-g",
+    "--gitdiff",
+    help="Use changes files from git default branch. Default: " + git_branch,
+    action="store_true",
+)
+g0.add_argument(
+    "-b",
+    "--branch",
+    metavar="<branch name>",
+    help="Use changes files from git specified branch.",
+)
+parser.add_argument(
+    "-i",
+    "--ignore",
+    metavar="<ignore file>",
+    help="File containing path to ignore. Default: " + ignore_path,
+)
+parser.add_argument(
+    "-p", "--path", metavar="<astyle install path>", help="Astyle installation path"
+)
+parser.add_argument(
+    "-r",
+    "--root",
+    metavar="<source root path>",
+    help="Source root path to use. Default: " + src_path,
+)
+args = parser.parse_args()
+
+
+def main():
+    global ignore_path
+    global def_path
+    global src_path
+    global astyle_path
+    global git_branch
+
+    if args.root:
+        src_path = os.path.realpath(args.root)
+
+    if args.definition:
+        def_path = os.path.realpath(args.definition)
+
+    if args.ignore:
+        ignore_path = os.path.realpath(args.ignore)
+
+    if args.path:
+        astyle_path = os.path.realpath(args.path)
+        checkPath(
+            os.path.join(astyle_path, astyle_cmd), "Could not find Astyle binary!"
+        )
+
+    checkPath(src_path, "Source root path does not exist!")
+    checkPath(def_path, "Code style definition file does not exist!")
+    checkPath(ignore_path, "Ignore file does not exist!")
+    checkAstyle()
+    try:
+        os.remove(astyle_out_path)
+    except OSError:
+        pass
+
+    if args.gitdiff or args.branch:
+        if args.branch:
+            git_branch = args.branch
+        gitdiff_files()
+    else:
+        find_files()
+    manage_exclude_list()
+    if len(source_list):
+        astyle()
+    else:
+        print("No file found to apply Astyle")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
AStyle will be used for coding style checking.
Only sources files (`*.h`, `*.hpp`, `*.c`, `*.cpp`) from the following lists will be check:
* cores
* libraries
* variants

`.astyleignore` file contains list of folder to ignore.

Hereafter the code style definition applied (`.astylerc`):

```bash
# STM32duino code style definition file for astyle

# Don't create backup files, let git handle it
suffix=none

# K&R style
style=kr

# 1 TBS addition to k&r, add braces to one liners
# Use -j as it was changed in astyle from brackets to braces, this way it is compatible with older astyle versions
-j

# 2 spaces, convert tabs to spaces
indent=spaces=2
convert-tabs

# Indent switches and cases
indent-classes
indent-switches
indent-cases
indent-col1-comments

# Remove spaces in and around parentheses
unpad-paren

# Insert a space after if, while, for, and around operators
pad-header
pad-oper

# Pointer/reference operators go next to the name (on the right)
align-pointer=name
align-reference=name

# Attach { for classes and namespaces
attach-namespaces
attach-classes

# Extend longer lines, define maximum 120 value. This results in aligned code,
# otherwise the lines are broken and not consistent 
max-continuation-indent=120

# if you like one-liners, keep them
keep-one-line-statements
```

Python script `astyle.py` is provided to ease use of AStyle:

```stdout
usage: astyle.py [-h] [-d <code style definition file>]
                 [-g | -b <branch name>] [-i <ignore file>]
                 [-p <astyle install path>] [-r <source root path>]

Launch astyle on source files found at specified root path.

optional arguments:
  -h, --help            show this help message and exit
  -d <code style definition file>, --definition <code style definition file>
                        Code style definition file for Astyle. Default: <repo path>/Arduino_Core_S
                        TM32/CI/astyle/.astylerc
  -g, --gitdiff         Use changes files from git default branch. Default:
                        remotes/origin/master
  -b <branch name>, --branch <branch name>
                        Use changes files from git specified branch.
  -i <ignore file>, --ignore <ignore file>
                        File containing path to ignore. Default: <repo path>/Arduino_Core_STM32/CI
                        /astyle/.astyleignore
  -p <astyle install path>, --path <astyle install path>
                        Astyle installation path
  -r <source root path>, --root <source root path>
                        Source root path to use. Default: <repo path>/Arduino_Core_STM32
```
