### PR TITLE
Hid/DFU boot loader (superseded by #525)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -638,6 +638,24 @@ GenF1.menu.upload_method.bmpMethod=BMP (Black Magic Probe)
 GenF1.menu.upload_method.bmpMethod.upload.protocol=gdb_bmp
 GenF1.menu.upload_method.bmpMethod.upload.tool=bmp_upload
 
+GenF1.menu.upload_method.hidMethod=HID Bootloader 3.0 (0x0800)
+GenF1.menu.upload_method.hidMethod.upload.protocol=hid3
+GenF1.menu.upload_method.hidMethod.upload.tool=hid_upload
+GenF1.menu.upload_method.hidMethod.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x0800 -DHIDBL_F1
+
+GenF1.menu.upload_method.dfu2Method=Maple DFU Bootloader 2.0
+GenF1.menu.upload_method.dfu2Method.upload.protocol=maple
+GenF1.menu.upload_method.dfu2Method.upload.tool=maple_upload
+GenF1.menu.upload_method.dfu2Method.upload.usbID=1EAF:0003
+GenF1.menu.upload_method.dfu2Method.upload.altID=2
+GenF1.menu.upload_method.dfu2Method.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x2000 -DDFUBL2_F1 -DUSB_DISC_PIN=PB9
+
+GenF1.menu.upload_method.dfuoMethod=Maple DFU Bootloader original (0x5000)
+GenF1.menu.upload_method.dfuoMethod.upload.protocol=maple
+GenF1.menu.upload_method.dfuoMethod.upload.tool=maple_upload
+GenF1.menu.upload_method.dfuoMethod.upload.usbID=1EAF:0003
+GenF1.menu.upload_method.dfuoMethod.upload.altID=1
+GenF1.menu.upload_method.dfuoMethod.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x5000 -DDFUBLO_F1  -DUSB_DISC_PIN=PB9
 ################################################################################
 # Generic F4
 
@@ -734,6 +752,11 @@ GenF4.menu.upload_method.bmpMethod=BMP (Black Magic Probe)
 GenF4.menu.upload_method.bmpMethod.upload.protocol=gdb_bmp
 GenF4.menu.upload_method.bmpMethod.upload.tool=bmp_upload
 
+GenF4.menu.upload_method.hidMethod=HID Bootloader 3.0 (0x4000)
+GenF4.menu.upload_method.hidMethod.upload.protocol=hid3
+GenF4.menu.upload_method.hidMethod.upload.tool=hid_upload
+GenF4.menu.upload_method.hidMethod.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x4000 -DHIDBL_F4
+
 ###############################
 # Sparky Flight Controllers
 
@@ -761,7 +784,7 @@ Sparky.menu.upload_method.STLinkMethod=STLink
 Sparky.menu.upload_method.STLinkMethod.upload.protocol=STLink
 Sparky.menu.upload_method.STLinkMethod.upload.tool=stlink_upload
 
-################################################################################
+###############################
 # RAK boards
 
 RAK.name=RAKWireless

--- a/boards.txt
+++ b/boards.txt
@@ -641,21 +641,24 @@ GenF1.menu.upload_method.bmpMethod.upload.tool=bmp_upload
 GenF1.menu.upload_method.hidMethod=HID Bootloader 3.0 (0x0800)
 GenF1.menu.upload_method.hidMethod.upload.protocol=hid3
 GenF1.menu.upload_method.hidMethod.upload.tool=hid_upload
+GenF1.menu.upload_method.hidMethod.upload.bl_size=0x800
 GenF1.menu.upload_method.hidMethod.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x0800 -DHIDBL_F1
 
 GenF1.menu.upload_method.dfu2Method=Maple DFU Bootloader 2.0
 GenF1.menu.upload_method.dfu2Method.upload.protocol=maple
 GenF1.menu.upload_method.dfu2Method.upload.tool=maple_upload
+GenF1.menu.upload_method.dfu2Method.upload.bl_size=0x2000
 GenF1.menu.upload_method.dfu2Method.upload.usbID=1EAF:0003
 GenF1.menu.upload_method.dfu2Method.upload.altID=2
-GenF1.menu.upload_method.dfu2Method.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x2000 -DDFUBL2_F1 -DUSB_DISC_PIN=PB9
+GenF1.menu.upload_method.dfu2Method.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x2000 -DUSB_DISC_PIN=PB9
 
 GenF1.menu.upload_method.dfuoMethod=Maple DFU Bootloader original (0x5000)
 GenF1.menu.upload_method.dfuoMethod.upload.protocol=maple
 GenF1.menu.upload_method.dfuoMethod.upload.tool=maple_upload
+GenF1.menu.upload_method.dfuoMethod.upload.bl_size=0x5000
 GenF1.menu.upload_method.dfuoMethod.upload.usbID=1EAF:0003
 GenF1.menu.upload_method.dfuoMethod.upload.altID=1
-GenF1.menu.upload_method.dfuoMethod.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x5000 -DDFUBLO_F1  -DUSB_DISC_PIN=PB9
+GenF1.menu.upload_method.dfuoMethod.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x5000 -DUSB_DISC_PIN=PB9
 ################################################################################
 # Generic F4
 
@@ -755,6 +758,7 @@ GenF4.menu.upload_method.bmpMethod.upload.tool=bmp_upload
 GenF4.menu.upload_method.hidMethod=HID Bootloader 3.0 (0x4000)
 GenF4.menu.upload_method.hidMethod.upload.protocol=hid3
 GenF4.menu.upload_method.hidMethod.upload.tool=hid_upload
+GenF4.menu.upload_method.hidMethod.upload.bl_size=0x4000
 GenF4.menu.upload_method.hidMethod.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET=0x4000 -DHIDBL_F4
 
 ###############################

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
@@ -187,6 +187,7 @@ static int8_t USBD_CDC_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length)
         transmitStart = 0;
       }
 	  dtr_pin++; //DTR pin is enabled
+
       break;
 
     case CDC_SEND_BREAK:
@@ -220,31 +221,31 @@ static int8_t USBD_CDC_Receive(uint8_t *Buf, uint32_t *Len)
 {
   /* USER CODE BEGIN 6 */
   /* Four byte is the magic pack "1EAF" that puts the MCU into bootloader. */
-  if(*Len >= 4){
-	/**
-	 * Check if the incoming contains the string "1EAF".
-	 * If yes, check if the DTR has been set, to put the MCU into the bootloader mode.
-	 */
-    if(dtr_pin > 3){
-      if((Buf[0] == '1')&&(Buf[1] == 'E')&&(Buf[2] == 'A')&&(Buf[3] == 'F')){
+  if (*Len >= 4) {
+    /**
+     * Check if the incoming contains the string "1EAF".
+     * If yes, check if the DTR has been set, to put the MCU into the bootloader mode.
+     */
+    if (dtr_pin > 3) {
+      if ((Buf[0] == '1') && (Buf[1] == 'E') && (Buf[2] == 'A') && (Buf[3] == 'F')) {
 
-#if defined (HIDBL_F1)  
-      RTC_HandleTypeDef hrtc;
-      __HAL_RCC_PWR_CLK_ENABLE();
-      __HAL_RCC_BKP_CLK_ENABLE();
-      HAL_PWR_EnableBkUpAccess();
-      HAL_RTCEx_BKUPWrite(&hrtc,RTC_BKP_DR10,0x424C);  //Write the magic number 0x424C  
-        
+#if defined (HIDBL_F1)
+        RTC_HandleTypeDef hrtc;
+        __HAL_RCC_PWR_CLK_ENABLE();
+        __HAL_RCC_BKP_CLK_ENABLE();
+        HAL_PWR_EnableBkUpAccess();
+        HAL_RTCEx_BKUPWrite(&hrtc, RTC_BKP_DR10, 0x424C); //Write the magic number 0x424C
+
 #elif defined (HIDBL_F4)
-      __HAL_RCC_PWR_CLK_ENABLE();
-      HAL_PWR_EnableBkUpAccess();
-      __BKPSRAM_CLK_ENABLE();
-      *(__IO uint32_t *)(BKPSRAM_BASE) = 0x424C; //Write the magic number 0x424C at Backup SRAM address 0x40024000    
-        
-#endif       
-      HAL_NVIC_SystemReset();
+        __HAL_RCC_PWR_CLK_ENABLE();
+        HAL_PWR_EnableBkUpAccess();
+        __BKPSRAM_CLK_ENABLE();
+        *(__IO uint32_t *)(BKPSRAM_BASE) = 0x424C; //Write the magic number 0x424C at Backup SRAM address 0x40024000
+
+#endif
+        HAL_NVIC_SystemReset();
       }
-    dtr_pin = 0;
+      dtr_pin = 0;
     }
   } /* USER CODE END */
   UNUSED(Buf);

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
@@ -186,7 +186,7 @@ static int8_t USBD_CDC_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length)
       if (lineState) { // Reset the transmit timeout when the port is connected
         transmitStart = 0;
       }
-	  dtr_pin++; //DTR pin is enabled
+      dtr_pin++; //DTR pin is enabled
 
       break;
 

--- a/platform.txt
+++ b/platform.txt
@@ -186,3 +186,26 @@ tools.bmp_upload.upload.speed=230400
 tools.bmp_upload.upload.params.verbose=-batch
 tools.bmp_upload.upload.params.quiet=--batch-silent
 tools.bmp_upload.upload.pattern="{path}{cmd}" -nx -b {upload.speed} {upload.verbose} -ex "set confirm off" -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "load" -ex "compare-sections" -ex "kill" "{build.path}/{build.project_name}.elf"
+
+# HID upload 2.0 (HID bootloader 2.0 This bootloader will cover the STM32F1 and STM32F4 MCUs)
+tools.hid_upload.cmd=hid_upload
+tools.hid_upload.cmd.windows=hid-flash.exe
+tools.hid_upload.cmd.macosx=hid_flash
+tools.hid_upload.path={runtime.hardware.path}/tools/win
+tools.hid_upload.path.macosx={runtime.hardware.path}/tools/macosx
+tools.hid_upload.path.linux={runtime.hardware.path}/tools/linux
+tools.hid_upload.path.linux64={runtime.hardware.path}/tools/linux64
+tools.hid_upload.upload.params.verbose=-d
+tools.hid_upload.upload.params.quiet=n
+tools.hid_upload.upload.pattern="{path}/{cmd}" "{build.path}/{build.project_name}.bin" {serial.port.file}
+
+# Upload using Maple bootloader over DFU
+tools.maple_upload.cmd=maple_upload
+tools.maple_upload.cmd.windows=maple_upload.bat
+tools.maple_upload.path={runtime.hardware.path}/tools/win
+tools.maple_upload.path.macosx={runtime.hardware.path}/tools/macosx
+tools.maple_upload.path.linux={runtime.hardware.path}/tools/linux
+tools.maple_upload.path.linux64={runtime.hardware.path}/tools/linux64
+tools.maple_upload.upload.params.verbose=-d
+tools.maple_upload.upload.params.quiet=n
+tools.maple_upload.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.altID} {upload.usbID} "{build.path}/{build.project_name}.bin"

--- a/platform.txt
+++ b/platform.txt
@@ -83,6 +83,7 @@ build.usb_speed=
 build.startup_file=
 build.flags.optimize=-Os
 build.flags.ldspecs=--specs=nano.specs
+upload.bl_size=0
 
 # Pre and post build hooks
 build.opt.name=build_opt.h
@@ -97,7 +98,7 @@ recipe.hooks.prebuild.1.pattern.macosx=bash -c "[ -f {build.opt.sourcepath} ] ||
 # preprocess linker file
 preprocld.name=preproc.ld
 preprocld.filepath={build.path}/{preprocld.name}
-preprocld.flags=-DLD_MAX_SIZE={upload.maximum_size} -DLD_MAX_DATA_SIZE={upload.maximum_data_size}
+preprocld.flags=-DLD_MAX_SIZE={upload.maximum_size} -DLD_MAX_DATA_SIZE={upload.maximum_data_size} -DBL_SIZE={upload.bl_size}
 recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.cmd}" -x c -E -P {preprocld.flags} {compiler.c.flags} {build.info.flags} {compiler.c.extra_flags} {build.extra_flags} {compiler.arm.cmsis.c.flags} "{build.variant.path}/{build.ldscript}" -o "{preprocld.filepath}"
 
 # compile patterns

--- a/variants/BLACK_F407XX/ldscript.ld
+++ b/variants/BLACK_F407XX/ldscript.ld
@@ -52,7 +52,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20020000;    /* end of RAM */
+_estack = 0x20000000 + LD_MAX_DATA_SIZE;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
@@ -60,13 +60,9 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
 CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
-#ifdef HIDBL_F4
-FLASH (rx)      : ORIGIN = 0x8004000, LENGTH = LD_MAX_SIZE - 0x4000
-#else
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = LD_MAX_SIZE
-#endif
+FLASH (rx)      : ORIGIN = 0x8000000 + BL_SIZE, LENGTH = LD_MAX_SIZE - BL_SIZE
 }
 
 /* Define output sections */

--- a/variants/BLACK_F407XX/ldscript.ld
+++ b/variants/BLACK_F407XX/ldscript.ld
@@ -62,7 +62,11 @@ MEMORY
 {
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
 CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
+#ifdef HIDBL_F4
+FLASH (rx)      : ORIGIN = 0x8004000, LENGTH = LD_MAX_SIZE - 0x4000
+#else
 FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = LD_MAX_SIZE
+#endif
 }
 
 /* Define output sections */

--- a/variants/BLUEPILL_F103XX/ldscript.ld
+++ b/variants/BLUEPILL_F103XX/ldscript.ld
@@ -61,13 +61,7 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 MEMORY
 {
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
-#ifdef HIDBL_F1
-FLASH (rx)      : ORIGIN = 0x8000800, LENGTH = LD_MAX_SIZE - 0x800
-#elif DFUBL2_F1
-FLASH (rx)      : ORIGIN = 0x8002000, LENGTH = LD_MAX_SIZE - 0x2000
-#else
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = LD_MAX_SIZE
-#endif
+FLASH (rx)      : ORIGIN = 0x8000000 + BL_SIZE, LENGTH = LD_MAX_SIZE - BL_SIZE
 }
 
 /* Define output sections */

--- a/variants/BLUEPILL_F103XX/ldscript.ld
+++ b/variants/BLUEPILL_F103XX/ldscript.ld
@@ -61,7 +61,13 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 MEMORY
 {
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
+#ifdef HIDBL_F1
+FLASH (rx)      : ORIGIN = 0x8000800, LENGTH = LD_MAX_SIZE - 0x800
+#elif DFUBL2_F1
+FLASH (rx)      : ORIGIN = 0x8002000, LENGTH = LD_MAX_SIZE - 0x2000
+#else
 FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = LD_MAX_SIZE
+#endif
 }
 
 /* Define output sections */

--- a/variants/BLUE_F407VE_Mini/ldscript.ld
+++ b/variants/BLUE_F407VE_Mini/ldscript.ld
@@ -52,7 +52,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20020000;    /* end of RAM */
+_estack = 0x20000000 + LD_MAX_DATA_SIZE;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
@@ -60,13 +60,9 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
 CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
-#ifdef HIDBL_F4
-FLASH (rx)      : ORIGIN = 0x8004000, LENGTH = 496K
-#else
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 512K
-#endif
+FLASH (rx)      : ORIGIN = 0x8000000 + BL_SIZE, LENGTH = LD_MAX_SIZE - BL_SIZE
 }
 
 /* Define output sections */

--- a/variants/BLUE_F407VE_Mini/ldscript.ld
+++ b/variants/BLUE_F407VE_Mini/ldscript.ld
@@ -62,7 +62,11 @@ MEMORY
 {
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
 CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
+#ifdef HIDBL_F4
+FLASH (rx)      : ORIGIN = 0x8004000, LENGTH = 496K
+#else
 FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 512K
+#endif
 }
 
 /* Define output sections */

--- a/variants/DIYMROE_F407VGT/ldscript.ld
+++ b/variants/DIYMROE_F407VGT/ldscript.ld
@@ -52,7 +52,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20020000;    /* end of RAM */
+_estack = 0x20000000 + LD_MAX_DATA_SIZE;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
@@ -60,13 +60,9 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
 CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
-#ifdef HIDBL_F4
-FLASH (rx)      : ORIGIN = 0x8004000, LENGTH = 1008K
-#else
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 1024K
-#endif
+FLASH (rx)      : ORIGIN = 0x8000000 + BL_SIZE, LENGTH = LD_MAX_SIZE - BL_SIZE
 }
 
 /* Define output sections */

--- a/variants/DIYMROE_F407VGT/ldscript.ld
+++ b/variants/DIYMROE_F407VGT/ldscript.ld
@@ -62,7 +62,11 @@ MEMORY
 {
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
 CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
+#ifdef HIDBL_F4
+FLASH (rx)      : ORIGIN = 0x8004000, LENGTH = 1008K
+#else
 FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 1024K
+#endif
 }
 
 /* Define output sections */

--- a/variants/FK407M1/ldscript.ld
+++ b/variants/FK407M1/ldscript.ld
@@ -52,7 +52,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20005000;    /* end of RAM */
+_estack = 0x20000000 + LD_MAX_DATA_SIZE;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
@@ -60,15 +60,9 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 20K
-#ifdef HIDBL_F1
-FLASH (rx)      : ORIGIN = 0x8000800, LENGTH = 126K
-#endif
-#ifdef DFUBL2_F1
-FLASH (rx)      : ORIGIN = 0x8002000, LENGTH = 120K
-#else
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 128K
-#endif
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
+CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
+FLASH (rx)      : ORIGIN = 0x8000000 + BL_SIZE, LENGTH = LD_MAX_SIZE - BL_SIZE
 }
 
 /* Define output sections */

--- a/variants/FK407M1/ldscript.ld
+++ b/variants/FK407M1/ldscript.ld
@@ -4,8 +4,8 @@
 
 **  File        : LinkerScript.ld
 **
-**  Abstract    : Linker script for STM32F407VETx Device with
-**                512KByte FLASH, 128KByte RAM
+**  Abstract    : Linker script for STM32F103CBTx Device with
+**                128KByte FLASH, 20KByte RAM
 **
 **                Set heap size, stack size and stack location according
 **                to application requirements.
@@ -52,7 +52,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20020000;    /* end of RAM */
+_estack = 0x20005000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
@@ -60,9 +60,15 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
-CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 512K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 20K
+#ifdef HIDBL_F1
+FLASH (rx)      : ORIGIN = 0x8000800, LENGTH = 126K
+#endif
+#ifdef DFUBL2_F1
+FLASH (rx)      : ORIGIN = 0x8002000, LENGTH = 120K
+#else
+FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 128K
+#endif
 }
 
 /* Define output sections */
@@ -77,7 +83,7 @@ SECTIONS
   } >FLASH
 
   /* The program code and other data goes into FLASH */
-  .text ALIGN(8):
+  .text ALIGN(4):
   {
     . = ALIGN(4);
     *(.text)           /* .text sections (code) */
@@ -94,7 +100,7 @@ SECTIONS
   } >FLASH
 
   /* Constant data goes into FLASH */
-  .rodata ALIGN(4):
+  .rodata :
   {
     . = ALIGN(4);
     *(.rodata)         /* .rodata sections (constants, strings, etc.) */
@@ -134,7 +140,7 @@ SECTIONS
   _sidata = LOADADDR(.data);
 
   /* Initialized data sections goes into RAM, load LMA copy after code */
-  .data :
+  .data : 
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
@@ -145,26 +151,7 @@ SECTIONS
     _edata = .;        /* define a global symbol at data end */
   } >RAM AT> FLASH
 
-  _siccmram = LOADADDR(.ccmram);
-
-  /* CCM-RAM section
-  *
-  * IMPORTANT NOTE!
-  * If initialized variables will be placed in this section,
-  * the startup code needs to be modified to copy the init-values.
-  */
-  .ccmram :
-  {
-    . = ALIGN(4);
-    _sccmram = .;       /* create a global symbol at ccmram start */
-    *(.ccmram)
-    *(.ccmram*)
-
-    . = ALIGN(4);
-    _eccmram = .;       /* create a global symbol at ccmram end */
-  } >CCMRAM AT> FLASH
-
-
+  
   /* Uninitialized data section */
   . = ALIGN(4);
   .bss :
@@ -192,7 +179,7 @@ SECTIONS
     . = ALIGN(8);
   } >RAM
 
-
+  
 
   /* Remove information from the standard libraries */
   /DISCARD/ :
@@ -204,5 +191,3 @@ SECTIONS
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
 }
-
-

--- a/variants/MAPLEMINI_F103CB/ldscript.ld
+++ b/variants/MAPLEMINI_F103CB/ldscript.ld
@@ -52,7 +52,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20005000;    /* end of RAM */
+_estack = 0x20000000 + LD_MAX_DATA_SIZE;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
@@ -60,17 +60,8 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-#ifdef DFUBLO_F1
-RAM (rwx) 	    : ORIGIN = 0x20000C00, LENGTH = 17K
-#else
-RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 20K
-#endif
-
-#ifdef DFUBLO_F1
-FLASH (rx)      : ORIGIN = 0x8005000, LENGTH = 108K
-#else
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 128K
-#endif
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
+FLASH (rx)      : ORIGIN = 0x8000000 + BL_SIZE, LENGTH = LD_MAX_SIZE - BL_SIZE
 }
 
 /* Define output sections */

--- a/variants/MAPLEMINI_F103CB/ldscript.ld
+++ b/variants/MAPLEMINI_F103CB/ldscript.ld
@@ -60,8 +60,17 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 20K
+#ifdef DFUBLO_F1
+RAM (rwx) 	    : ORIGIN = 0x20000C00, LENGTH = 17K
+#else
+RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 20K
+#endif
+
+#ifdef DFUBLO_F1
+FLASH (rx)      : ORIGIN = 0x8005000, LENGTH = 108K
+#else
 FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 128K
+#endif
 }
 
 /* Define output sections */


### PR DESCRIPTION
This PR enables the use of the STM32 HID Bootloader 3.0 for Generic F103 & Generic F4 variants

Tested on Bluepill, Blackpill (using BP menu option), & Black407VET6.

**Limitations:**
* boards.txt glue probably needs to be a bit more elegant
* F1 boards must use the latest 2K HID bootloader -> https://github.com/Serasidis/STM32_HID_Bootloader  (hid_flash tool will warn if an older version is installed)

**Usage:**

First apply this PR to your STM32 tools -> https://github.com/stm32duino/Arduino_Tools/pull/33.

**HID:**
Select your variant in the boards menu
Set the upload method to "HID Bootloader 3.0 (0x0800)" for F1 or "HID Bootloader 3.0 (0x4000)" for F4
Ensure that "USB Interface (if available):" is set to "CDC Full Speed" (required for DTR toggling)

**DFU:**
_The PR applies the magic word & byte code recognition to USB_CDC_IF.cpp which also enables STM32Duino Bootloader 2.0 to work.  ~~Also included is DISC pin handling for Maple Mini~~. This is the same logic used in Roger Clarke's core and in STM32GENERIC_
Select your variant in the boards menu
Set the upload method to "Maple DFU Bootloader 2.0" or "Maple DFU Bootloader original (0x5000)" depedning on the BL installed.
Ensure that "USB support (if available):" is set to either CDC option (required for DTR toggling)

Note - edited due to changes to HID Bootloader 3.0 on 21/1/19. & addition of DFU 27/1/2019
