### PR TITLE
[USBD] Force re-enumeration

### DIFF
--- a/cores/arduino/stm32/usb/usbd_conf.c
+++ b/cores/arduino/stm32/usb/usbd_conf.c
@@ -19,6 +19,7 @@
 #ifdef USBCON
 /* Includes ------------------------------------------------------------------*/
 #include "usbd_core.h"
+#include "usbd_if.h"
 #include "stm32yyxx_ll_pwr.h"
 
 #ifndef HAL_PCD_MODULE_ENABLED
@@ -421,6 +422,7 @@ void USBWakeUp_IRQHandler(void)
   */
 USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
 {
+  USBD_reenumerate();
   /* Set common LL Driver parameters */
   g_hpcd.Init.dev_endpoints = 4;
   g_hpcd.Init.ep0_mps = DEP0CTL_MPS_64;

--- a/cores/arduino/stm32/usb/usbd_if.c
+++ b/cores/arduino/stm32/usb/usbd_if.c
@@ -1,0 +1,41 @@
+/**
+  ******************************************************************************
+  * @file    usbd_if.c
+  * @author  fpistm
+  * @brief   USB Device common interface file
+  ******************************************************************************
+  */
+#ifdef USBCON
+
+#include "usbd_if.h"
+/**
+  * @brief  Force to re-enumerate USB
+  * @param  None
+  * @retval None
+  */
+
+void USBD_reenumerate(void)
+{
+#ifndef USBD_REENUM_DISABLED
+  /* Re-enumerate the USB */
+#ifdef USB_DISC_PIN
+  pinMode(USB_DISC_PIN, OUTPUT);
+  digitalWrite(USB_DISC_PIN, LOW);
+#else
+#ifdef USE_USB_HS_IN_FS
+  PinName pinDP = USB_OTG_HS_DP;
+#elif defined(USB_OTG_FS)
+  PinName pinDP = USB_OTG_FS_DP;
+#else /* USB */
+  PinName pinDP =  USB_DP;
+#endif
+  pin_function(pinDP, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0));
+  digitalWriteFast(pinDP, LOW);
+  delay(USBD_ENUM_DELAY);
+  pin_function(pinDP, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+  /*delay(USBD_ENUM_DELAY);*/
+#endif /* USB_DISC_PIN */
+#endif /* USBD_REENUM_DISABLED */
+}
+
+#endif /* USBCON */

--- a/cores/arduino/stm32/usb/usbd_if.h
+++ b/cores/arduino/stm32/usb/usbd_if.h
@@ -1,0 +1,32 @@
+/**
+  ******************************************************************************
+  * @file    usbd_if.h
+  * @author  fpistm
+  * @brief   Header file for the usbd_if.c file
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USBD_IF_H
+#define __USBD_IF_H
+
+#ifdef USBCON
+/* Includes ------------------------------------------------------------------*/
+#include "Arduino.h"
+
+/* Re-enumeration handling*/
+#ifndef USBD_ENUM_DELAY
+#define USBD_ENUM_DELAY 10
+#endif
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+void USBD_reenumerate(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* USBCON */
+#endif /* __USBD_IF_H */

--- a/variants/MAPLEMINI_F103CB/variant.h
+++ b/variants/MAPLEMINI_F103CB/variant.h
@@ -117,6 +117,9 @@ extern const PinName digitalPin[];
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
+// USB
+#define USB_DISC_PIN            PB9
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
Enumeration delay could be redefined using `USBD_ENUM_DELAY`
To disable re-enumeration define `USBD_REENUM_DISABLED`
Use `USB_DISC_PIN` if defined.

Tested with BluePill, MapleMini and Disco F746.

Any comments are welcome.