### PR TITLE
Do not provide some default macro's

### DIFF
--- a/cores/arduino/utils.h
+++ b/cores/arduino/utils.h
@@ -1,15 +1,13 @@
 #ifndef __UTILS_H
 #define __UTILS_H
 
-#include "avr/dtostrf.h"
-
-// Concatenate 2 strings
+/* Concatenate 2 strings */
 #define CONCAT(s1, s2) (s1 s2)
-// Concatenate 2 strings separated by space
+/* Concatenate 2 strings separated by space */
 #define CONCATS(s1, s2) (s1" " s2)
 
-// Stringification
-#define xstr(s) str(s)
-#define str(s) #s
+/* Stringification */
+#define XSTR(s) STR(s)
+#define STR(s) #s
 
 #endif

--- a/cores/arduino/wiring.h
+++ b/cores/arduino/wiring.h
@@ -26,9 +26,9 @@
 #include <string.h>
 #include <math.h>
 
+#include "avr/dtostrf.h"
 #include "binary.h"
 #include "itoa.h"
-#include "utils.h"
 
 #include "wiring_analog.h"
 #include "wiring_constants.h"


### PR DESCRIPTION
Include utils.h manually will provide them
Note: `str()` and `xstr()` are now capitalized.

Fix #389 

@matthijskooijman : any comment are welcome ;)
