### PR TITLE
Add STM32 core version

### DIFF
--- a/cores/arduino/stm32/stm32_def.h
+++ b/cores/arduino/stm32/stm32_def.h
@@ -1,6 +1,25 @@
 #ifndef _STM32_DEF_
 #define _STM32_DEF_
 
+
+/**
+ * @brief STM32 core version number
+ */
+#define STM32_CORE_VERSION_MAJOR    (0x01U) /*!< [31:24] major version */
+#define STM32_CORE_VERSION_MINOR    (0x05U) /*!< [23:16] minor version */
+#define STM32_CORE_VERSION_PATCH    (0x01U) /*!< [15:8]  patch version */
+/*
+ * Extra label for development:
+ * 0: official release
+ * [1-9]: release candidate
+ * F[0-9]: development
+ */
+#define STM32_CORE_VERSION_EXTRA    (0xF0U) /*!< [7:0]  extra version */
+#define STM32_CORE_VERSION          ((STM32_CORE_VERSION_MAJOR << 24U)\
+                                        |(STM32_CORE_VERSION_MINOR << 16U)\
+                                        |(STM32_CORE_VERSION_PATCH << 8U )\
+                                        |(STM32_CORE_VERSION_EXTRA))
+
 #define F_CPU SystemCoreClock
 #define USE_HAL_DRIVER
 


### PR DESCRIPTION
Based on Semantic Versioning 2.0.0 (https://semver.org/)
This will ease core dependencies.

* STM32_CORE_VERSION_MAJOR -> major version
* STM32_CORE_VERSION_MINOR -> minor version
* STM32_CORE_VERSION_PATCH -> patch version
* STM32_CORE_VERSION_EXTRA -> Extra label
 with:
  - 0: official release
  - [1-9]: release candidate
  - F[0-9]: development

* STM32_CORE_VERSION --> Full version number