### PR TITLE
Add I2C definition for RemRam V1

### DIFF
--- a/variants/REMRAM_V1/variant.h
+++ b/variants/REMRAM_V1/variant.h
@@ -171,6 +171,10 @@ extern "C"
 // UART Definitions
 #define SERIAL_UART_INSTANCE 1
 
+// I2C Definitions
+#define PIN_WIRE_SDA PB7
+#define PIN_WIRE_SCL PB6
+
 // Default pin used for 'Serial' instance
 #define PIN_SERIAL_RX 0
 #define PIN_SERIAL_TX 1


### PR DESCRIPTION
I thought I had set the I2C pins to the arduino compatible
values, but it seems I messed that up. This change will
set the defaults for the board variant RemRam V1.