### PR TITLE
udp: Add beginMulticast method

### DIFF
--- a/cores/arduino/Udp.h
+++ b/cores/arduino/Udp.h
@@ -41,7 +41,8 @@
 class UDP : public Stream {
 
 public:
-  virtual uint8_t begin(uint16_t) =0;	// initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
+  virtual uint8_t begin(uint16_t) =0;  // initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
+  virtual uint8_t beginMulticast(IPAddress, uint16_t) { return 0; }  // initialize, start listening on specified multicast IP address and port. Returns 1 if successful, 0 on failure
   virtual void stop() =0;  // Finish with the UDP socket
 
   // Sending UDP packets


### PR DESCRIPTION
This was needed to use ArduinoMNS
it was tested on nucleo-f767zi

[Sandeep Mistry]

Add virtual beginMulticast(...) stub to UDP class

Change-Id: I7cb92be0c88d350408ecc21f1662299b0721856a
Origin: https://github.com/arduino/ArduinoCore-avr/commit/5a05bf01f4ffbe16670eb8d713688d059c3bd084
Author: Sandeep Mistry <s.mistry@arduino.cc>
Signed-off-by: Philippe Coval <p.coval@samsung.com>