### PR TITLE
Timer pull request

### DIFF
--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -799,7 +799,7 @@ void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*
 {
   TIM_OC_InitTypeDef sConfig = {};
   TIM_HandleTypeDef *handle = &(obj->handle);
-  
+
   if (obj->timer == 0x00) {
     obj->timer = TIMER_SERVO;
   }

--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -843,7 +843,7 @@ void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*
   * @brief  This function will attach timer interrupt to with a particular duty cycle on channel x
   * @param  timer_id : timer_id_e
   * @param  irqHandle : interrupt routine to call
-  * @param  timChannel : timmer channel
+  * @param  timChannel : timer channel
   * @param  pulseWidth : phase of the timer where the callback will happen
   * @retval None
   */

--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -795,7 +795,7 @@ uint32_t getTimerClkFreq(TIM_TypeDef *tim)
   * @param  irqHandle : interrupt routine to call
   * @retval None
   */
-void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(void))
+void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(stimer_t *, uint32_t))
 {
   TIM_OC_InitTypeDef sConfig = {};
   TIM_HandleTypeDef *handle = &(obj->handle);
@@ -810,7 +810,7 @@ void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
   handle->Init.RepetitionCounter = 0;
 #endif
-  obj->irqHandleOC_CH1 = irqHandle;
+  obj->irqHandleOC = irqHandle;
 
   sConfig.OCMode        = TIM_OCMODE_TIMING;
   sConfig.Pulse         = pulseWidth;
@@ -997,8 +997,10 @@ void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
         return;
         break;
     }
-    
-  
+
+    //make it compatible with older versions
+    if (obj->irqHandleOC != NULL) {obj->irqHandleOC(obj, channel);}
+     
 }
 
 /**

--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -1161,6 +1161,19 @@ void setCCRRegister(stimer_t *obj, uint32_t channel, uint32_t value)
   __HAL_TIM_SET_COMPARE(&(obj->handle), channel * 4, value);
 }
 
+
+/**
+  * @brief  Set the TIM Capture Compare Register value.
+  * @param  timer_id : id of the timer
+  * @param  prescaler : prescaler value to set for this timer.
+  * @retval None
+  */
+void setTimerPrescalerRegister(stimer_t *obj, uint32_t prescaler)
+{
+  __HAL_TIM_SET_PRESCALER(&(obj->handle), prescaler);
+}
+
+
 /**
   * @brief  Set the TIM Capture Compare Register value.
   * @param  timer_id : id of the timer

--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -841,6 +841,7 @@ void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*
   * @param  timer_id : timer_id_e
   * @param  irqHandle : interrupt routine to call
   * @param  timChannel : timmer channel 
+  * @param  pulseWidth : phase of the timer where the callback will happen  
   * @retval None
   */
 void attachIntHandleOC(stimer_t *obj, void (*irqHandle)(void), uint16_t timChannel, uint16_t pulseWidth)
@@ -917,7 +918,7 @@ void attachIntHandleOC(stimer_t *obj, void (*irqHandle)(void), uint16_t timChann
 void TimerPulseDeinit(stimer_t *obj)
 {
   TIM_HandleTypeDef *handle = &(obj->handle);
-
+  obj->irqHandleOC = NULL;
   obj->irqHandleOC_CH1 = NULL;
   obj->irqHandleOC_CH2 = NULL;
   obj->irqHandleOC_CH3 = NULL;

--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -111,138 +111,138 @@ static TIM_HandleTypeDef *timer_handles[TIMER_NUM] = {NULL};
   */
 void timer_enable_clock(TIM_HandleTypeDef *htim)
 {
-    // Enable TIM clock
+  // Enable TIM clock
 #if defined(TIM1_BASE)
-    if (htim->Instance == TIM1) {
-        __HAL_RCC_TIM1_CLK_ENABLE();
-        timer_handles[0] = htim;
-    }
+  if (htim->Instance == TIM1) {
+    __HAL_RCC_TIM1_CLK_ENABLE();
+    timer_handles[0] = htim;
+  }
 #endif
 #if defined(TIM2_BASE)
-    if (htim->Instance == TIM2) {
-        __HAL_RCC_TIM2_CLK_ENABLE();
-        timer_handles[1] = htim;
-    }
+  if (htim->Instance == TIM2) {
+    __HAL_RCC_TIM2_CLK_ENABLE();
+    timer_handles[1] = htim;
+  }
 #endif
 #if defined(TIM3_BASE)
-    if (htim->Instance == TIM3) {
-        __HAL_RCC_TIM3_CLK_ENABLE();
-        timer_handles[2] = htim;
-    }
+  if (htim->Instance == TIM3) {
+    __HAL_RCC_TIM3_CLK_ENABLE();
+    timer_handles[2] = htim;
+  }
 #endif
 #if defined(TIM4_BASE)
-    if (htim->Instance == TIM4) {
-        __HAL_RCC_TIM4_CLK_ENABLE();
-        timer_handles[3] = htim;
-    }
+  if (htim->Instance == TIM4) {
+    __HAL_RCC_TIM4_CLK_ENABLE();
+    timer_handles[3] = htim;
+  }
 #endif
 #if defined(TIM5_BASE)
-    if (htim->Instance == TIM5) {
-        __HAL_RCC_TIM5_CLK_ENABLE();
-        timer_handles[4] = htim;
-    }
+  if (htim->Instance == TIM5) {
+    __HAL_RCC_TIM5_CLK_ENABLE();
+    timer_handles[4] = htim;
+  }
 #endif
 #if defined(TIM6_BASE)
-    if (htim->Instance == TIM6) {
-        __HAL_RCC_TIM6_CLK_ENABLE();
-        timer_handles[5] = htim;
-    }
+  if (htim->Instance == TIM6) {
+    __HAL_RCC_TIM6_CLK_ENABLE();
+    timer_handles[5] = htim;
+  }
 #endif
 #if defined(TIM7_BASE)
-    if (htim->Instance == TIM7) {
-        __HAL_RCC_TIM7_CLK_ENABLE();
-        timer_handles[6] = htim;
-    }
+  if (htim->Instance == TIM7) {
+    __HAL_RCC_TIM7_CLK_ENABLE();
+    timer_handles[6] = htim;
+  }
 #endif
 #if defined(TIM8_BASE)
-    if (htim->Instance == TIM8) {
-        __HAL_RCC_TIM8_CLK_ENABLE();
-        timer_handles[7] = htim;
-    }
+  if (htim->Instance == TIM8) {
+    __HAL_RCC_TIM8_CLK_ENABLE();
+    timer_handles[7] = htim;
+  }
 #endif
 #if defined(TIM9_BASE)
-    if (htim->Instance == TIM9) {
-        __HAL_RCC_TIM9_CLK_ENABLE();
-        timer_handles[8] = htim;
-    }
+  if (htim->Instance == TIM9) {
+    __HAL_RCC_TIM9_CLK_ENABLE();
+    timer_handles[8] = htim;
+  }
 #endif
 #if defined(TIM10_BASE)
-    if (htim->Instance == TIM10) {
-        __HAL_RCC_TIM10_CLK_ENABLE();
-        timer_handles[9] = htim;
-    }
+  if (htim->Instance == TIM10) {
+    __HAL_RCC_TIM10_CLK_ENABLE();
+    timer_handles[9] = htim;
+  }
 #endif
 #if defined(TIM11_BASE)
-    if (htim->Instance == TIM11) {
-        __HAL_RCC_TIM11_CLK_ENABLE();
-        timer_handles[10] = htim;
-    }
+  if (htim->Instance == TIM11) {
+    __HAL_RCC_TIM11_CLK_ENABLE();
+    timer_handles[10] = htim;
+  }
 #endif
 #if defined(TIM12_BASE)
-    if (htim->Instance == TIM12) {
-        __HAL_RCC_TIM12_CLK_ENABLE();
-        timer_handles[11] = htim;
-    }
+  if (htim->Instance == TIM12) {
+    __HAL_RCC_TIM12_CLK_ENABLE();
+    timer_handles[11] = htim;
+  }
 #endif
 #if defined(TIM13_BASE)
-    if (htim->Instance == TIM13) {
-        __HAL_RCC_TIM13_CLK_ENABLE();
-        timer_handles[12] = htim;
-    }
+  if (htim->Instance == TIM13) {
+    __HAL_RCC_TIM13_CLK_ENABLE();
+    timer_handles[12] = htim;
+  }
 #endif
 #if defined(TIM14_BASE)
-    if (htim->Instance == TIM14) {
-        __HAL_RCC_TIM14_CLK_ENABLE();
-        timer_handles[13] = htim;
-    }
+  if (htim->Instance == TIM14) {
+    __HAL_RCC_TIM14_CLK_ENABLE();
+    timer_handles[13] = htim;
+  }
 #endif
 #if defined(TIM15_BASE)
-    if (htim->Instance == TIM15) {
-        __HAL_RCC_TIM15_CLK_ENABLE();
-        timer_handles[14] = htim;
-    }
+  if (htim->Instance == TIM15) {
+    __HAL_RCC_TIM15_CLK_ENABLE();
+    timer_handles[14] = htim;
+  }
 #endif
 #if defined(TIM16_BASE)
-    if (htim->Instance == TIM16) {
-        __HAL_RCC_TIM16_CLK_ENABLE();
-        timer_handles[15] = htim;
-    }
+  if (htim->Instance == TIM16) {
+    __HAL_RCC_TIM16_CLK_ENABLE();
+    timer_handles[15] = htim;
+  }
 #endif
 #if defined(TIM17_BASE)
-    if (htim->Instance == TIM17) {
-        __HAL_RCC_TIM17_CLK_ENABLE();
-        timer_handles[16] = htim;
-    }
+  if (htim->Instance == TIM17) {
+    __HAL_RCC_TIM17_CLK_ENABLE();
+    timer_handles[16] = htim;
+  }
 #endif
 #if defined(TIM18_BASE)
-    if (htim->Instance == TIM18) {
-        __HAL_RCC_TIM18_CLK_ENABLE();
-        timer_handles[17] = htim;
-    }
+  if (htim->Instance == TIM18) {
+    __HAL_RCC_TIM18_CLK_ENABLE();
+    timer_handles[17] = htim;
+  }
 #endif
 #if defined(TIM19_BASE)
-    if (htim->Instance == TIM19) {
-        __HAL_RCC_TIM19_CLK_ENABLE();
-        timer_handles[18] = htim;
-    }
+  if (htim->Instance == TIM19) {
+    __HAL_RCC_TIM19_CLK_ENABLE();
+    timer_handles[18] = htim;
+  }
 #endif
 #if defined(TIM20_BASE)
-    if (htim->Instance == TIM20) {
-        __HAL_RCC_TIM20_CLK_ENABLE();
-        timer_handles[19] = htim;
-    }
+  if (htim->Instance == TIM20) {
+    __HAL_RCC_TIM20_CLK_ENABLE();
+    timer_handles[19] = htim;
+  }
 #endif
 #if defined(TIM21_BASE)
-    if (htim->Instance == TIM21) {
-        __HAL_RCC_TIM21_CLK_ENABLE();
-        timer_handles[20] = htim;
-    }
+  if (htim->Instance == TIM21) {
+    __HAL_RCC_TIM21_CLK_ENABLE();
+    timer_handles[20] = htim;
+  }
 #endif
 #if defined(TIM22_BASE)
-    if (htim->Instance == TIM22) {
-        __HAL_RCC_TIM22_CLK_ENABLE();
-        timer_handles[21] = htim;
-    }
+  if (htim->Instance == TIM22) {
+    __HAL_RCC_TIM22_CLK_ENABLE();
+    timer_handles[21] = htim;
+  }
 #endif
 }
 
@@ -253,116 +253,116 @@ void timer_enable_clock(TIM_HandleTypeDef *htim)
   */
 void timer_disable_clock(TIM_HandleTypeDef *htim)
 {
-    // Enable TIM clock
+  // Enable TIM clock
 #if defined(TIM1_BASE)
-    if (htim->Instance == TIM1) {
-        __HAL_RCC_TIM1_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM1) {
+    __HAL_RCC_TIM1_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM2_BASE)
-    if (htim->Instance == TIM2) {
-        __HAL_RCC_TIM2_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM2) {
+    __HAL_RCC_TIM2_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM3_BASE)
-    if (htim->Instance == TIM3) {
-        __HAL_RCC_TIM3_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM3) {
+    __HAL_RCC_TIM3_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM4_BASE)
-    if (htim->Instance == TIM4) {
-        __HAL_RCC_TIM4_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM4) {
+    __HAL_RCC_TIM4_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM5_BASE)
-    if (htim->Instance == TIM5) {
-        __HAL_RCC_TIM5_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM5) {
+    __HAL_RCC_TIM5_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM6_BASE)
-    if (htim->Instance == TIM6) {
-        __HAL_RCC_TIM6_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM6) {
+    __HAL_RCC_TIM6_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM7_BASE)
-    if (htim->Instance == TIM7) {
-        __HAL_RCC_TIM7_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM7) {
+    __HAL_RCC_TIM7_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM8_BASE)
-    if (htim->Instance == TIM8) {
-        __HAL_RCC_TIM8_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM8) {
+    __HAL_RCC_TIM8_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM9_BASE)
-    if (htim->Instance == TIM9) {
-        __HAL_RCC_TIM9_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM9) {
+    __HAL_RCC_TIM9_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM10_BASE)
-    if (htim->Instance == TIM10) {
-        __HAL_RCC_TIM10_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM10) {
+    __HAL_RCC_TIM10_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM11_BASE)
-    if (htim->Instance == TIM11) {
-        __HAL_RCC_TIM11_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM11) {
+    __HAL_RCC_TIM11_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM12_BASE)
-    if (htim->Instance == TIM12) {
-        __HAL_RCC_TIM12_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM12) {
+    __HAL_RCC_TIM12_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM13_BASE)
-    if (htim->Instance == TIM13) {
-        __HAL_RCC_TIM13_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM13) {
+    __HAL_RCC_TIM13_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM14_BASE)
-    if (htim->Instance == TIM14) {
-        __HAL_RCC_TIM14_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM14) {
+    __HAL_RCC_TIM14_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM15_BASE)
-    if (htim->Instance == TIM15) {
-        __HAL_RCC_TIM15_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM15) {
+    __HAL_RCC_TIM15_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM16_BASE)
-    if (htim->Instance == TIM16) {
-        __HAL_RCC_TIM16_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM16) {
+    __HAL_RCC_TIM16_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM17_BASE)
-    if (htim->Instance == TIM17) {
-        __HAL_RCC_TIM17_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM17) {
+    __HAL_RCC_TIM17_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM18_BASE)
-    if (htim->Instance == TIM18) {
-        __HAL_RCC_TIM18_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM18) {
+    __HAL_RCC_TIM18_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM19_BASE)
-    if (htim->Instance == TIM19) {
-        __HAL_RCC_TIM19_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM19) {
+    __HAL_RCC_TIM19_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM20_BASE)
-    if (htim->Instance == TIM20) {
-        __HAL_RCC_TIM20_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM20) {
+    __HAL_RCC_TIM20_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM21_BASE)
-    if (htim->Instance == TIM21) {
-        __HAL_RCC_TIM21_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM21) {
+    __HAL_RCC_TIM21_CLK_DISABLE();
+  }
 #endif
 #if defined(TIM22_BASE)
-    if (htim->Instance == TIM22) {
-        __HAL_RCC_TIM22_CLK_DISABLE();
-    }
+  if (htim->Instance == TIM22) {
+    __HAL_RCC_TIM22_CLK_DISABLE();
+  }
 #endif
 }
 
@@ -373,10 +373,10 @@ void timer_disable_clock(TIM_HandleTypeDef *htim)
   */
 void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim_base)
 {
-    timer_enable_clock(htim_base);
+  timer_enable_clock(htim_base);
 
-    HAL_NVIC_SetPriority(getTimerIrq(htim_base->Instance), 15, 0);
-    HAL_NVIC_EnableIRQ(getTimerIrq(htim_base->Instance));
+  HAL_NVIC_SetPriority(getTimerIrq(htim_base->Instance), 15, 0);
+  HAL_NVIC_EnableIRQ(getTimerIrq(htim_base->Instance));
 }
 
 /**
@@ -386,8 +386,8 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim_base)
   */
 void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim_base)
 {
-    timer_disable_clock(htim_base);
-    HAL_NVIC_DisableIRQ(getTimerIrq(htim_base->Instance));
+  timer_disable_clock(htim_base);
+  HAL_NVIC_DisableIRQ(getTimerIrq(htim_base->Instance));
 }
 
 /**
@@ -399,27 +399,27 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim_base)
   */
 void TimerHandleInit(stimer_t *obj, uint16_t period, uint16_t prescaler)
 {
-    if (obj == NULL) {
-        return;
-    }
+  if (obj == NULL) {
+    return;
+  }
 
-    TIM_HandleTypeDef *handle = &(obj->handle);
+  TIM_HandleTypeDef *handle = &(obj->handle);
 
-    handle->Instance               = obj->timer;
-    handle->Init.Prescaler         = prescaler;
-    handle->Init.CounterMode       = TIM_COUNTERMODE_UP;
-    handle->Init.Period            = period;
-    handle->Init.ClockDivision     = TIM_CLOCKDIVISION_DIV1;
+  handle->Instance               = obj->timer;
+  handle->Init.Prescaler         = prescaler;
+  handle->Init.CounterMode       = TIM_COUNTERMODE_UP;
+  handle->Init.Period            = period;
+  handle->Init.ClockDivision     = TIM_CLOCKDIVISION_DIV1;
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
-    handle->Init.RepetitionCounter = 0x0000;
+  handle->Init.RepetitionCounter = 0x0000;
 #endif
-    if (HAL_TIM_Base_Init(handle) != HAL_OK) {
-        return;
-    }
+  if (HAL_TIM_Base_Init(handle) != HAL_OK) {
+    return;
+  }
 
-    if (HAL_TIM_Base_Start_IT(handle) != HAL_OK) {
-        return;
-    }
+  if (HAL_TIM_Base_Start_IT(handle) != HAL_OK) {
+    return;
+  }
 }
 
 /**
@@ -429,128 +429,128 @@ void TimerHandleInit(stimer_t *obj, uint16_t period, uint16_t prescaler)
   */
 uint32_t getTimerIrq(TIM_TypeDef *tim)
 {
-    uint32_t IRQn = 0;
+  uint32_t IRQn = 0;
 
-    if (tim != (TIM_TypeDef *)NC) {
-        /* Get IRQn depending on TIM instance */
-        switch ((uint32_t)tim) {
+  if (tim != (TIM_TypeDef *)NC) {
+    /* Get IRQn depending on TIM instance */
+    switch ((uint32_t)tim) {
 #if defined(TIM1_BASE)
-        case (uint32_t)TIM1:
-            IRQn = TIM1_IRQn;
-            break;
+      case (uint32_t)TIM1:
+        IRQn = TIM1_IRQn;
+        break;
 #endif
 #if defined(TIM2_BASE)
-        case (uint32_t)TIM2:
-            IRQn = TIM2_IRQn;
-            break;
+      case (uint32_t)TIM2:
+        IRQn = TIM2_IRQn;
+        break;
 #endif
 #if defined(TIM3_BASE)
-        case (uint32_t)TIM3:
-            IRQn = TIM3_IRQn;
-            break;
+      case (uint32_t)TIM3:
+        IRQn = TIM3_IRQn;
+        break;
 #endif
 #if defined(TIM4_BASE)
-        case (uint32_t)TIM4:
-            IRQn = TIM4_IRQn;
-            break;
+      case (uint32_t)TIM4:
+        IRQn = TIM4_IRQn;
+        break;
 #endif
 #if defined(TIM5_BASE)
-        case (uint32_t)TIM5:
-            IRQn = TIM5_IRQn;
-            break;
+      case (uint32_t)TIM5:
+        IRQn = TIM5_IRQn;
+        break;
 #endif
 #if defined(TIM6_BASE)
-        case (uint32_t)TIM6:
-            IRQn = TIM6_IRQn;
-            break;
+      case (uint32_t)TIM6:
+        IRQn = TIM6_IRQn;
+        break;
 #endif
 #if defined(TIM7_BASE)
-        case (uint32_t)TIM7:
-            IRQn = TIM7_IRQn;
-            break;
+      case (uint32_t)TIM7:
+        IRQn = TIM7_IRQn;
+        break;
 #endif
 #if defined(TIM8_BASE)
-        case (uint32_t)TIM8:
-            IRQn = TIM8_IRQn;
-            break;
+      case (uint32_t)TIM8:
+        IRQn = TIM8_IRQn;
+        break;
 #endif
 #if defined(TIM9_BASE)
-        case (uint32_t)TIM9:
-            IRQn = TIM9_IRQn;
-            break;
+      case (uint32_t)TIM9:
+        IRQn = TIM9_IRQn;
+        break;
 #endif
 #if defined(TIM10_BASE)
-        case (uint32_t)TIM10:
-            IRQn = TIM10_IRQn;
-            break;
+      case (uint32_t)TIM10:
+        IRQn = TIM10_IRQn;
+        break;
 #endif
 #if defined(TIM11_BASE)
-        case (uint32_t)TIM11:
-            IRQn = TIM11_IRQn;
-            break;
+      case (uint32_t)TIM11:
+        IRQn = TIM11_IRQn;
+        break;
 #endif
 #if defined(TIM12_BASE)
-        case (uint32_t)TIM12:
-            IRQn = TIM12_IRQn;
-            break;
+      case (uint32_t)TIM12:
+        IRQn = TIM12_IRQn;
+        break;
 #endif
 #if defined(TIM13_BASE)
-        case (uint32_t)TIM13:
-            IRQn = TIM13_IRQn;
-            break;
+      case (uint32_t)TIM13:
+        IRQn = TIM13_IRQn;
+        break;
 #endif
 #if defined(TIM14_BASE)
-        case (uint32_t)TIM14:
-            IRQn = TIM14_IRQn;
-            break;
+      case (uint32_t)TIM14:
+        IRQn = TIM14_IRQn;
+        break;
 #endif
 #if defined(TIM15_BASE)
-        case (uint32_t)TIM15:
-            IRQn = TIM15_IRQn;
-            break;
+      case (uint32_t)TIM15:
+        IRQn = TIM15_IRQn;
+        break;
 #endif
 #if defined(TIM16_BASE)
-        case (uint32_t)TIM16:
-            IRQn = TIM16_IRQn;
-            break;
+      case (uint32_t)TIM16:
+        IRQn = TIM16_IRQn;
+        break;
 #endif
 #if defined(TIM17_BASE)
-        case (uint32_t)TIM17:
-            IRQn = TIM17_IRQn;
-            break;
+      case (uint32_t)TIM17:
+        IRQn = TIM17_IRQn;
+        break;
 #endif
 #if defined(TIM18_BASE)
-        case (uint32_t)TIM18:
-            IRQn = TIM18_IRQn;
-            break;
+      case (uint32_t)TIM18:
+        IRQn = TIM18_IRQn;
+        break;
 #endif
 #if defined(TIM19_BASE)
-        case (uint32_t)TIM19:
-            IRQn = TIM19_IRQn;
-            break;
+      case (uint32_t)TIM19:
+        IRQn = TIM19_IRQn;
+        break;
 #endif
 #if defined(TIM20_BASE)
-        case (uint32_t)TIM20:
-            IRQn = TIM20_IRQn;
-            break;
+      case (uint32_t)TIM20:
+        IRQn = TIM20_IRQn;
+        break;
 #endif
 #if defined(TIM21_BASE)
-        case (uint32_t)TIM21:
-            IRQn = TIM21_IRQn;
-            break;
+      case (uint32_t)TIM21:
+        IRQn = TIM21_IRQn;
+        break;
 #endif
 #if defined(TIM22_BASE)
-        case (uint32_t)TIM22:
-            IRQn = TIM22_IRQn;
-            break;
+      case (uint32_t)TIM22:
+        IRQn = TIM22_IRQn;
+        break;
 #endif
-            break;
-        default:
-            core_debug("TIM: Unknown timer IRQn");
-            break;
-        }
+        break;
+      default:
+        core_debug("TIM: Unknown timer IRQn");
+        break;
     }
-    return IRQn;
+  }
+  return IRQn;
 }
 
 /**
@@ -560,10 +560,10 @@ uint32_t getTimerIrq(TIM_TypeDef *tim)
   */
 void TimerHandleDeinit(stimer_t *obj)
 {
-    if (obj != NULL) {
-        HAL_TIM_Base_DeInit(&(obj->handle));
-        HAL_TIM_Base_Stop_IT(&(obj->handle));
-    }
+  if (obj != NULL) {
+    HAL_TIM_Base_DeInit(&(obj->handle));
+    HAL_TIM_Base_Stop_IT(&(obj->handle));
+  }
 }
 
 /**
@@ -573,93 +573,93 @@ void TimerHandleDeinit(stimer_t *obj)
   */
 uint8_t getTimerClkSrc(TIM_TypeDef *tim)
 {
-    uint8_t clkSrc = 0;
+  uint8_t clkSrc = 0;
 
-    if (tim != (TIM_TypeDef *)NC)
+  if (tim != (TIM_TypeDef *)NC)
 #ifdef STM32F0xx
-        /* TIMx source CLK is PCKL1 */
-        clkSrc = 1;
+    /* TIMx source CLK is PCKL1 */
+    clkSrc = 1;
 #else
-    {
-        /* Get source clock depending on TIM instance */
-        switch ((uint32_t)tim) {
+  {
+    /* Get source clock depending on TIM instance */
+    switch ((uint32_t)tim) {
 #if defined(TIM2_BASE)
-        case (uint32_t)TIM2:
+      case (uint32_t)TIM2:
 #endif
 #if defined(TIM3_BASE)
-        case (uint32_t)TIM3:
+      case (uint32_t)TIM3:
 #endif
 #if defined(TIM4_BASE)
-        case (uint32_t)TIM4:
+      case (uint32_t)TIM4:
 #endif
 #if defined(TIM5_BASE)
-        case (uint32_t)TIM5:
+      case (uint32_t)TIM5:
 #endif
 #if defined(TIM6_BASE)
-        case (uint32_t)TIM6:
+      case (uint32_t)TIM6:
 #endif
 #if defined(TIM7_BASE)
-        case (uint32_t)TIM7:
+      case (uint32_t)TIM7:
 #endif
 #if defined(TIM12_BASE)
-        case (uint32_t)TIM12:
+      case (uint32_t)TIM12:
 #endif
 #if defined(TIM13_BASE)
-        case (uint32_t)TIM13:
+      case (uint32_t)TIM13:
 #endif
 #if defined(TIM14_BASE)
-        case (uint32_t)TIM14:
+      case (uint32_t)TIM14:
 #endif
 #if defined(TIM18_BASE)
-        case (uint32_t)TIM18:
+      case (uint32_t)TIM18:
 #endif
-            clkSrc = 1;
-            break;
+        clkSrc = 1;
+        break;
 #if defined(TIM1_BASE)
-        case (uint32_t)TIM1:
+      case (uint32_t)TIM1:
 #endif
 #if defined(TIM8_BASE)
-        case (uint32_t)TIM8:
+      case (uint32_t)TIM8:
 #endif
 #if defined(TIM9_BASE)
-        case (uint32_t)TIM9:
+      case (uint32_t)TIM9:
 #endif
 #if defined(TIM10_BASE)
-        case (uint32_t)TIM10:
+      case (uint32_t)TIM10:
 #endif
 #if defined(TIM11_BASE)
-        case (uint32_t)TIM11:
+      case (uint32_t)TIM11:
 #endif
 #if defined(TIM15_BASE)
-        case (uint32_t)TIM15:
+      case (uint32_t)TIM15:
 #endif
 #if defined(TIM16_BASE)
-        case (uint32_t)TIM16:
+      case (uint32_t)TIM16:
 #endif
 #if defined(TIM17_BASE)
-        case (uint32_t)TIM17:
+      case (uint32_t)TIM17:
 #endif
 #if defined(TIM19_BASE)
-        case (uint32_t)TIM19:
+      case (uint32_t)TIM19:
 #endif
 #if defined(TIM20_BASE)
-        case (uint32_t)TIM20:
+      case (uint32_t)TIM20:
 #endif
 #if defined(TIM21_BASE)
-        case (uint32_t)TIM21:
+      case (uint32_t)TIM21:
 #endif
 #if defined(TIM22_BASE)
-        case (uint32_t)TIM22:
+      case (uint32_t)TIM22:
 #endif
-            clkSrc = 2;
-            break;
-        default:
-            core_debug("TIM: Unknown timer instance");
-            break;
-        }
+        clkSrc = 2;
+        break;
+      default:
+        core_debug("TIM: Unknown timer instance");
+        break;
     }
+  }
 #endif
-    return clkSrc;
+  return clkSrc;
 }
 
 /**
@@ -669,122 +669,121 @@ uint8_t getTimerClkSrc(TIM_TypeDef *tim)
   */
 uint32_t getTimerClkFreq(TIM_TypeDef *tim)
 {
-    RCC_ClkInitTypeDef    clkconfig = {};
-    uint32_t              pFLatency = 0U;
-    uint32_t              uwTimclock = 0U, uwAPBxPrescaler = 0U;
+  RCC_ClkInitTypeDef    clkconfig = {};
+  uint32_t              pFLatency = 0U;
+  uint32_t              uwTimclock = 0U, uwAPBxPrescaler = 0U;
 
-    /* Get clock configuration */
-    HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
-    switch (getTimerClkSrc(tim)) {
+  /* Get clock configuration */
+  HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
+  switch (getTimerClkSrc(tim)) {
     case 1:
-        uwAPBxPrescaler = clkconfig.APB1CLKDivider;
-        uwTimclock = HAL_RCC_GetPCLK1Freq();
-        break;
+      uwAPBxPrescaler = clkconfig.APB1CLKDivider;
+      uwTimclock = HAL_RCC_GetPCLK1Freq();
+      break;
 #ifndef STM32F0xx
     case 2:
-        uwAPBxPrescaler = clkconfig.APB2CLKDivider;
-        uwTimclock = HAL_RCC_GetPCLK2Freq();
-        break;
+      uwAPBxPrescaler = clkconfig.APB2CLKDivider;
+      uwTimclock = HAL_RCC_GetPCLK2Freq();
+      break;
 #endif
     default:
     case 0:
-        core_debug("TIM: Unknown clock source");
-        break;
-    }
+      core_debug("TIM: Unknown clock source");
+      break;
+  }
 
 #if defined(STM32H7xx)
-    /* When TIMPRE bit of the RCC_CFGR register is reset,
-     *   if APBx prescaler is 1 or 2 then TIMxCLK = HCLK,
-     *   otherwise TIMxCLK = 2x PCLKx.
-     * When TIMPRE bit in the RCC_CFGR register is set,
-     *   if APBx prescaler is 1,2 or 4, then TIMxCLK = HCLK,
-     *   otherwise TIMxCLK = 4x PCLKx
-     */
-    RCC_PeriphCLKInitTypeDef PeriphClkConfig = {};
-    HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkConfig);
+  /* When TIMPRE bit of the RCC_CFGR register is reset,
+   *   if APBx prescaler is 1 or 2 then TIMxCLK = HCLK,
+   *   otherwise TIMxCLK = 2x PCLKx.
+   * When TIMPRE bit in the RCC_CFGR register is set,
+   *   if APBx prescaler is 1,2 or 4, then TIMxCLK = HCLK,
+   *   otherwise TIMxCLK = 4x PCLKx
+   */
+  RCC_PeriphCLKInitTypeDef PeriphClkConfig = {};
+  HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkConfig);
 
-    if (PeriphClkConfig.TIMPresSelection == RCC_TIMPRES_ACTIVATED) {
-        switch (uwAPBxPrescaler) {
-        default:
-        case RCC_APB1_DIV1:
-        case RCC_APB1_DIV2:
-        case RCC_APB1_DIV4:
-        /* case RCC_APB2_DIV1: */
-        case RCC_APB2_DIV2:
-        case RCC_APB2_DIV4:
-            uwTimclock = HAL_RCC_GetHCLKFreq();
-            break;
-        case RCC_APB1_DIV8:
-        case RCC_APB1_DIV16:
-        case RCC_APB2_DIV8:
-        case RCC_APB2_DIV16:
-            uwTimclock *= 4;
-            break;
-        }
-    } else {
-        switch (uwAPBxPrescaler) {
-        default:
-        case RCC_APB1_DIV1:
-        case RCC_APB1_DIV2:
-        /* case RCC_APB2_DIV1: */
-        case RCC_APB2_DIV2:
-            // uwTimclock*=1;
-            uwTimclock = HAL_RCC_GetHCLKFreq();
-            break;
-        case RCC_APB1_DIV4:
-        case RCC_APB1_DIV8:
-        case RCC_APB1_DIV16:
-        case RCC_APB2_DIV4:
-        case RCC_APB2_DIV8:
-        case RCC_APB2_DIV16:
-            uwTimclock *= 2;
-            break;
-        }
+  if (PeriphClkConfig.TIMPresSelection == RCC_TIMPRES_ACTIVATED) {
+    switch (uwAPBxPrescaler) {
+      default:
+      case RCC_APB1_DIV1:
+      case RCC_APB1_DIV2:
+      case RCC_APB1_DIV4:
+      /* case RCC_APB2_DIV1: */
+      case RCC_APB2_DIV2:
+      case RCC_APB2_DIV4:
+        uwTimclock = HAL_RCC_GetHCLKFreq();
+        break;
+      case RCC_APB1_DIV8:
+      case RCC_APB1_DIV16:
+      case RCC_APB2_DIV8:
+      case RCC_APB2_DIV16:
+        uwTimclock *= 4;
+        break;
     }
+  } else {
+    switch (uwAPBxPrescaler) {
+      default:
+      case RCC_APB1_DIV1:
+      case RCC_APB1_DIV2:
+      /* case RCC_APB2_DIV1: */
+      case RCC_APB2_DIV2:
+        // uwTimclock*=1;
+        uwTimclock = HAL_RCC_GetHCLKFreq();
+        break;
+      case RCC_APB1_DIV4:
+      case RCC_APB1_DIV8:
+      case RCC_APB1_DIV16:
+      case RCC_APB2_DIV4:
+      case RCC_APB2_DIV8:
+      case RCC_APB2_DIV16:
+        uwTimclock *= 2;
+        break;
+    }
+  }
 #else
-    /* When TIMPRE bit of the RCC_DCKCFGR register is reset,
-     *   if APBx prescaler is 1, then TIMxCLK = PCLKx,
-     *   otherwise TIMxCLK = 2x PCLKx.
-     * When TIMPRE bit in the RCC_DCKCFGR register is set,
-     *   if APBx prescaler is 1,2 or 4, then TIMxCLK = HCLK,
-     *   otherwise TIMxCLK = 4x PCLKx
-     */
+  /* When TIMPRE bit of the RCC_DCKCFGR register is reset,
+   *   if APBx prescaler is 1, then TIMxCLK = PCLKx,
+   *   otherwise TIMxCLK = 2x PCLKx.
+   * When TIMPRE bit in the RCC_DCKCFGR register is set,
+   *   if APBx prescaler is 1,2 or 4, then TIMxCLK = HCLK,
+   *   otherwise TIMxCLK = 4x PCLKx
+   */
 #if defined(STM32F4xx) || defined(STM32F7xx)
 #if !defined(STM32F405xx) && !defined(STM32F415xx) &&\
     !defined(STM32F407xx) && !defined(STM32F417xx)
-    RCC_PeriphCLKInitTypeDef PeriphClkConfig = {};
-    HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkConfig);
+  RCC_PeriphCLKInitTypeDef PeriphClkConfig = {};
+  HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkConfig);
 
-    if (PeriphClkConfig.TIMPresSelection == RCC_TIMPRES_ACTIVATED)
-        switch (uwAPBxPrescaler) {
-        default:
-        case RCC_HCLK_DIV1:
-        case RCC_HCLK_DIV2:
-        case RCC_HCLK_DIV4:
-            uwTimclock = HAL_RCC_GetHCLKFreq();
-            break;
-        case RCC_HCLK_DIV8:
-        case RCC_HCLK_DIV16:
-            uwTimclock *= 4;
-            break;
-        }
-    else
+  if (PeriphClkConfig.TIMPresSelection == RCC_TIMPRES_ACTIVATED)
+    switch (uwAPBxPrescaler) {
+      default:
+      case RCC_HCLK_DIV1:
+      case RCC_HCLK_DIV2:
+      case RCC_HCLK_DIV4:
+        uwTimclock = HAL_RCC_GetHCLKFreq();
+        break;
+      case RCC_HCLK_DIV8:
+      case RCC_HCLK_DIV16:
+        uwTimclock *= 4;
+        break;
+    } else
 #endif
 #endif
-        switch (uwAPBxPrescaler) {
-        default:
-        case RCC_HCLK_DIV1:
-            // uwTimclock*=1;
-            break;
-        case RCC_HCLK_DIV2:
-        case RCC_HCLK_DIV4:
-        case RCC_HCLK_DIV8:
-        case RCC_HCLK_DIV16:
-            uwTimclock *= 2;
-            break;
-        }
+    switch (uwAPBxPrescaler) {
+      default:
+      case RCC_HCLK_DIV1:
+        // uwTimclock*=1;
+        break;
+      case RCC_HCLK_DIV2:
+      case RCC_HCLK_DIV4:
+      case RCC_HCLK_DIV8:
+      case RCC_HCLK_DIV16:
+        uwTimclock *= 2;
+        break;
+    }
 #endif /* STM32H7xx */
-    return uwTimclock;
+  return uwTimclock;
 }
 
 
@@ -798,45 +797,45 @@ uint32_t getTimerClkFreq(TIM_TypeDef *tim)
   */
 void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(stimer_t *, uint32_t))
 {
-    TIM_OC_InitTypeDef sConfig = {};
-    TIM_HandleTypeDef *handle = &(obj->handle);
-    if (obj->timer == NULL) {
-        obj->timer = TIMER_SERVO;
-    }
+  TIM_OC_InitTypeDef sConfig = {};
+  TIM_HandleTypeDef *handle = &(obj->handle);
+  if (obj->timer == NULL) {
+    obj->timer = TIMER_SERVO;
+  }
 
-    //min pulse = 1us - max pulse = 65535us
-    handle->Instance               = obj->timer;
-    handle->Init.Period            = period;
-    handle->Init.Prescaler         = (uint32_t)(getTimerClkFreq(obj->timer) / (1000000)) - 1;
-    handle->Init.ClockDivision     = 0;
-    handle->Init.CounterMode       = TIM_COUNTERMODE_UP;
+  //min pulse = 1us - max pulse = 65535us
+  handle->Instance               = obj->timer;
+  handle->Init.Period            = period;
+  handle->Init.Prescaler         = (uint32_t)(getTimerClkFreq(obj->timer) / (1000000)) - 1;
+  handle->Init.ClockDivision     = 0;
+  handle->Init.CounterMode       = TIM_COUNTERMODE_UP;
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
-    handle->Init.RepetitionCounter = 0;
+  handle->Init.RepetitionCounter = 0;
 #endif
-    obj->irqHandleOC = irqHandle;
+  obj->irqHandleOC = irqHandle;
 
-    sConfig.OCMode        = TIM_OCMODE_TIMING;
-    sConfig.Pulse         = pulseWidth;
-    sConfig.OCPolarity    = TIM_OCPOLARITY_HIGH;
-    sConfig.OCFastMode    = TIM_OCFAST_DISABLE;
+  sConfig.OCMode        = TIM_OCMODE_TIMING;
+  sConfig.Pulse         = pulseWidth;
+  sConfig.OCPolarity    = TIM_OCPOLARITY_HIGH;
+  sConfig.OCFastMode    = TIM_OCFAST_DISABLE;
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
-    sConfig.OCNPolarity   = TIM_OCNPOLARITY_HIGH;
-    sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
-    sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
+  sConfig.OCNPolarity   = TIM_OCNPOLARITY_HIGH;
+  sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
+  sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
 #endif
-    HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
-    HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
+  HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
+  HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
 
-    if (HAL_TIM_OC_Init(handle) != HAL_OK) {
-        return;
-    }
+  if (HAL_TIM_OC_Init(handle) != HAL_OK) {
+    return;
+  }
 
-    if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_1) != HAL_OK) {
-        return;
-    }
-    if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
-        return;
-    }
+  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_1) != HAL_OK) {
+    return;
+  }
+  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
+    return;
+  }
 }
 
 /**
@@ -849,66 +848,66 @@ void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*
   */
 void attachIntHandleOC(stimer_t *obj, void (*irqHandle)(void), uint16_t timChannel, uint16_t pulseWidth)
 {
-    TIM_OC_InitTypeDef sConfig = {};
-    TIM_HandleTypeDef *handle = &(obj->handle);
+  TIM_OC_InitTypeDef sConfig = {};
+  TIM_HandleTypeDef *handle = &(obj->handle);
 
-    sConfig.OCMode        = TIM_OCMODE_TIMING;
-    sConfig.Pulse         = pulseWidth;
-    sConfig.OCPolarity    = TIM_OCPOLARITY_HIGH;
-    sConfig.OCFastMode    = TIM_OCFAST_DISABLE;
+  sConfig.OCMode        = TIM_OCMODE_TIMING;
+  sConfig.Pulse         = pulseWidth;
+  sConfig.OCPolarity    = TIM_OCPOLARITY_HIGH;
+  sConfig.OCFastMode    = TIM_OCFAST_DISABLE;
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
-    sConfig.OCNPolarity   = TIM_OCNPOLARITY_HIGH;
-    sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
-    sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
+  sConfig.OCNPolarity   = TIM_OCNPOLARITY_HIGH;
+  sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
+  sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
 #endif
-    //HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
-    //HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
+  //HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
+  //HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
 
-    if (HAL_TIM_OC_Init(handle) != HAL_OK) {
-        return;
-    }
-    switch (timChannel) {
-    case 1:
-        obj->irqHandleOC_CH1 = irqHandle;
-        if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
-            return;
-        }
-        if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_1) != HAL_OK) {
-            return;
-        }
-        break;
-    case 2:
-        obj->irqHandleOC_CH2 = irqHandle;
-        if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_2) != HAL_OK) {
-            return;
-        }
-        if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_2) != HAL_OK) {
-            return;
-        }
-        break;
-    case 3:
-        obj->irqHandleOC_CH3 = irqHandle;
-        if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_3) != HAL_OK) {
-            return;
-        }
-        if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_3) != HAL_OK) {
-            return;
-        }
-        break;
-    case 4:
-        obj->irqHandleOC_CH4 = irqHandle;
-        if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_4) != HAL_OK) {
-            return;
-        }
-        if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_4) != HAL_OK) {
-            return;
-        }
-        break;
-    default:
-        return;
-        break;
-    }
+  if (HAL_TIM_OC_Init(handle) != HAL_OK) {
     return;
+  }
+  switch (timChannel) {
+    case 1:
+      obj->irqHandleOC_CH1 = irqHandle;
+      if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
+        return;
+      }
+      if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_1) != HAL_OK) {
+        return;
+      }
+      break;
+    case 2:
+      obj->irqHandleOC_CH2 = irqHandle;
+      if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_2) != HAL_OK) {
+        return;
+      }
+      if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_2) != HAL_OK) {
+        return;
+      }
+      break;
+    case 3:
+      obj->irqHandleOC_CH3 = irqHandle;
+      if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_3) != HAL_OK) {
+        return;
+      }
+      if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_3) != HAL_OK) {
+        return;
+      }
+      break;
+    case 4:
+      obj->irqHandleOC_CH4 = irqHandle;
+      if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_4) != HAL_OK) {
+        return;
+      }
+      if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_4) != HAL_OK) {
+        return;
+      }
+      break;
+    default:
+      return;
+      break;
+  }
+  return;
 }
 
 
@@ -920,21 +919,21 @@ void attachIntHandleOC(stimer_t *obj, void (*irqHandle)(void), uint16_t timChann
   */
 void TimerPulseDeinit(stimer_t *obj)
 {
-    TIM_HandleTypeDef *handle = &(obj->handle);
-    obj->irqHandleOC = NULL;
-    obj->irqHandleOC_CH1 = NULL;
-    obj->irqHandleOC_CH2 = NULL;
-    obj->irqHandleOC_CH3 = NULL;
-    obj->irqHandleOC_CH4 = NULL;
+  TIM_HandleTypeDef *handle = &(obj->handle);
+  obj->irqHandleOC = NULL;
+  obj->irqHandleOC_CH1 = NULL;
+  obj->irqHandleOC_CH2 = NULL;
+  obj->irqHandleOC_CH3 = NULL;
+  obj->irqHandleOC_CH4 = NULL;
 
-    HAL_NVIC_DisableIRQ(getTimerIrq(obj->timer));
+  HAL_NVIC_DisableIRQ(getTimerIrq(obj->timer));
 
-    if (HAL_TIM_OC_DeInit(handle) != HAL_OK) {
-        return;
-    }
-    if (HAL_TIM_OC_Stop_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
-        return;
-    }
+  if (HAL_TIM_OC_DeInit(handle) != HAL_OK) {
+    return;
+  }
+  if (HAL_TIM_OC_Stop_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
+    return;
+  }
 }
 
 /**
@@ -944,7 +943,7 @@ void TimerPulseDeinit(stimer_t *obj)
   */
 void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim)
 {
-    timer_enable_clock(htim);
+  timer_enable_clock(htim);
 }
 
 /**
@@ -954,7 +953,7 @@ void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim)
   */
 void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim)
 {
-    timer_disable_clock(htim);
+  timer_disable_clock(htim);
 }
 
 /* Aim of the function is to get timer_s pointer using htim pointer */
@@ -962,13 +961,13 @@ void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim)
 /* (which was not directly used since not compatible with IAR toolchain) */
 stimer_t *get_timer_obj(TIM_HandleTypeDef *htim)
 {
-    struct timer_s *obj_s;
-    stimer_t *obj;
+  struct timer_s *obj_s;
+  stimer_t *obj;
 
-    obj_s = (struct timer_s *)((char *)htim - offsetof(struct timer_s, handle));
-    obj = (stimer_t *)((char *)obj_s - offsetof(stimer_t, timer));
+  obj_s = (struct timer_s *)((char *)htim - offsetof(struct timer_s, handle));
+  obj = (stimer_t *)((char *)obj_s - offsetof(stimer_t, timer));
 
-    return (obj);
+  return (obj);
 }
 
 /**
@@ -978,42 +977,42 @@ stimer_t *get_timer_obj(TIM_HandleTypeDef *htim)
   */
 void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
 {
-    uint32_t channel = 0;
-    stimer_t *obj = get_timer_obj(htim);
-    switch (htim->Channel) {
+  uint32_t channel = 0;
+  stimer_t *obj = get_timer_obj(htim);
+  switch (htim->Channel) {
     case HAL_TIM_ACTIVE_CHANNEL_1:
-        channel = TIM_CHANNEL_1 / 4;
-        if (obj->irqHandleOC_CH1 != NULL) {
-            obj->irqHandleOC_CH1();
-        }
-        break;
+      channel = TIM_CHANNEL_1 / 4;
+      if (obj->irqHandleOC_CH1 != NULL) {
+        obj->irqHandleOC_CH1();
+      }
+      break;
     case HAL_TIM_ACTIVE_CHANNEL_2:
-        channel = TIM_CHANNEL_2 / 4;
-        if (obj->irqHandleOC_CH2 != NULL) {
-            obj->irqHandleOC_CH2();
-        }
-        break;
+      channel = TIM_CHANNEL_2 / 4;
+      if (obj->irqHandleOC_CH2 != NULL) {
+        obj->irqHandleOC_CH2();
+      }
+      break;
     case HAL_TIM_ACTIVE_CHANNEL_3:
-        if (obj->irqHandleOC_CH3 != NULL) {
-            obj->irqHandleOC_CH3();
-        }
-        channel = TIM_CHANNEL_3 / 4;
-        break;
+      if (obj->irqHandleOC_CH3 != NULL) {
+        obj->irqHandleOC_CH3();
+      }
+      channel = TIM_CHANNEL_3 / 4;
+      break;
     case HAL_TIM_ACTIVE_CHANNEL_4:
-        if (obj->irqHandleOC_CH4 != NULL) {
-            obj->irqHandleOC_CH4();
-        }
-        channel = TIM_CHANNEL_4 / 4;
-        break;
+      if (obj->irqHandleOC_CH4 != NULL) {
+        obj->irqHandleOC_CH4();
+      }
+      channel = TIM_CHANNEL_4 / 4;
+      break;
     default:
-        return;
-        break;
-    }
+      return;
+      break;
+  }
 
-    //make it compatible with older versions
-    if (obj->irqHandleOC != NULL) {
-        obj->irqHandleOC(obj, channel);
-    }
+  //make it compatible with older versions
+  if (obj->irqHandleOC != NULL) {
+    obj->irqHandleOC(obj, channel);
+  }
 
 }
 
@@ -1024,19 +1023,19 @@ void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
   */
 void HAL_TIMx_PeriodElapsedCallback(stimer_t *obj)
 {
-    GPIO_TypeDef *port = get_GPIO_Port(STM_PORT(obj->pin));
+  GPIO_TypeDef *port = get_GPIO_Port(STM_PORT(obj->pin));
 
-    if (port != NULL) {
-        if (obj->pinInfo.count != 0) {
-            if (obj->pinInfo.count > 0) {
-                obj->pinInfo.count--;
-            }
-            obj->pinInfo.state = (obj->pinInfo.state == 0) ? 1 : 0;
-            digital_io_write(port, STM_LL_GPIO_PIN(obj->pin), obj->pinInfo.state);
-        } else {
-            digital_io_write(port, STM_LL_GPIO_PIN(obj->pin), 0);
-        }
+  if (port != NULL) {
+    if (obj->pinInfo.count != 0) {
+      if (obj->pinInfo.count > 0) {
+        obj->pinInfo.count--;
+      }
+      obj->pinInfo.state = (obj->pinInfo.state == 0) ? 1 : 0;
+      digital_io_write(port, STM_LL_GPIO_PIN(obj->pin), obj->pinInfo.state);
+    } else {
+      digital_io_write(port, STM_LL_GPIO_PIN(obj->pin), 0);
     }
+  }
 }
 
 /**
@@ -1046,11 +1045,11 @@ void HAL_TIMx_PeriodElapsedCallback(stimer_t *obj)
   */
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
-    stimer_t *obj = get_timer_obj(htim);
+  stimer_t *obj = get_timer_obj(htim);
 
-    if (obj->irqHandle != NULL) {
-        obj->irqHandle(obj);
-    }
+  if (obj->irqHandle != NULL) {
+    obj->irqHandle(obj);
+  }
 }
 
 /**
@@ -1064,56 +1063,56 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
   */
 void TimerPinInit(stimer_t *obj, uint32_t frequency, uint32_t duration)
 {
-    uint8_t end = 0;
-    uint32_t timClkFreq = 0;
-    // TIMER_TONE freq is twice frequency
-    uint32_t timFreq = 2 * frequency;
-    uint32_t prescaler = 1;
-    uint32_t period = 0;
-    uint32_t scale = 0;
+  uint8_t end = 0;
+  uint32_t timClkFreq = 0;
+  // TIMER_TONE freq is twice frequency
+  uint32_t timFreq = 2 * frequency;
+  uint32_t prescaler = 1;
+  uint32_t period = 0;
+  uint32_t scale = 0;
 
-    if (frequency > MAX_FREQ) {
-        return;
+  if (frequency > MAX_FREQ) {
+    return;
+  }
+
+  obj->timer = TIMER_TONE;
+  obj->pinInfo.state = 0;
+
+  if (frequency == 0) {
+    TimerPinDeinit(obj);
+    return;
+  }
+
+  //Calculate the toggle count
+  if (duration > 0) {
+    obj->pinInfo.count = ((timFreq * duration) / 1000);
+  } else {
+    obj->pinInfo.count = -1;
+  }
+
+  pin_function(obj->pin, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0));
+  timClkFreq = getTimerClkFreq(obj->timer);
+
+  // Do this once
+  scale = timClkFreq / timFreq;
+  while (end == 0) {
+    period = ((uint32_t)(scale / prescaler)) - 1;
+
+    if ((period >= 0xFFFF) && (prescaler < 0xFFFF)) {
+      prescaler++;  //prescaler *= 2;
     }
 
-    obj->timer = TIMER_TONE;
-    obj->pinInfo.state = 0;
-
-    if (frequency == 0) {
-        TimerPinDeinit(obj);
-        return;
+    else {
+      end = 1;
     }
+  }
 
-    //Calculate the toggle count
-    if (duration > 0) {
-        obj->pinInfo.count = ((timFreq * duration) / 1000);
-    } else {
-        obj->pinInfo.count = -1;
-    }
-
-    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0));
-    timClkFreq = getTimerClkFreq(obj->timer);
-
-    // Do this once
-    scale = timClkFreq / timFreq;
-    while (end == 0) {
-        period = ((uint32_t)(scale / prescaler)) - 1;
-
-        if ((period >= 0xFFFF) && (prescaler < 0xFFFF)) {
-            prescaler++;  //prescaler *= 2;
-        }
-
-        else {
-            end = 1;
-        }
-    }
-
-    if ((period < 0xFFFF) && (prescaler < 0xFFFF)) {
-        obj->irqHandle = HAL_TIMx_PeriodElapsedCallback;
-        TimerHandleInit(obj, period, prescaler - 1);
-    } else {
-        TimerHandleDeinit(obj);
-    }
+  if ((period < 0xFFFF) && (prescaler < 0xFFFF)) {
+    obj->irqHandle = HAL_TIMx_PeriodElapsedCallback;
+    TimerHandleInit(obj, period, prescaler - 1);
+  } else {
+    TimerHandleDeinit(obj);
+  }
 }
 
 /**
@@ -1124,8 +1123,8 @@ void TimerPinInit(stimer_t *obj, uint32_t frequency, uint32_t duration)
   */
 void TimerPinDeinit(stimer_t *obj)
 {
-    TimerHandleDeinit(obj);
-    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+  TimerHandleDeinit(obj);
+  pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
 }
 
 /**
@@ -1135,7 +1134,7 @@ void TimerPinDeinit(stimer_t *obj)
   */
 uint32_t getTimerCounter(stimer_t *obj)
 {
-    return __HAL_TIM_GET_COUNTER(&(obj->handle));
+  return __HAL_TIM_GET_COUNTER(&(obj->handle));
 }
 
 /**
@@ -1146,7 +1145,7 @@ uint32_t getTimerCounter(stimer_t *obj)
   */
 void setTimerCounter(stimer_t *obj, uint32_t value)
 {
-    __HAL_TIM_SET_COUNTER(&(obj->handle), value);
+  __HAL_TIM_SET_COUNTER(&(obj->handle), value);
 }
 
 /**
@@ -1158,7 +1157,7 @@ void setTimerCounter(stimer_t *obj, uint32_t value)
   */
 void setCCRRegister(stimer_t *obj, uint32_t channel, uint32_t value)
 {
-    __HAL_TIM_SET_COMPARE(&(obj->handle), channel * 4, value);
+  __HAL_TIM_SET_COMPARE(&(obj->handle), channel * 4, value);
 }
 
 /**
@@ -1169,7 +1168,7 @@ void setCCRRegister(stimer_t *obj, uint32_t channel, uint32_t value)
   */
 uint32_t getCCRRegister(stimer_t *obj, uint32_t channel)
 {
-    return __HAL_TIM_GET_COMPARE(&(obj->handle), channel);
+  return __HAL_TIM_GET_COMPARE(&(obj->handle), channel);
 }
 
 /**
@@ -1180,7 +1179,7 @@ uint32_t getCCRRegister(stimer_t *obj, uint32_t channel)
   */
 void attachIntHandle(stimer_t *obj, void (*irqHandle)(stimer_t *))
 {
-    obj->irqHandle = irqHandle;
+  obj->irqHandle = irqHandle;
 }
 
 
@@ -1196,23 +1195,23 @@ void attachIntHandle(stimer_t *obj, void (*irqHandle)(stimer_t *))
   */
 void TIM1_IRQHandler(void)
 {
-    if (timer_handles[0] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[0]);
-    }
+  if (timer_handles[0] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[0]);
+  }
 
 #if defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32F7xx)
 #if defined (TIM10_BASE)
-    if (timer_handles[9] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[9]);
-    }
+  if (timer_handles[9] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[9]);
+  }
 #endif
 #endif
 
 #if defined(STM32F1xx) || defined(STM32F3xx) || defined(STM32L4xx)
 #if defined (TIM16_BASE)
-    if (timer_handles[15] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[15]);
-    }
+  if (timer_handles[15] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[15]);
+  }
 #endif
 #endif
 }
@@ -1226,9 +1225,9 @@ void TIM1_IRQHandler(void)
   */
 void TIM2_IRQHandler(void)
 {
-    if (timer_handles[1] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[1]);
-    }
+  if (timer_handles[1] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[1]);
+  }
 }
 #endif //TIM2_BASE
 
@@ -1240,9 +1239,9 @@ void TIM2_IRQHandler(void)
   */
 void TIM3_IRQHandler(void)
 {
-    if (timer_handles[2] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[2]);
-    }
+  if (timer_handles[2] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[2]);
+  }
 }
 #endif //TIM3_BASE
 
@@ -1254,9 +1253,9 @@ void TIM3_IRQHandler(void)
   */
 void TIM4_IRQHandler(void)
 {
-    if (timer_handles[3] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[3]);
-    }
+  if (timer_handles[3] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[3]);
+  }
 }
 #endif //TIM4_BASE
 
@@ -1268,9 +1267,9 @@ void TIM4_IRQHandler(void)
   */
 void TIM5_IRQHandler(void)
 {
-    if (timer_handles[4] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[4]);
-    }
+  if (timer_handles[4] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[4]);
+  }
 }
 #endif //TIM5_BASE
 
@@ -1282,9 +1281,9 @@ void TIM5_IRQHandler(void)
   */
 void TIM6_IRQHandler(void)
 {
-    if (timer_handles[5] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[5]);
-    }
+  if (timer_handles[5] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[5]);
+  }
 }
 #endif //TIM6_BASE
 
@@ -1296,9 +1295,9 @@ void TIM6_IRQHandler(void)
   */
 void TIM7_IRQHandler(void)
 {
-    if (timer_handles[6] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[6]);
-    }
+  if (timer_handles[6] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[6]);
+  }
 }
 #endif //TIM7_BASE
 
@@ -1310,14 +1309,14 @@ void TIM7_IRQHandler(void)
   */
 void TIM8_IRQHandler(void)
 {
-    if (timer_handles[7] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[7]);
-    }
+  if (timer_handles[7] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[7]);
+  }
 
 #if defined(STM32F1xx) || defined(STM32F2xx) ||defined(STM32F4xx) || defined(STM32F7xx)
-    if (timer_handles[12] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[12]);
-    }
+  if (timer_handles[12] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[12]);
+  }
 #endif
 }
 #endif //TIM8_BASE
@@ -1330,9 +1329,9 @@ void TIM8_IRQHandler(void)
   */
 void TIM9_IRQHandler(void)
 {
-    if (timer_handles[8] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[8]);
-    }
+  if (timer_handles[8] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[8]);
+  }
 }
 #endif //TIM9_BASE
 
@@ -1345,9 +1344,9 @@ void TIM9_IRQHandler(void)
   */
 void TIM10_IRQHandler(void)
 {
-    if (timer_handles[9] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[9]);
-    }
+  if (timer_handles[9] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[9]);
+  }
 }
 #endif
 #endif //TIM10_BASE
@@ -1360,9 +1359,9 @@ void TIM10_IRQHandler(void)
   */
 void TIM11_IRQHandler(void)
 {
-    if (timer_handles[10] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[10]);
-    }
+  if (timer_handles[10] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[10]);
+  }
 }
 #endif //TIM11_BASE
 
@@ -1374,9 +1373,9 @@ void TIM11_IRQHandler(void)
   */
 void TIM12_IRQHandler(void)
 {
-    if (timer_handles[11] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[11]);
-    }
+  if (timer_handles[11] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[11]);
+  }
 }
 #endif //TIM12_BASE
 
@@ -1389,9 +1388,9 @@ void TIM12_IRQHandler(void)
   */
 void TIM13_IRQHandler(void)
 {
-    if (timer_handles[12] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[12]);
-    }
+  if (timer_handles[12] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[12]);
+  }
 }
 #endif
 #endif //TIM13_BASE
@@ -1404,9 +1403,9 @@ void TIM13_IRQHandler(void)
   */
 void TIM14_IRQHandler(void)
 {
-    if (timer_handles[13] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[13]);
-    }
+  if (timer_handles[13] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[13]);
+  }
 }
 #endif //TIM14_BASE
 
@@ -1418,9 +1417,9 @@ void TIM14_IRQHandler(void)
   */
 void TIM15_IRQHandler(void)
 {
-    if (timer_handles[14] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[14]);
-    }
+  if (timer_handles[14] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[14]);
+  }
 }
 #endif //TIM15_BASE
 
@@ -1433,9 +1432,9 @@ void TIM15_IRQHandler(void)
   */
 void TIM16_IRQHandler(void)
 {
-    if (timer_handles[15] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[15]);
-    }
+  if (timer_handles[15] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[15]);
+  }
 }
 #endif
 #endif //TIM16_BASE
@@ -1448,9 +1447,9 @@ void TIM16_IRQHandler(void)
   */
 void TIM17_IRQHandler(void)
 {
-    if (timer_handles[16] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[16]);
-    }
+  if (timer_handles[16] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[16]);
+  }
 }
 #endif //TIM17_BASE
 
@@ -1462,9 +1461,9 @@ void TIM17_IRQHandler(void)
   */
 void TIM18_IRQHandler(void)
 {
-    if (timer_handles[17] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[17]);
-    }
+  if (timer_handles[17] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[17]);
+  }
 }
 #endif //TIM18_BASE
 
@@ -1476,9 +1475,9 @@ void TIM18_IRQHandler(void)
   */
 void TIM19_IRQHandler(void)
 {
-    if (timer_handles[18] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[18]);
-    }
+  if (timer_handles[18] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[18]);
+  }
 }
 #endif //TIM19_BASE
 
@@ -1490,9 +1489,9 @@ void TIM19_IRQHandler(void)
   */
 void TIM20_IRQHandler(void)
 {
-    if (timer_handles[19] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[19]);
-    }
+  if (timer_handles[19] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[19]);
+  }
 }
 #endif //TIM20_BASE
 
@@ -1504,9 +1503,9 @@ void TIM20_IRQHandler(void)
   */
 void TIM21_IRQHandler(void)
 {
-    if (timer_handles[20] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[20]);
-    }
+  if (timer_handles[20] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[20]);
+  }
 }
 #endif //TIM21_BASE
 
@@ -1518,9 +1517,9 @@ void TIM21_IRQHandler(void)
   */
 void TIM22_IRQHandler(void)
 {
-    if (timer_handles[21] != NULL) {
-        HAL_TIM_IRQHandler(timer_handles[21]);
-    }
+  if (timer_handles[21] != NULL) {
+    HAL_TIM_IRQHandler(timer_handles[21]);
+  }
 }
 #endif //TIM22_BASE
 

--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -799,7 +799,8 @@ void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*
 {
   TIM_OC_InitTypeDef sConfig = {};
   TIM_HandleTypeDef *handle = &(obj->handle);
-  if (obj->timer == NULL) {
+  
+  if (obj->timer == 0x00) {
     obj->timer = TIMER_SERVO;
   }
 

--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -111,138 +111,138 @@ static TIM_HandleTypeDef *timer_handles[TIMER_NUM] = {NULL};
   */
 void timer_enable_clock(TIM_HandleTypeDef *htim)
 {
-  // Enable TIM clock
+    // Enable TIM clock
 #if defined(TIM1_BASE)
-  if (htim->Instance == TIM1) {
-    __HAL_RCC_TIM1_CLK_ENABLE();
-    timer_handles[0] = htim;
-  }
+    if (htim->Instance == TIM1) {
+        __HAL_RCC_TIM1_CLK_ENABLE();
+        timer_handles[0] = htim;
+    }
 #endif
 #if defined(TIM2_BASE)
-  if (htim->Instance == TIM2) {
-    __HAL_RCC_TIM2_CLK_ENABLE();
-    timer_handles[1] = htim;
-  }
+    if (htim->Instance == TIM2) {
+        __HAL_RCC_TIM2_CLK_ENABLE();
+        timer_handles[1] = htim;
+    }
 #endif
 #if defined(TIM3_BASE)
-  if (htim->Instance == TIM3) {
-    __HAL_RCC_TIM3_CLK_ENABLE();
-    timer_handles[2] = htim;
-  }
+    if (htim->Instance == TIM3) {
+        __HAL_RCC_TIM3_CLK_ENABLE();
+        timer_handles[2] = htim;
+    }
 #endif
 #if defined(TIM4_BASE)
-  if (htim->Instance == TIM4) {
-    __HAL_RCC_TIM4_CLK_ENABLE();
-    timer_handles[3] = htim;
-  }
+    if (htim->Instance == TIM4) {
+        __HAL_RCC_TIM4_CLK_ENABLE();
+        timer_handles[3] = htim;
+    }
 #endif
 #if defined(TIM5_BASE)
-  if (htim->Instance == TIM5) {
-    __HAL_RCC_TIM5_CLK_ENABLE();
-    timer_handles[4] = htim;
-  }
+    if (htim->Instance == TIM5) {
+        __HAL_RCC_TIM5_CLK_ENABLE();
+        timer_handles[4] = htim;
+    }
 #endif
 #if defined(TIM6_BASE)
-  if (htim->Instance == TIM6) {
-    __HAL_RCC_TIM6_CLK_ENABLE();
-    timer_handles[5] = htim;
-  }
+    if (htim->Instance == TIM6) {
+        __HAL_RCC_TIM6_CLK_ENABLE();
+        timer_handles[5] = htim;
+    }
 #endif
 #if defined(TIM7_BASE)
-  if (htim->Instance == TIM7) {
-    __HAL_RCC_TIM7_CLK_ENABLE();
-    timer_handles[6] = htim;
-  }
+    if (htim->Instance == TIM7) {
+        __HAL_RCC_TIM7_CLK_ENABLE();
+        timer_handles[6] = htim;
+    }
 #endif
 #if defined(TIM8_BASE)
-  if (htim->Instance == TIM8) {
-    __HAL_RCC_TIM8_CLK_ENABLE();
-    timer_handles[7] = htim;
-  }
+    if (htim->Instance == TIM8) {
+        __HAL_RCC_TIM8_CLK_ENABLE();
+        timer_handles[7] = htim;
+    }
 #endif
 #if defined(TIM9_BASE)
-  if (htim->Instance == TIM9) {
-    __HAL_RCC_TIM9_CLK_ENABLE();
-    timer_handles[8] = htim;
-  }
+    if (htim->Instance == TIM9) {
+        __HAL_RCC_TIM9_CLK_ENABLE();
+        timer_handles[8] = htim;
+    }
 #endif
 #if defined(TIM10_BASE)
-  if (htim->Instance == TIM10) {
-    __HAL_RCC_TIM10_CLK_ENABLE();
-    timer_handles[9] = htim;
-  }
+    if (htim->Instance == TIM10) {
+        __HAL_RCC_TIM10_CLK_ENABLE();
+        timer_handles[9] = htim;
+    }
 #endif
 #if defined(TIM11_BASE)
-  if (htim->Instance == TIM11) {
-    __HAL_RCC_TIM11_CLK_ENABLE();
-    timer_handles[10] = htim;
-  }
+    if (htim->Instance == TIM11) {
+        __HAL_RCC_TIM11_CLK_ENABLE();
+        timer_handles[10] = htim;
+    }
 #endif
 #if defined(TIM12_BASE)
-  if (htim->Instance == TIM12) {
-    __HAL_RCC_TIM12_CLK_ENABLE();
-    timer_handles[11] = htim;
-  }
+    if (htim->Instance == TIM12) {
+        __HAL_RCC_TIM12_CLK_ENABLE();
+        timer_handles[11] = htim;
+    }
 #endif
 #if defined(TIM13_BASE)
-  if (htim->Instance == TIM13) {
-    __HAL_RCC_TIM13_CLK_ENABLE();
-    timer_handles[12] = htim;
-  }
+    if (htim->Instance == TIM13) {
+        __HAL_RCC_TIM13_CLK_ENABLE();
+        timer_handles[12] = htim;
+    }
 #endif
 #if defined(TIM14_BASE)
-  if (htim->Instance == TIM14) {
-    __HAL_RCC_TIM14_CLK_ENABLE();
-    timer_handles[13] = htim;
-  }
+    if (htim->Instance == TIM14) {
+        __HAL_RCC_TIM14_CLK_ENABLE();
+        timer_handles[13] = htim;
+    }
 #endif
 #if defined(TIM15_BASE)
-  if (htim->Instance == TIM15) {
-    __HAL_RCC_TIM15_CLK_ENABLE();
-    timer_handles[14] = htim;
-  }
+    if (htim->Instance == TIM15) {
+        __HAL_RCC_TIM15_CLK_ENABLE();
+        timer_handles[14] = htim;
+    }
 #endif
 #if defined(TIM16_BASE)
-  if (htim->Instance == TIM16) {
-    __HAL_RCC_TIM16_CLK_ENABLE();
-    timer_handles[15] = htim;
-  }
+    if (htim->Instance == TIM16) {
+        __HAL_RCC_TIM16_CLK_ENABLE();
+        timer_handles[15] = htim;
+    }
 #endif
 #if defined(TIM17_BASE)
-  if (htim->Instance == TIM17) {
-    __HAL_RCC_TIM17_CLK_ENABLE();
-    timer_handles[16] = htim;
-  }
+    if (htim->Instance == TIM17) {
+        __HAL_RCC_TIM17_CLK_ENABLE();
+        timer_handles[16] = htim;
+    }
 #endif
 #if defined(TIM18_BASE)
-  if (htim->Instance == TIM18) {
-    __HAL_RCC_TIM18_CLK_ENABLE();
-    timer_handles[17] = htim;
-  }
+    if (htim->Instance == TIM18) {
+        __HAL_RCC_TIM18_CLK_ENABLE();
+        timer_handles[17] = htim;
+    }
 #endif
 #if defined(TIM19_BASE)
-  if (htim->Instance == TIM19) {
-    __HAL_RCC_TIM19_CLK_ENABLE();
-    timer_handles[18] = htim;
-  }
+    if (htim->Instance == TIM19) {
+        __HAL_RCC_TIM19_CLK_ENABLE();
+        timer_handles[18] = htim;
+    }
 #endif
 #if defined(TIM20_BASE)
-  if (htim->Instance == TIM20) {
-    __HAL_RCC_TIM20_CLK_ENABLE();
-    timer_handles[19] = htim;
-  }
+    if (htim->Instance == TIM20) {
+        __HAL_RCC_TIM20_CLK_ENABLE();
+        timer_handles[19] = htim;
+    }
 #endif
 #if defined(TIM21_BASE)
-  if (htim->Instance == TIM21) {
-    __HAL_RCC_TIM21_CLK_ENABLE();
-    timer_handles[20] = htim;
-  }
+    if (htim->Instance == TIM21) {
+        __HAL_RCC_TIM21_CLK_ENABLE();
+        timer_handles[20] = htim;
+    }
 #endif
 #if defined(TIM22_BASE)
-  if (htim->Instance == TIM22) {
-    __HAL_RCC_TIM22_CLK_ENABLE();
-    timer_handles[21] = htim;
-  }
+    if (htim->Instance == TIM22) {
+        __HAL_RCC_TIM22_CLK_ENABLE();
+        timer_handles[21] = htim;
+    }
 #endif
 }
 
@@ -253,116 +253,116 @@ void timer_enable_clock(TIM_HandleTypeDef *htim)
   */
 void timer_disable_clock(TIM_HandleTypeDef *htim)
 {
-  // Enable TIM clock
+    // Enable TIM clock
 #if defined(TIM1_BASE)
-  if (htim->Instance == TIM1) {
-    __HAL_RCC_TIM1_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM1) {
+        __HAL_RCC_TIM1_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM2_BASE)
-  if (htim->Instance == TIM2) {
-    __HAL_RCC_TIM2_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM2) {
+        __HAL_RCC_TIM2_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM3_BASE)
-  if (htim->Instance == TIM3) {
-    __HAL_RCC_TIM3_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM3) {
+        __HAL_RCC_TIM3_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM4_BASE)
-  if (htim->Instance == TIM4) {
-    __HAL_RCC_TIM4_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM4) {
+        __HAL_RCC_TIM4_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM5_BASE)
-  if (htim->Instance == TIM5) {
-    __HAL_RCC_TIM5_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM5) {
+        __HAL_RCC_TIM5_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM6_BASE)
-  if (htim->Instance == TIM6) {
-    __HAL_RCC_TIM6_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM6) {
+        __HAL_RCC_TIM6_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM7_BASE)
-  if (htim->Instance == TIM7) {
-    __HAL_RCC_TIM7_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM7) {
+        __HAL_RCC_TIM7_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM8_BASE)
-  if (htim->Instance == TIM8) {
-    __HAL_RCC_TIM8_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM8) {
+        __HAL_RCC_TIM8_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM9_BASE)
-  if (htim->Instance == TIM9) {
-    __HAL_RCC_TIM9_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM9) {
+        __HAL_RCC_TIM9_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM10_BASE)
-  if (htim->Instance == TIM10) {
-    __HAL_RCC_TIM10_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM10) {
+        __HAL_RCC_TIM10_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM11_BASE)
-  if (htim->Instance == TIM11) {
-    __HAL_RCC_TIM11_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM11) {
+        __HAL_RCC_TIM11_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM12_BASE)
-  if (htim->Instance == TIM12) {
-    __HAL_RCC_TIM12_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM12) {
+        __HAL_RCC_TIM12_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM13_BASE)
-  if (htim->Instance == TIM13) {
-    __HAL_RCC_TIM13_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM13) {
+        __HAL_RCC_TIM13_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM14_BASE)
-  if (htim->Instance == TIM14) {
-    __HAL_RCC_TIM14_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM14) {
+        __HAL_RCC_TIM14_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM15_BASE)
-  if (htim->Instance == TIM15) {
-    __HAL_RCC_TIM15_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM15) {
+        __HAL_RCC_TIM15_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM16_BASE)
-  if (htim->Instance == TIM16) {
-    __HAL_RCC_TIM16_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM16) {
+        __HAL_RCC_TIM16_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM17_BASE)
-  if (htim->Instance == TIM17) {
-    __HAL_RCC_TIM17_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM17) {
+        __HAL_RCC_TIM17_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM18_BASE)
-  if (htim->Instance == TIM18) {
-    __HAL_RCC_TIM18_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM18) {
+        __HAL_RCC_TIM18_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM19_BASE)
-  if (htim->Instance == TIM19) {
-    __HAL_RCC_TIM19_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM19) {
+        __HAL_RCC_TIM19_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM20_BASE)
-  if (htim->Instance == TIM20) {
-    __HAL_RCC_TIM20_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM20) {
+        __HAL_RCC_TIM20_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM21_BASE)
-  if (htim->Instance == TIM21) {
-    __HAL_RCC_TIM21_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM21) {
+        __HAL_RCC_TIM21_CLK_DISABLE();
+    }
 #endif
 #if defined(TIM22_BASE)
-  if (htim->Instance == TIM22) {
-    __HAL_RCC_TIM22_CLK_DISABLE();
-  }
+    if (htim->Instance == TIM22) {
+        __HAL_RCC_TIM22_CLK_DISABLE();
+    }
 #endif
 }
 
@@ -373,10 +373,10 @@ void timer_disable_clock(TIM_HandleTypeDef *htim)
   */
 void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim_base)
 {
-  timer_enable_clock(htim_base);
+    timer_enable_clock(htim_base);
 
-  HAL_NVIC_SetPriority(getTimerIrq(htim_base->Instance), 15, 0);
-  HAL_NVIC_EnableIRQ(getTimerIrq(htim_base->Instance));
+    HAL_NVIC_SetPriority(getTimerIrq(htim_base->Instance), 15, 0);
+    HAL_NVIC_EnableIRQ(getTimerIrq(htim_base->Instance));
 }
 
 /**
@@ -386,8 +386,8 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim_base)
   */
 void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim_base)
 {
-  timer_disable_clock(htim_base);
-  HAL_NVIC_DisableIRQ(getTimerIrq(htim_base->Instance));
+    timer_disable_clock(htim_base);
+    HAL_NVIC_DisableIRQ(getTimerIrq(htim_base->Instance));
 }
 
 /**
@@ -399,27 +399,27 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim_base)
   */
 void TimerHandleInit(stimer_t *obj, uint16_t period, uint16_t prescaler)
 {
-  if (obj == NULL) {
-    return;
-  }
+    if (obj == NULL) {
+        return;
+    }
 
-  TIM_HandleTypeDef *handle = &(obj->handle);
+    TIM_HandleTypeDef *handle = &(obj->handle);
 
-  handle->Instance               = obj->timer;
-  handle->Init.Prescaler         = prescaler;
-  handle->Init.CounterMode       = TIM_COUNTERMODE_UP;
-  handle->Init.Period            = period;
-  handle->Init.ClockDivision     = TIM_CLOCKDIVISION_DIV1;
+    handle->Instance               = obj->timer;
+    handle->Init.Prescaler         = prescaler;
+    handle->Init.CounterMode       = TIM_COUNTERMODE_UP;
+    handle->Init.Period            = period;
+    handle->Init.ClockDivision     = TIM_CLOCKDIVISION_DIV1;
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
-  handle->Init.RepetitionCounter = 0x0000;
+    handle->Init.RepetitionCounter = 0x0000;
 #endif
-  if (HAL_TIM_Base_Init(handle) != HAL_OK) {
-    return;
-  }
+    if (HAL_TIM_Base_Init(handle) != HAL_OK) {
+        return;
+    }
 
-  if (HAL_TIM_Base_Start_IT(handle) != HAL_OK) {
-    return;
-  }
+    if (HAL_TIM_Base_Start_IT(handle) != HAL_OK) {
+        return;
+    }
 }
 
 /**
@@ -429,128 +429,128 @@ void TimerHandleInit(stimer_t *obj, uint16_t period, uint16_t prescaler)
   */
 uint32_t getTimerIrq(TIM_TypeDef *tim)
 {
-  uint32_t IRQn = 0;
+    uint32_t IRQn = 0;
 
-  if (tim != (TIM_TypeDef *)NC) {
-    /* Get IRQn depending on TIM instance */
-    switch ((uint32_t)tim) {
+    if (tim != (TIM_TypeDef *)NC) {
+        /* Get IRQn depending on TIM instance */
+        switch ((uint32_t)tim) {
 #if defined(TIM1_BASE)
-      case (uint32_t)TIM1:
-        IRQn = TIM1_IRQn;
-        break;
+        case (uint32_t)TIM1:
+            IRQn = TIM1_IRQn;
+            break;
 #endif
 #if defined(TIM2_BASE)
-      case (uint32_t)TIM2:
-        IRQn = TIM2_IRQn;
-        break;
+        case (uint32_t)TIM2:
+            IRQn = TIM2_IRQn;
+            break;
 #endif
 #if defined(TIM3_BASE)
-      case (uint32_t)TIM3:
-        IRQn = TIM3_IRQn;
-        break;
+        case (uint32_t)TIM3:
+            IRQn = TIM3_IRQn;
+            break;
 #endif
 #if defined(TIM4_BASE)
-      case (uint32_t)TIM4:
-        IRQn = TIM4_IRQn;
-        break;
+        case (uint32_t)TIM4:
+            IRQn = TIM4_IRQn;
+            break;
 #endif
 #if defined(TIM5_BASE)
-      case (uint32_t)TIM5:
-        IRQn = TIM5_IRQn;
-        break;
+        case (uint32_t)TIM5:
+            IRQn = TIM5_IRQn;
+            break;
 #endif
 #if defined(TIM6_BASE)
-      case (uint32_t)TIM6:
-        IRQn = TIM6_IRQn;
-        break;
+        case (uint32_t)TIM6:
+            IRQn = TIM6_IRQn;
+            break;
 #endif
 #if defined(TIM7_BASE)
-      case (uint32_t)TIM7:
-        IRQn = TIM7_IRQn;
-        break;
+        case (uint32_t)TIM7:
+            IRQn = TIM7_IRQn;
+            break;
 #endif
 #if defined(TIM8_BASE)
-      case (uint32_t)TIM8:
-        IRQn = TIM8_IRQn;
-        break;
+        case (uint32_t)TIM8:
+            IRQn = TIM8_IRQn;
+            break;
 #endif
 #if defined(TIM9_BASE)
-      case (uint32_t)TIM9:
-        IRQn = TIM9_IRQn;
-        break;
+        case (uint32_t)TIM9:
+            IRQn = TIM9_IRQn;
+            break;
 #endif
 #if defined(TIM10_BASE)
-      case (uint32_t)TIM10:
-        IRQn = TIM10_IRQn;
-        break;
+        case (uint32_t)TIM10:
+            IRQn = TIM10_IRQn;
+            break;
 #endif
 #if defined(TIM11_BASE)
-      case (uint32_t)TIM11:
-        IRQn = TIM11_IRQn;
-        break;
+        case (uint32_t)TIM11:
+            IRQn = TIM11_IRQn;
+            break;
 #endif
 #if defined(TIM12_BASE)
-      case (uint32_t)TIM12:
-        IRQn = TIM12_IRQn;
-        break;
+        case (uint32_t)TIM12:
+            IRQn = TIM12_IRQn;
+            break;
 #endif
 #if defined(TIM13_BASE)
-      case (uint32_t)TIM13:
-        IRQn = TIM13_IRQn;
-        break;
+        case (uint32_t)TIM13:
+            IRQn = TIM13_IRQn;
+            break;
 #endif
 #if defined(TIM14_BASE)
-      case (uint32_t)TIM14:
-        IRQn = TIM14_IRQn;
-        break;
+        case (uint32_t)TIM14:
+            IRQn = TIM14_IRQn;
+            break;
 #endif
 #if defined(TIM15_BASE)
-      case (uint32_t)TIM15:
-        IRQn = TIM15_IRQn;
-        break;
+        case (uint32_t)TIM15:
+            IRQn = TIM15_IRQn;
+            break;
 #endif
 #if defined(TIM16_BASE)
-      case (uint32_t)TIM16:
-        IRQn = TIM16_IRQn;
-        break;
+        case (uint32_t)TIM16:
+            IRQn = TIM16_IRQn;
+            break;
 #endif
 #if defined(TIM17_BASE)
-      case (uint32_t)TIM17:
-        IRQn = TIM17_IRQn;
-        break;
+        case (uint32_t)TIM17:
+            IRQn = TIM17_IRQn;
+            break;
 #endif
 #if defined(TIM18_BASE)
-      case (uint32_t)TIM18:
-        IRQn = TIM18_IRQn;
-        break;
+        case (uint32_t)TIM18:
+            IRQn = TIM18_IRQn;
+            break;
 #endif
 #if defined(TIM19_BASE)
-      case (uint32_t)TIM19:
-        IRQn = TIM19_IRQn;
-        break;
+        case (uint32_t)TIM19:
+            IRQn = TIM19_IRQn;
+            break;
 #endif
 #if defined(TIM20_BASE)
-      case (uint32_t)TIM20:
-        IRQn = TIM20_IRQn;
-        break;
+        case (uint32_t)TIM20:
+            IRQn = TIM20_IRQn;
+            break;
 #endif
 #if defined(TIM21_BASE)
-      case (uint32_t)TIM21:
-        IRQn = TIM21_IRQn;
-        break;
+        case (uint32_t)TIM21:
+            IRQn = TIM21_IRQn;
+            break;
 #endif
 #if defined(TIM22_BASE)
-      case (uint32_t)TIM22:
-        IRQn = TIM22_IRQn;
-        break;
+        case (uint32_t)TIM22:
+            IRQn = TIM22_IRQn;
+            break;
 #endif
-        break;
-      default:
-        core_debug("TIM: Unknown timer IRQn");
-        break;
+            break;
+        default:
+            core_debug("TIM: Unknown timer IRQn");
+            break;
+        }
     }
-  }
-  return IRQn;
+    return IRQn;
 }
 
 /**
@@ -560,10 +560,10 @@ uint32_t getTimerIrq(TIM_TypeDef *tim)
   */
 void TimerHandleDeinit(stimer_t *obj)
 {
-  if (obj != NULL) {
-    HAL_TIM_Base_DeInit(&(obj->handle));
-    HAL_TIM_Base_Stop_IT(&(obj->handle));
-  }
+    if (obj != NULL) {
+        HAL_TIM_Base_DeInit(&(obj->handle));
+        HAL_TIM_Base_Stop_IT(&(obj->handle));
+    }
 }
 
 /**
@@ -573,93 +573,93 @@ void TimerHandleDeinit(stimer_t *obj)
   */
 uint8_t getTimerClkSrc(TIM_TypeDef *tim)
 {
-  uint8_t clkSrc = 0;
+    uint8_t clkSrc = 0;
 
-  if (tim != (TIM_TypeDef *)NC)
+    if (tim != (TIM_TypeDef *)NC)
 #ifdef STM32F0xx
-    /* TIMx source CLK is PCKL1 */
-    clkSrc = 1;
+        /* TIMx source CLK is PCKL1 */
+        clkSrc = 1;
 #else
-  {
-    /* Get source clock depending on TIM instance */
-    switch ((uint32_t)tim) {
+    {
+        /* Get source clock depending on TIM instance */
+        switch ((uint32_t)tim) {
 #if defined(TIM2_BASE)
-      case (uint32_t)TIM2:
+        case (uint32_t)TIM2:
 #endif
 #if defined(TIM3_BASE)
-      case (uint32_t)TIM3:
+        case (uint32_t)TIM3:
 #endif
 #if defined(TIM4_BASE)
-      case (uint32_t)TIM4:
+        case (uint32_t)TIM4:
 #endif
 #if defined(TIM5_BASE)
-      case (uint32_t)TIM5:
+        case (uint32_t)TIM5:
 #endif
 #if defined(TIM6_BASE)
-      case (uint32_t)TIM6:
+        case (uint32_t)TIM6:
 #endif
 #if defined(TIM7_BASE)
-      case (uint32_t)TIM7:
+        case (uint32_t)TIM7:
 #endif
 #if defined(TIM12_BASE)
-      case (uint32_t)TIM12:
+        case (uint32_t)TIM12:
 #endif
 #if defined(TIM13_BASE)
-      case (uint32_t)TIM13:
+        case (uint32_t)TIM13:
 #endif
 #if defined(TIM14_BASE)
-      case (uint32_t)TIM14:
+        case (uint32_t)TIM14:
 #endif
 #if defined(TIM18_BASE)
-      case (uint32_t)TIM18:
+        case (uint32_t)TIM18:
 #endif
-        clkSrc = 1;
-        break;
+            clkSrc = 1;
+            break;
 #if defined(TIM1_BASE)
-      case (uint32_t)TIM1:
+        case (uint32_t)TIM1:
 #endif
 #if defined(TIM8_BASE)
-      case (uint32_t)TIM8:
+        case (uint32_t)TIM8:
 #endif
 #if defined(TIM9_BASE)
-      case (uint32_t)TIM9:
+        case (uint32_t)TIM9:
 #endif
 #if defined(TIM10_BASE)
-      case (uint32_t)TIM10:
+        case (uint32_t)TIM10:
 #endif
 #if defined(TIM11_BASE)
-      case (uint32_t)TIM11:
+        case (uint32_t)TIM11:
 #endif
 #if defined(TIM15_BASE)
-      case (uint32_t)TIM15:
+        case (uint32_t)TIM15:
 #endif
 #if defined(TIM16_BASE)
-      case (uint32_t)TIM16:
+        case (uint32_t)TIM16:
 #endif
 #if defined(TIM17_BASE)
-      case (uint32_t)TIM17:
+        case (uint32_t)TIM17:
 #endif
 #if defined(TIM19_BASE)
-      case (uint32_t)TIM19:
+        case (uint32_t)TIM19:
 #endif
 #if defined(TIM20_BASE)
-      case (uint32_t)TIM20:
+        case (uint32_t)TIM20:
 #endif
 #if defined(TIM21_BASE)
-      case (uint32_t)TIM21:
+        case (uint32_t)TIM21:
 #endif
 #if defined(TIM22_BASE)
-      case (uint32_t)TIM22:
+        case (uint32_t)TIM22:
 #endif
-        clkSrc = 2;
-        break;
-      default:
-        core_debug("TIM: Unknown timer instance");
-        break;
+            clkSrc = 2;
+            break;
+        default:
+            core_debug("TIM: Unknown timer instance");
+            break;
+        }
     }
-  }
 #endif
-  return clkSrc;
+    return clkSrc;
 }
 
 /**
@@ -669,121 +669,122 @@ uint8_t getTimerClkSrc(TIM_TypeDef *tim)
   */
 uint32_t getTimerClkFreq(TIM_TypeDef *tim)
 {
-  RCC_ClkInitTypeDef    clkconfig = {};
-  uint32_t              pFLatency = 0U;
-  uint32_t              uwTimclock = 0U, uwAPBxPrescaler = 0U;
+    RCC_ClkInitTypeDef    clkconfig = {};
+    uint32_t              pFLatency = 0U;
+    uint32_t              uwTimclock = 0U, uwAPBxPrescaler = 0U;
 
-  /* Get clock configuration */
-  HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
-  switch (getTimerClkSrc(tim)) {
+    /* Get clock configuration */
+    HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
+    switch (getTimerClkSrc(tim)) {
     case 1:
-      uwAPBxPrescaler = clkconfig.APB1CLKDivider;
-      uwTimclock = HAL_RCC_GetPCLK1Freq();
-      break;
+        uwAPBxPrescaler = clkconfig.APB1CLKDivider;
+        uwTimclock = HAL_RCC_GetPCLK1Freq();
+        break;
 #ifndef STM32F0xx
     case 2:
-      uwAPBxPrescaler = clkconfig.APB2CLKDivider;
-      uwTimclock = HAL_RCC_GetPCLK2Freq();
-      break;
+        uwAPBxPrescaler = clkconfig.APB2CLKDivider;
+        uwTimclock = HAL_RCC_GetPCLK2Freq();
+        break;
 #endif
     default:
     case 0:
-      core_debug("TIM: Unknown clock source");
-      break;
-  }
+        core_debug("TIM: Unknown clock source");
+        break;
+    }
 
 #if defined(STM32H7xx)
-  /* When TIMPRE bit of the RCC_CFGR register is reset,
-   *   if APBx prescaler is 1 or 2 then TIMxCLK = HCLK,
-   *   otherwise TIMxCLK = 2x PCLKx.
-   * When TIMPRE bit in the RCC_CFGR register is set,
-   *   if APBx prescaler is 1,2 or 4, then TIMxCLK = HCLK,
-   *   otherwise TIMxCLK = 4x PCLKx
-   */
-  RCC_PeriphCLKInitTypeDef PeriphClkConfig = {};
-  HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkConfig);
+    /* When TIMPRE bit of the RCC_CFGR register is reset,
+     *   if APBx prescaler is 1 or 2 then TIMxCLK = HCLK,
+     *   otherwise TIMxCLK = 2x PCLKx.
+     * When TIMPRE bit in the RCC_CFGR register is set,
+     *   if APBx prescaler is 1,2 or 4, then TIMxCLK = HCLK,
+     *   otherwise TIMxCLK = 4x PCLKx
+     */
+    RCC_PeriphCLKInitTypeDef PeriphClkConfig = {};
+    HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkConfig);
 
-  if (PeriphClkConfig.TIMPresSelection == RCC_TIMPRES_ACTIVATED) {
-    switch (uwAPBxPrescaler) {
-      default:
-      case RCC_APB1_DIV1:
-      case RCC_APB1_DIV2:
-      case RCC_APB1_DIV4:
-      /* case RCC_APB2_DIV1: */
-      case RCC_APB2_DIV2:
-      case RCC_APB2_DIV4:
-        uwTimclock = HAL_RCC_GetHCLKFreq();
-        break;
-      case RCC_APB1_DIV8:
-      case RCC_APB1_DIV16:
-      case RCC_APB2_DIV8:
-      case RCC_APB2_DIV16:
-        uwTimclock *= 4;
-        break;
+    if (PeriphClkConfig.TIMPresSelection == RCC_TIMPRES_ACTIVATED) {
+        switch (uwAPBxPrescaler) {
+        default:
+        case RCC_APB1_DIV1:
+        case RCC_APB1_DIV2:
+        case RCC_APB1_DIV4:
+        /* case RCC_APB2_DIV1: */
+        case RCC_APB2_DIV2:
+        case RCC_APB2_DIV4:
+            uwTimclock = HAL_RCC_GetHCLKFreq();
+            break;
+        case RCC_APB1_DIV8:
+        case RCC_APB1_DIV16:
+        case RCC_APB2_DIV8:
+        case RCC_APB2_DIV16:
+            uwTimclock *= 4;
+            break;
+        }
+    } else {
+        switch (uwAPBxPrescaler) {
+        default:
+        case RCC_APB1_DIV1:
+        case RCC_APB1_DIV2:
+        /* case RCC_APB2_DIV1: */
+        case RCC_APB2_DIV2:
+            // uwTimclock*=1;
+            uwTimclock = HAL_RCC_GetHCLKFreq();
+            break;
+        case RCC_APB1_DIV4:
+        case RCC_APB1_DIV8:
+        case RCC_APB1_DIV16:
+        case RCC_APB2_DIV4:
+        case RCC_APB2_DIV8:
+        case RCC_APB2_DIV16:
+            uwTimclock *= 2;
+            break;
+        }
     }
-  } else {
-    switch (uwAPBxPrescaler) {
-      default:
-      case RCC_APB1_DIV1:
-      case RCC_APB1_DIV2:
-      /* case RCC_APB2_DIV1: */
-      case RCC_APB2_DIV2:
-        // uwTimclock*=1;
-        uwTimclock = HAL_RCC_GetHCLKFreq();
-        break;
-      case RCC_APB1_DIV4:
-      case RCC_APB1_DIV8:
-      case RCC_APB1_DIV16:
-      case RCC_APB2_DIV4:
-      case RCC_APB2_DIV8:
-      case RCC_APB2_DIV16:
-        uwTimclock *= 2;
-        break;
-    }
-  }
 #else
-  /* When TIMPRE bit of the RCC_DCKCFGR register is reset,
-   *   if APBx prescaler is 1, then TIMxCLK = PCLKx,
-   *   otherwise TIMxCLK = 2x PCLKx.
-   * When TIMPRE bit in the RCC_DCKCFGR register is set,
-   *   if APBx prescaler is 1,2 or 4, then TIMxCLK = HCLK,
-   *   otherwise TIMxCLK = 4x PCLKx
-   */
+    /* When TIMPRE bit of the RCC_DCKCFGR register is reset,
+     *   if APBx prescaler is 1, then TIMxCLK = PCLKx,
+     *   otherwise TIMxCLK = 2x PCLKx.
+     * When TIMPRE bit in the RCC_DCKCFGR register is set,
+     *   if APBx prescaler is 1,2 or 4, then TIMxCLK = HCLK,
+     *   otherwise TIMxCLK = 4x PCLKx
+     */
 #if defined(STM32F4xx) || defined(STM32F7xx)
 #if !defined(STM32F405xx) && !defined(STM32F415xx) &&\
     !defined(STM32F407xx) && !defined(STM32F417xx)
-  RCC_PeriphCLKInitTypeDef PeriphClkConfig = {};
-  HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkConfig);
+    RCC_PeriphCLKInitTypeDef PeriphClkConfig = {};
+    HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkConfig);
 
-  if (PeriphClkConfig.TIMPresSelection == RCC_TIMPRES_ACTIVATED)
-    switch (uwAPBxPrescaler) {
-      default:
-      case RCC_HCLK_DIV1:
-      case RCC_HCLK_DIV2:
-      case RCC_HCLK_DIV4:
-        uwTimclock = HAL_RCC_GetHCLKFreq();
-        break;
-      case RCC_HCLK_DIV8:
-      case RCC_HCLK_DIV16:
-        uwTimclock *= 4;
-        break;
-    } else
+    if (PeriphClkConfig.TIMPresSelection == RCC_TIMPRES_ACTIVATED)
+        switch (uwAPBxPrescaler) {
+        default:
+        case RCC_HCLK_DIV1:
+        case RCC_HCLK_DIV2:
+        case RCC_HCLK_DIV4:
+            uwTimclock = HAL_RCC_GetHCLKFreq();
+            break;
+        case RCC_HCLK_DIV8:
+        case RCC_HCLK_DIV16:
+            uwTimclock *= 4;
+            break;
+        }
+    else
 #endif
 #endif
-    switch (uwAPBxPrescaler) {
-      default:
-      case RCC_HCLK_DIV1:
-        // uwTimclock*=1;
-        break;
-      case RCC_HCLK_DIV2:
-      case RCC_HCLK_DIV4:
-      case RCC_HCLK_DIV8:
-      case RCC_HCLK_DIV16:
-        uwTimclock *= 2;
-        break;
-    }
+        switch (uwAPBxPrescaler) {
+        default:
+        case RCC_HCLK_DIV1:
+            // uwTimclock*=1;
+            break;
+        case RCC_HCLK_DIV2:
+        case RCC_HCLK_DIV4:
+        case RCC_HCLK_DIV8:
+        case RCC_HCLK_DIV16:
+            uwTimclock *= 2;
+            break;
+        }
 #endif /* STM32H7xx */
-  return uwTimclock;
+    return uwTimclock;
 }
 
 
@@ -797,111 +798,113 @@ uint32_t getTimerClkFreq(TIM_TypeDef *tim)
   */
 void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(stimer_t *, uint32_t))
 {
-  TIM_OC_InitTypeDef sConfig = {};
-  TIM_HandleTypeDef *handle = &(obj->handle);
-  if (obj->timer == NULL){obj->timer = TIMER_SERVO;}
+    TIM_OC_InitTypeDef sConfig = {};
+    TIM_HandleTypeDef *handle = &(obj->handle);
+    if (obj->timer == NULL) {
+        obj->timer = TIMER_SERVO;
+    }
 
-  //min pulse = 1us - max pulse = 65535us
-  handle->Instance               = obj->timer;
-  handle->Init.Period            = period;
-  handle->Init.Prescaler         = (uint32_t)(getTimerClkFreq(obj->timer) / (1000000)) - 1;
-  handle->Init.ClockDivision     = 0;
-  handle->Init.CounterMode       = TIM_COUNTERMODE_UP;
+    //min pulse = 1us - max pulse = 65535us
+    handle->Instance               = obj->timer;
+    handle->Init.Period            = period;
+    handle->Init.Prescaler         = (uint32_t)(getTimerClkFreq(obj->timer) / (1000000)) - 1;
+    handle->Init.ClockDivision     = 0;
+    handle->Init.CounterMode       = TIM_COUNTERMODE_UP;
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
-  handle->Init.RepetitionCounter = 0;
+    handle->Init.RepetitionCounter = 0;
 #endif
-  obj->irqHandleOC = irqHandle;
+    obj->irqHandleOC = irqHandle;
 
-  sConfig.OCMode        = TIM_OCMODE_TIMING;
-  sConfig.Pulse         = pulseWidth;
-  sConfig.OCPolarity    = TIM_OCPOLARITY_HIGH;
-  sConfig.OCFastMode    = TIM_OCFAST_DISABLE;
+    sConfig.OCMode        = TIM_OCMODE_TIMING;
+    sConfig.Pulse         = pulseWidth;
+    sConfig.OCPolarity    = TIM_OCPOLARITY_HIGH;
+    sConfig.OCFastMode    = TIM_OCFAST_DISABLE;
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
-  sConfig.OCNPolarity   = TIM_OCNPOLARITY_HIGH;
-  sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
-  sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
+    sConfig.OCNPolarity   = TIM_OCNPOLARITY_HIGH;
+    sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
+    sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
 #endif
-  HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
-  HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
+    HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
+    HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
 
-  if (HAL_TIM_OC_Init(handle) != HAL_OK) {
-    return;
-  }
+    if (HAL_TIM_OC_Init(handle) != HAL_OK) {
+        return;
+    }
 
-  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_1) != HAL_OK) {
-    return;
-  }
-  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
-    return;
-  }
+    if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_1) != HAL_OK) {
+        return;
+    }
+    if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
+        return;
+    }
 }
 
 /**
   * @brief  This function will attach timer interrupt to with a particular duty cycle on channel x
   * @param  timer_id : timer_id_e
   * @param  irqHandle : interrupt routine to call
-  * @param  timChannel : timmer channel 
-  * @param  pulseWidth : phase of the timer where the callback will happen  
+  * @param  timChannel : timmer channel
+  * @param  pulseWidth : phase of the timer where the callback will happen
   * @retval None
   */
 void attachIntHandleOC(stimer_t *obj, void (*irqHandle)(void), uint16_t timChannel, uint16_t pulseWidth)
 {
-  TIM_OC_InitTypeDef sConfig = {};
-  TIM_HandleTypeDef *handle = &(obj->handle);
+    TIM_OC_InitTypeDef sConfig = {};
+    TIM_HandleTypeDef *handle = &(obj->handle);
 
-  sConfig.OCMode        = TIM_OCMODE_TIMING;
-  sConfig.Pulse         = pulseWidth;
-  sConfig.OCPolarity    = TIM_OCPOLARITY_HIGH;
-  sConfig.OCFastMode    = TIM_OCFAST_DISABLE;
+    sConfig.OCMode        = TIM_OCMODE_TIMING;
+    sConfig.Pulse         = pulseWidth;
+    sConfig.OCPolarity    = TIM_OCPOLARITY_HIGH;
+    sConfig.OCFastMode    = TIM_OCFAST_DISABLE;
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
-  sConfig.OCNPolarity   = TIM_OCNPOLARITY_HIGH;
-  sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
-  sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
+    sConfig.OCNPolarity   = TIM_OCNPOLARITY_HIGH;
+    sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
+    sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
 #endif
-  //HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
-  //HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
+    //HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
+    //HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
 
-  if (HAL_TIM_OC_Init(handle) != HAL_OK) {
-    return;
-  }
+    if (HAL_TIM_OC_Init(handle) != HAL_OK) {
+        return;
+    }
     switch (timChannel) {
-      case 1:
-	  obj->irqHandleOC_CH1 = irqHandle;
-	  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
-	    return;
-	  }
-	  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_1) != HAL_OK) {
-	    return;
-	  }
+    case 1:
+        obj->irqHandleOC_CH1 = irqHandle;
+        if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
+            return;
+        }
+        if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_1) != HAL_OK) {
+            return;
+        }
         break;
-      case 2:
-	  obj->irqHandleOC_CH2 = irqHandle;
-	  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_2) != HAL_OK) {
-	    return;
-	  }
-	  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_2) != HAL_OK) {
-	    return;
-	  }
+    case 2:
+        obj->irqHandleOC_CH2 = irqHandle;
+        if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_2) != HAL_OK) {
+            return;
+        }
+        if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_2) != HAL_OK) {
+            return;
+        }
         break;
-      case 3:
-	  obj->irqHandleOC_CH3 = irqHandle;
-	  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_3) != HAL_OK) {
-	    return;
-	  }
-	  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_3) != HAL_OK) {
-	    return;
-	  }
+    case 3:
+        obj->irqHandleOC_CH3 = irqHandle;
+        if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_3) != HAL_OK) {
+            return;
+        }
+        if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_3) != HAL_OK) {
+            return;
+        }
         break;
-      case 4:
-	  obj->irqHandleOC_CH4 = irqHandle;
-	  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_4) != HAL_OK) {
-	    return;
-	  }
-	  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_4) != HAL_OK) {
-	    return;
-	  }
+    case 4:
+        obj->irqHandleOC_CH4 = irqHandle;
+        if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_4) != HAL_OK) {
+            return;
+        }
+        if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_4) != HAL_OK) {
+            return;
+        }
         break;
-      default:
+    default:
         return;
         break;
     }
@@ -917,21 +920,21 @@ void attachIntHandleOC(stimer_t *obj, void (*irqHandle)(void), uint16_t timChann
   */
 void TimerPulseDeinit(stimer_t *obj)
 {
-  TIM_HandleTypeDef *handle = &(obj->handle);
-  obj->irqHandleOC = NULL;
-  obj->irqHandleOC_CH1 = NULL;
-  obj->irqHandleOC_CH2 = NULL;
-  obj->irqHandleOC_CH3 = NULL;
-  obj->irqHandleOC_CH4 = NULL;
+    TIM_HandleTypeDef *handle = &(obj->handle);
+    obj->irqHandleOC = NULL;
+    obj->irqHandleOC_CH1 = NULL;
+    obj->irqHandleOC_CH2 = NULL;
+    obj->irqHandleOC_CH3 = NULL;
+    obj->irqHandleOC_CH4 = NULL;
 
-  HAL_NVIC_DisableIRQ(getTimerIrq(obj->timer));
+    HAL_NVIC_DisableIRQ(getTimerIrq(obj->timer));
 
-  if (HAL_TIM_OC_DeInit(handle) != HAL_OK) {
-    return;
-  }
-  if (HAL_TIM_OC_Stop_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
-    return;
-  }
+    if (HAL_TIM_OC_DeInit(handle) != HAL_OK) {
+        return;
+    }
+    if (HAL_TIM_OC_Stop_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
+        return;
+    }
 }
 
 /**
@@ -941,7 +944,7 @@ void TimerPulseDeinit(stimer_t *obj)
   */
 void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim)
 {
-  timer_enable_clock(htim);
+    timer_enable_clock(htim);
 }
 
 /**
@@ -951,7 +954,7 @@ void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim)
   */
 void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim)
 {
-  timer_disable_clock(htim);
+    timer_disable_clock(htim);
 }
 
 /* Aim of the function is to get timer_s pointer using htim pointer */
@@ -959,13 +962,13 @@ void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim)
 /* (which was not directly used since not compatible with IAR toolchain) */
 stimer_t *get_timer_obj(TIM_HandleTypeDef *htim)
 {
-  struct timer_s *obj_s;
-  stimer_t *obj;
+    struct timer_s *obj_s;
+    stimer_t *obj;
 
-  obj_s = (struct timer_s *)((char *)htim - offsetof(struct timer_s, handle));
-  obj = (stimer_t *)((char *)obj_s - offsetof(stimer_t, timer));
+    obj_s = (struct timer_s *)((char *)htim - offsetof(struct timer_s, handle));
+    obj = (stimer_t *)((char *)obj_s - offsetof(stimer_t, timer));
 
-  return (obj);
+    return (obj);
 }
 
 /**
@@ -975,33 +978,43 @@ stimer_t *get_timer_obj(TIM_HandleTypeDef *htim)
   */
 void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
 {
-  uint32_t channel = 0;
-  stimer_t *obj = get_timer_obj(htim);
+    uint32_t channel = 0;
+    stimer_t *obj = get_timer_obj(htim);
     switch (htim->Channel) {
-      case HAL_TIM_ACTIVE_CHANNEL_1:
+    case HAL_TIM_ACTIVE_CHANNEL_1:
         channel = TIM_CHANNEL_1 / 4;
-	if (obj->irqHandleOC_CH1 != NULL) {obj->irqHandleOC_CH1();}
+        if (obj->irqHandleOC_CH1 != NULL) {
+            obj->irqHandleOC_CH1();
+        }
         break;
-      case HAL_TIM_ACTIVE_CHANNEL_2:
+    case HAL_TIM_ACTIVE_CHANNEL_2:
         channel = TIM_CHANNEL_2 / 4;
-        if (obj->irqHandleOC_CH2 != NULL) {obj->irqHandleOC_CH2();}  
+        if (obj->irqHandleOC_CH2 != NULL) {
+            obj->irqHandleOC_CH2();
+        }
         break;
-      case HAL_TIM_ACTIVE_CHANNEL_3:
-        if (obj->irqHandleOC_CH3 != NULL) {obj->irqHandleOC_CH3();} 
+    case HAL_TIM_ACTIVE_CHANNEL_3:
+        if (obj->irqHandleOC_CH3 != NULL) {
+            obj->irqHandleOC_CH3();
+        }
         channel = TIM_CHANNEL_3 / 4;
         break;
-      case HAL_TIM_ACTIVE_CHANNEL_4:
-        if (obj->irqHandleOC_CH4 != NULL) {obj->irqHandleOC_CH4();} 
+    case HAL_TIM_ACTIVE_CHANNEL_4:
+        if (obj->irqHandleOC_CH4 != NULL) {
+            obj->irqHandleOC_CH4();
+        }
         channel = TIM_CHANNEL_4 / 4;
         break;
-      default:
+    default:
         return;
         break;
     }
 
     //make it compatible with older versions
-    if (obj->irqHandleOC != NULL) {obj->irqHandleOC(obj, channel);}
-     
+    if (obj->irqHandleOC != NULL) {
+        obj->irqHandleOC(obj, channel);
+    }
+
 }
 
 /**
@@ -1011,19 +1024,19 @@ void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
   */
 void HAL_TIMx_PeriodElapsedCallback(stimer_t *obj)
 {
-  GPIO_TypeDef *port = get_GPIO_Port(STM_PORT(obj->pin));
+    GPIO_TypeDef *port = get_GPIO_Port(STM_PORT(obj->pin));
 
-  if (port != NULL) {
-    if (obj->pinInfo.count != 0) {
-      if (obj->pinInfo.count > 0) {
-        obj->pinInfo.count--;
-      }
-      obj->pinInfo.state = (obj->pinInfo.state == 0) ? 1 : 0;
-      digital_io_write(port, STM_LL_GPIO_PIN(obj->pin), obj->pinInfo.state);
-    } else {
-      digital_io_write(port, STM_LL_GPIO_PIN(obj->pin), 0);
+    if (port != NULL) {
+        if (obj->pinInfo.count != 0) {
+            if (obj->pinInfo.count > 0) {
+                obj->pinInfo.count--;
+            }
+            obj->pinInfo.state = (obj->pinInfo.state == 0) ? 1 : 0;
+            digital_io_write(port, STM_LL_GPIO_PIN(obj->pin), obj->pinInfo.state);
+        } else {
+            digital_io_write(port, STM_LL_GPIO_PIN(obj->pin), 0);
+        }
     }
-  }
 }
 
 /**
@@ -1033,11 +1046,11 @@ void HAL_TIMx_PeriodElapsedCallback(stimer_t *obj)
   */
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
-  stimer_t *obj = get_timer_obj(htim);
+    stimer_t *obj = get_timer_obj(htim);
 
-  if (obj->irqHandle != NULL) {
-    obj->irqHandle(obj);
-  }
+    if (obj->irqHandle != NULL) {
+        obj->irqHandle(obj);
+    }
 }
 
 /**
@@ -1051,56 +1064,56 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
   */
 void TimerPinInit(stimer_t *obj, uint32_t frequency, uint32_t duration)
 {
-  uint8_t end = 0;
-  uint32_t timClkFreq = 0;
-  // TIMER_TONE freq is twice frequency
-  uint32_t timFreq = 2 * frequency;
-  uint32_t prescaler = 1;
-  uint32_t period = 0;
-  uint32_t scale = 0;
+    uint8_t end = 0;
+    uint32_t timClkFreq = 0;
+    // TIMER_TONE freq is twice frequency
+    uint32_t timFreq = 2 * frequency;
+    uint32_t prescaler = 1;
+    uint32_t period = 0;
+    uint32_t scale = 0;
 
-  if (frequency > MAX_FREQ) {
-    return;
-  }
-
-  obj->timer = TIMER_TONE;
-  obj->pinInfo.state = 0;
-
-  if (frequency == 0) {
-    TimerPinDeinit(obj);
-    return;
-  }
-
-  //Calculate the toggle count
-  if (duration > 0) {
-    obj->pinInfo.count = ((timFreq * duration) / 1000);
-  } else {
-    obj->pinInfo.count = -1;
-  }
-
-  pin_function(obj->pin, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0));
-  timClkFreq = getTimerClkFreq(obj->timer);
-
-  // Do this once
-  scale = timClkFreq / timFreq;
-  while (end == 0) {
-    period = ((uint32_t)(scale / prescaler)) - 1;
-
-    if ((period >= 0xFFFF) && (prescaler < 0xFFFF)) {
-      prescaler++;  //prescaler *= 2;
+    if (frequency > MAX_FREQ) {
+        return;
     }
 
-    else {
-      end = 1;
-    }
-  }
+    obj->timer = TIMER_TONE;
+    obj->pinInfo.state = 0;
 
-  if ((period < 0xFFFF) && (prescaler < 0xFFFF)) {
-    obj->irqHandle = HAL_TIMx_PeriodElapsedCallback;
-    TimerHandleInit(obj, period, prescaler - 1);
-  } else {
-    TimerHandleDeinit(obj);
-  }
+    if (frequency == 0) {
+        TimerPinDeinit(obj);
+        return;
+    }
+
+    //Calculate the toggle count
+    if (duration > 0) {
+        obj->pinInfo.count = ((timFreq * duration) / 1000);
+    } else {
+        obj->pinInfo.count = -1;
+    }
+
+    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0));
+    timClkFreq = getTimerClkFreq(obj->timer);
+
+    // Do this once
+    scale = timClkFreq / timFreq;
+    while (end == 0) {
+        period = ((uint32_t)(scale / prescaler)) - 1;
+
+        if ((period >= 0xFFFF) && (prescaler < 0xFFFF)) {
+            prescaler++;  //prescaler *= 2;
+        }
+
+        else {
+            end = 1;
+        }
+    }
+
+    if ((period < 0xFFFF) && (prescaler < 0xFFFF)) {
+        obj->irqHandle = HAL_TIMx_PeriodElapsedCallback;
+        TimerHandleInit(obj, period, prescaler - 1);
+    } else {
+        TimerHandleDeinit(obj);
+    }
 }
 
 /**
@@ -1111,8 +1124,8 @@ void TimerPinInit(stimer_t *obj, uint32_t frequency, uint32_t duration)
   */
 void TimerPinDeinit(stimer_t *obj)
 {
-  TimerHandleDeinit(obj);
-  pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    TimerHandleDeinit(obj);
+    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
 }
 
 /**
@@ -1122,7 +1135,7 @@ void TimerPinDeinit(stimer_t *obj)
   */
 uint32_t getTimerCounter(stimer_t *obj)
 {
-  return __HAL_TIM_GET_COUNTER(&(obj->handle));
+    return __HAL_TIM_GET_COUNTER(&(obj->handle));
 }
 
 /**
@@ -1133,7 +1146,7 @@ uint32_t getTimerCounter(stimer_t *obj)
   */
 void setTimerCounter(stimer_t *obj, uint32_t value)
 {
-  __HAL_TIM_SET_COUNTER(&(obj->handle), value);
+    __HAL_TIM_SET_COUNTER(&(obj->handle), value);
 }
 
 /**
@@ -1145,7 +1158,7 @@ void setTimerCounter(stimer_t *obj, uint32_t value)
   */
 void setCCRRegister(stimer_t *obj, uint32_t channel, uint32_t value)
 {
-  __HAL_TIM_SET_COMPARE(&(obj->handle), channel * 4, value);
+    __HAL_TIM_SET_COMPARE(&(obj->handle), channel * 4, value);
 }
 
 /**
@@ -1156,7 +1169,7 @@ void setCCRRegister(stimer_t *obj, uint32_t channel, uint32_t value)
   */
 uint32_t getCCRRegister(stimer_t *obj, uint32_t channel)
 {
-  return __HAL_TIM_GET_COMPARE(&(obj->handle), channel);
+    return __HAL_TIM_GET_COMPARE(&(obj->handle), channel);
 }
 
 /**
@@ -1167,7 +1180,7 @@ uint32_t getCCRRegister(stimer_t *obj, uint32_t channel)
   */
 void attachIntHandle(stimer_t *obj, void (*irqHandle)(stimer_t *))
 {
-  obj->irqHandle = irqHandle;
+    obj->irqHandle = irqHandle;
 }
 
 
@@ -1183,23 +1196,23 @@ void attachIntHandle(stimer_t *obj, void (*irqHandle)(stimer_t *))
   */
 void TIM1_IRQHandler(void)
 {
-  if (timer_handles[0] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[0]);
-  }
+    if (timer_handles[0] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[0]);
+    }
 
 #if defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32F7xx)
 #if defined (TIM10_BASE)
-  if (timer_handles[9] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[9]);
-  }
+    if (timer_handles[9] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[9]);
+    }
 #endif
 #endif
 
 #if defined(STM32F1xx) || defined(STM32F3xx) || defined(STM32L4xx)
 #if defined (TIM16_BASE)
-  if (timer_handles[15] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[15]);
-  }
+    if (timer_handles[15] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[15]);
+    }
 #endif
 #endif
 }
@@ -1213,9 +1226,9 @@ void TIM1_IRQHandler(void)
   */
 void TIM2_IRQHandler(void)
 {
-  if (timer_handles[1] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[1]);
-  }
+    if (timer_handles[1] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[1]);
+    }
 }
 #endif //TIM2_BASE
 
@@ -1227,9 +1240,9 @@ void TIM2_IRQHandler(void)
   */
 void TIM3_IRQHandler(void)
 {
-  if (timer_handles[2] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[2]);
-  }
+    if (timer_handles[2] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[2]);
+    }
 }
 #endif //TIM3_BASE
 
@@ -1241,9 +1254,9 @@ void TIM3_IRQHandler(void)
   */
 void TIM4_IRQHandler(void)
 {
-  if (timer_handles[3] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[3]);
-  }
+    if (timer_handles[3] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[3]);
+    }
 }
 #endif //TIM4_BASE
 
@@ -1255,9 +1268,9 @@ void TIM4_IRQHandler(void)
   */
 void TIM5_IRQHandler(void)
 {
-  if (timer_handles[4] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[4]);
-  }
+    if (timer_handles[4] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[4]);
+    }
 }
 #endif //TIM5_BASE
 
@@ -1269,9 +1282,9 @@ void TIM5_IRQHandler(void)
   */
 void TIM6_IRQHandler(void)
 {
-  if (timer_handles[5] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[5]);
-  }
+    if (timer_handles[5] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[5]);
+    }
 }
 #endif //TIM6_BASE
 
@@ -1283,9 +1296,9 @@ void TIM6_IRQHandler(void)
   */
 void TIM7_IRQHandler(void)
 {
-  if (timer_handles[6] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[6]);
-  }
+    if (timer_handles[6] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[6]);
+    }
 }
 #endif //TIM7_BASE
 
@@ -1297,14 +1310,14 @@ void TIM7_IRQHandler(void)
   */
 void TIM8_IRQHandler(void)
 {
-  if (timer_handles[7] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[7]);
-  }
+    if (timer_handles[7] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[7]);
+    }
 
 #if defined(STM32F1xx) || defined(STM32F2xx) ||defined(STM32F4xx) || defined(STM32F7xx)
-  if (timer_handles[12] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[12]);
-  }
+    if (timer_handles[12] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[12]);
+    }
 #endif
 }
 #endif //TIM8_BASE
@@ -1317,9 +1330,9 @@ void TIM8_IRQHandler(void)
   */
 void TIM9_IRQHandler(void)
 {
-  if (timer_handles[8] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[8]);
-  }
+    if (timer_handles[8] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[8]);
+    }
 }
 #endif //TIM9_BASE
 
@@ -1332,9 +1345,9 @@ void TIM9_IRQHandler(void)
   */
 void TIM10_IRQHandler(void)
 {
-  if (timer_handles[9] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[9]);
-  }
+    if (timer_handles[9] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[9]);
+    }
 }
 #endif
 #endif //TIM10_BASE
@@ -1347,9 +1360,9 @@ void TIM10_IRQHandler(void)
   */
 void TIM11_IRQHandler(void)
 {
-  if (timer_handles[10] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[10]);
-  }
+    if (timer_handles[10] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[10]);
+    }
 }
 #endif //TIM11_BASE
 
@@ -1361,9 +1374,9 @@ void TIM11_IRQHandler(void)
   */
 void TIM12_IRQHandler(void)
 {
-  if (timer_handles[11] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[11]);
-  }
+    if (timer_handles[11] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[11]);
+    }
 }
 #endif //TIM12_BASE
 
@@ -1376,9 +1389,9 @@ void TIM12_IRQHandler(void)
   */
 void TIM13_IRQHandler(void)
 {
-  if (timer_handles[12] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[12]);
-  }
+    if (timer_handles[12] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[12]);
+    }
 }
 #endif
 #endif //TIM13_BASE
@@ -1391,9 +1404,9 @@ void TIM13_IRQHandler(void)
   */
 void TIM14_IRQHandler(void)
 {
-  if (timer_handles[13] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[13]);
-  }
+    if (timer_handles[13] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[13]);
+    }
 }
 #endif //TIM14_BASE
 
@@ -1405,9 +1418,9 @@ void TIM14_IRQHandler(void)
   */
 void TIM15_IRQHandler(void)
 {
-  if (timer_handles[14] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[14]);
-  }
+    if (timer_handles[14] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[14]);
+    }
 }
 #endif //TIM15_BASE
 
@@ -1420,9 +1433,9 @@ void TIM15_IRQHandler(void)
   */
 void TIM16_IRQHandler(void)
 {
-  if (timer_handles[15] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[15]);
-  }
+    if (timer_handles[15] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[15]);
+    }
 }
 #endif
 #endif //TIM16_BASE
@@ -1435,9 +1448,9 @@ void TIM16_IRQHandler(void)
   */
 void TIM17_IRQHandler(void)
 {
-  if (timer_handles[16] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[16]);
-  }
+    if (timer_handles[16] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[16]);
+    }
 }
 #endif //TIM17_BASE
 
@@ -1449,9 +1462,9 @@ void TIM17_IRQHandler(void)
   */
 void TIM18_IRQHandler(void)
 {
-  if (timer_handles[17] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[17]);
-  }
+    if (timer_handles[17] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[17]);
+    }
 }
 #endif //TIM18_BASE
 
@@ -1463,9 +1476,9 @@ void TIM18_IRQHandler(void)
   */
 void TIM19_IRQHandler(void)
 {
-  if (timer_handles[18] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[18]);
-  }
+    if (timer_handles[18] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[18]);
+    }
 }
 #endif //TIM19_BASE
 
@@ -1477,9 +1490,9 @@ void TIM19_IRQHandler(void)
   */
 void TIM20_IRQHandler(void)
 {
-  if (timer_handles[19] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[19]);
-  }
+    if (timer_handles[19] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[19]);
+    }
 }
 #endif //TIM20_BASE
 
@@ -1491,9 +1504,9 @@ void TIM20_IRQHandler(void)
   */
 void TIM21_IRQHandler(void)
 {
-  if (timer_handles[20] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[20]);
-  }
+    if (timer_handles[20] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[20]);
+    }
 }
 #endif //TIM21_BASE
 
@@ -1505,9 +1518,9 @@ void TIM21_IRQHandler(void)
   */
 void TIM22_IRQHandler(void)
 {
-  if (timer_handles[21] != NULL) {
-    HAL_TIM_IRQHandler(timer_handles[21]);
-  }
+    if (timer_handles[21] != NULL) {
+        HAL_TIM_IRQHandler(timer_handles[21]);
+    }
 }
 #endif //TIM22_BASE
 

--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -786,6 +786,7 @@ uint32_t getTimerClkFreq(TIM_TypeDef *tim)
   return uwTimclock;
 }
 
+
 /**
   * @brief  This function will set the timer to generate pulse in interrupt mode with a particular duty cycle
   * @param  timer_id : timer_id_e
@@ -794,12 +795,11 @@ uint32_t getTimerClkFreq(TIM_TypeDef *tim)
   * @param  irqHandle : interrupt routine to call
   * @retval None
   */
-void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(stimer_t *, uint32_t))
+void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(void))
 {
   TIM_OC_InitTypeDef sConfig = {};
   TIM_HandleTypeDef *handle = &(obj->handle);
-
-  obj->timer = TIMER_SERVO;
+  if (obj->timer == NULL){obj->timer = TIMER_SERVO;}
 
   //min pulse = 1us - max pulse = 65535us
   handle->Instance               = obj->timer;
@@ -810,7 +810,7 @@ void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*
 #if !defined(STM32L0xx) && !defined(STM32L1xx)
   handle->Init.RepetitionCounter = 0;
 #endif
-  obj->irqHandleOC = irqHandle;
+  obj->irqHandleOC_CH1 = irqHandle;
 
   sConfig.OCMode        = TIM_OCMODE_TIMING;
   sConfig.Pulse         = pulseWidth;
@@ -837,6 +837,79 @@ void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*
 }
 
 /**
+  * @brief  This function will attach timer interrupt to with a particular duty cycle on channel x
+  * @param  timer_id : timer_id_e
+  * @param  irqHandle : interrupt routine to call
+  * @param  timChannel : timmer channel 
+  * @retval None
+  */
+void attachIntHandleOC(stimer_t *obj, void (*irqHandle)(void), uint16_t timChannel, uint16_t pulseWidth)
+{
+  TIM_OC_InitTypeDef sConfig = {};
+  TIM_HandleTypeDef *handle = &(obj->handle);
+
+  sConfig.OCMode        = TIM_OCMODE_TIMING;
+  sConfig.Pulse         = pulseWidth;
+  sConfig.OCPolarity    = TIM_OCPOLARITY_HIGH;
+  sConfig.OCFastMode    = TIM_OCFAST_DISABLE;
+#if !defined(STM32L0xx) && !defined(STM32L1xx)
+  sConfig.OCNPolarity   = TIM_OCNPOLARITY_HIGH;
+  sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
+  sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
+#endif
+  //HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
+  //HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
+
+  if (HAL_TIM_OC_Init(handle) != HAL_OK) {
+    return;
+  }
+    switch (timChannel) {
+      case 1:
+	  obj->irqHandleOC_CH1 = irqHandle;
+	  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_1) != HAL_OK) {
+	    return;
+	  }
+	  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_1) != HAL_OK) {
+	    return;
+	  }
+        break;
+      case 2:
+	  obj->irqHandleOC_CH2 = irqHandle;
+	  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_2) != HAL_OK) {
+	    return;
+	  }
+	  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_2) != HAL_OK) {
+	    return;
+	  }
+        break;
+      case 3:
+	  obj->irqHandleOC_CH3 = irqHandle;
+	  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_3) != HAL_OK) {
+	    return;
+	  }
+	  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_3) != HAL_OK) {
+	    return;
+	  }
+        break;
+      case 4:
+	  obj->irqHandleOC_CH4 = irqHandle;
+	  if (HAL_TIM_OC_Start_IT(handle, TIM_CHANNEL_4) != HAL_OK) {
+	    return;
+	  }
+	  if (HAL_TIM_OC_ConfigChannel(handle, &sConfig, TIM_CHANNEL_4) != HAL_OK) {
+	    return;
+	  }
+        break;
+      default:
+        return;
+        break;
+    }
+    return;
+}
+
+
+
+/**
   * @brief  This function will reset the pulse generation
   * @param  timer_id : timer_id_e
   * @retval None
@@ -845,7 +918,10 @@ void TimerPulseDeinit(stimer_t *obj)
 {
   TIM_HandleTypeDef *handle = &(obj->handle);
 
-  obj->irqHandleOC = NULL;
+  obj->irqHandleOC_CH1 = NULL;
+  obj->irqHandleOC_CH2 = NULL;
+  obj->irqHandleOC_CH3 = NULL;
+  obj->irqHandleOC_CH4 = NULL;
 
   HAL_NVIC_DisableIRQ(getTimerIrq(obj->timer));
 
@@ -900,18 +976,29 @@ void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
 {
   uint32_t channel = 0;
   stimer_t *obj = get_timer_obj(htim);
-
-  if (obj->irqHandleOC != NULL) {
     switch (htim->Channel) {
       case HAL_TIM_ACTIVE_CHANNEL_1:
         channel = TIM_CHANNEL_1 / 4;
+	if (obj->irqHandleOC_CH1 != NULL) {obj->irqHandleOC_CH1();}
+        break;
+      case HAL_TIM_ACTIVE_CHANNEL_2:
+        channel = TIM_CHANNEL_2 / 4;
+        if (obj->irqHandleOC_CH2 != NULL) {obj->irqHandleOC_CH2();}  
+        break;
+      case HAL_TIM_ACTIVE_CHANNEL_3:
+        if (obj->irqHandleOC_CH3 != NULL) {obj->irqHandleOC_CH3();} 
+        channel = TIM_CHANNEL_3 / 4;
+        break;
+      case HAL_TIM_ACTIVE_CHANNEL_4:
+        if (obj->irqHandleOC_CH4 != NULL) {obj->irqHandleOC_CH4();} 
+        channel = TIM_CHANNEL_4 / 4;
         break;
       default:
         return;
         break;
     }
-    obj->irqHandleOC(obj, channel);
-  }
+    
+  
 }
 
 /**

--- a/cores/arduino/stm32/timer.h
+++ b/cores/arduino/stm32/timer.h
@@ -67,6 +67,7 @@ struct timer_s {
   TIM_HandleTypeDef handle;
   uint8_t idx;
   void (*irqHandle)(stimer_t *);
+  void (*irqHandleOC)(stimer_t *, uint32_t);
   void (*irqHandleOC_CH1)(void);
   void (*irqHandleOC_CH2)(void);
   void (*irqHandleOC_CH3)(void);
@@ -197,7 +198,7 @@ void TimerHandleDeinit(stimer_t *obj);
 void TimerPinInit(stimer_t *obj, uint32_t frequency, uint32_t duration);
 void TimerPinDeinit(stimer_t *obj);
 
-void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(void));
+void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(stimer_t *, uint32_t));
 void TimerPulseDeinit(stimer_t *obj);
 
 uint32_t getTimerCounter(stimer_t *obj);

--- a/cores/arduino/stm32/timer.h
+++ b/cores/arduino/stm32/timer.h
@@ -204,6 +204,7 @@ void TimerPulseDeinit(stimer_t *obj);
 uint32_t getTimerCounter(stimer_t *obj);
 void setTimerCounter(stimer_t *obj, uint32_t value);
 void setCCRRegister(stimer_t *obj, uint32_t channel, uint32_t value);
+void setTimerPrescalerRegister(stimer_t *obj, uint32_t prescaler);
 uint32_t getCCRRegister(stimer_t *obj, uint32_t channel);
 
 uint32_t getTimerIrq(TIM_TypeDef *tim);

--- a/cores/arduino/stm32/timer.h
+++ b/cores/arduino/stm32/timer.h
@@ -67,7 +67,10 @@ struct timer_s {
   TIM_HandleTypeDef handle;
   uint8_t idx;
   void (*irqHandle)(stimer_t *);
-  void (*irqHandleOC)(stimer_t *, uint32_t);
+  void (*irqHandleOC_CH1)(void);
+  void (*irqHandleOC_CH2)(void);
+  void (*irqHandleOC_CH3)(void);
+  void (*irqHandleOC_CH4)(void);
   PinName pin;
   volatile timerPinInfo_t pinInfo;
 };
@@ -194,7 +197,7 @@ void TimerHandleDeinit(stimer_t *obj);
 void TimerPinInit(stimer_t *obj, uint32_t frequency, uint32_t duration);
 void TimerPinDeinit(stimer_t *obj);
 
-void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(stimer_t *, uint32_t));
+void TimerPulseInit(stimer_t *obj, uint16_t period, uint16_t pulseWidth, void (*irqHandle)(void));
 void TimerPulseDeinit(stimer_t *obj);
 
 uint32_t getTimerCounter(stimer_t *obj);
@@ -207,6 +210,7 @@ uint8_t getTimerClkSrc(TIM_TypeDef *tim);
 uint32_t getTimerClkFreq(TIM_TypeDef *tim);
 
 void attachIntHandle(stimer_t *obj, void (*irqHandle)(stimer_t *));
+void attachIntHandleOC(stimer_t *obj, void (*irqHandle)(void), uint16_t timChannel, uint16_t pulseWidth);
 
 #ifdef __cplusplus
 }

--- a/cores/arduino/stm32/timer.h
+++ b/cores/arduino/stm32/timer.h
@@ -51,29 +51,29 @@ extern "C" {
 #define OFFSETOF(type, member) ((uint32_t) (&(((type *)(0))->member)))
 
 typedef struct {
-    int32_t count;
-    uint8_t state;
+  int32_t count;
+  uint8_t state;
 } timerPinInfo_t;
 
 typedef struct timer_s stimer_t;
 
 struct timer_s {
-    /*  The 1st 2 members TIM_TypeDef *timer
-       *  and TIM_HandleTypeDef handle should
-       *  be kept as the first members of this struct
-       *  to have get_timer_obj() function work as expected
-       */
-    TIM_TypeDef *timer;
-    TIM_HandleTypeDef handle;
-    uint8_t idx;
-    void (*irqHandle)(stimer_t *);
-    void (*irqHandleOC)(stimer_t *, uint32_t);
-    void (*irqHandleOC_CH1)(void);
-    void (*irqHandleOC_CH2)(void);
-    void (*irqHandleOC_CH3)(void);
-    void (*irqHandleOC_CH4)(void);
-    PinName pin;
-    volatile timerPinInfo_t pinInfo;
+  /*  The 1st 2 members TIM_TypeDef *timer
+     *  and TIM_HandleTypeDef handle should
+     *  be kept as the first members of this struct
+     *  to have get_timer_obj() function work as expected
+     */
+  TIM_TypeDef *timer;
+  TIM_HandleTypeDef handle;
+  uint8_t idx;
+  void (*irqHandle)(stimer_t *);
+  void (*irqHandleOC)(stimer_t *, uint32_t);
+  void (*irqHandleOC_CH1)(void);
+  void (*irqHandleOC_CH2)(void);
+  void (*irqHandleOC_CH3)(void);
+  void (*irqHandleOC_CH4)(void);
+  PinName pin;
+  volatile timerPinInfo_t pinInfo;
 };
 
 /* Exported constants --------------------------------------------------------*/

--- a/cores/arduino/stm32/timer.h
+++ b/cores/arduino/stm32/timer.h
@@ -51,29 +51,29 @@ extern "C" {
 #define OFFSETOF(type, member) ((uint32_t) (&(((type *)(0))->member)))
 
 typedef struct {
-  int32_t count;
-  uint8_t state;
+    int32_t count;
+    uint8_t state;
 } timerPinInfo_t;
 
 typedef struct timer_s stimer_t;
 
 struct timer_s {
-  /*  The 1st 2 members TIM_TypeDef *timer
-     *  and TIM_HandleTypeDef handle should
-     *  be kept as the first members of this struct
-     *  to have get_timer_obj() function work as expected
-     */
-  TIM_TypeDef *timer;
-  TIM_HandleTypeDef handle;
-  uint8_t idx;
-  void (*irqHandle)(stimer_t *);
-  void (*irqHandleOC)(stimer_t *, uint32_t);
-  void (*irqHandleOC_CH1)(void);
-  void (*irqHandleOC_CH2)(void);
-  void (*irqHandleOC_CH3)(void);
-  void (*irqHandleOC_CH4)(void);
-  PinName pin;
-  volatile timerPinInfo_t pinInfo;
+    /*  The 1st 2 members TIM_TypeDef *timer
+       *  and TIM_HandleTypeDef handle should
+       *  be kept as the first members of this struct
+       *  to have get_timer_obj() function work as expected
+       */
+    TIM_TypeDef *timer;
+    TIM_HandleTypeDef handle;
+    uint8_t idx;
+    void (*irqHandle)(stimer_t *);
+    void (*irqHandleOC)(stimer_t *, uint32_t);
+    void (*irqHandleOC_CH1)(void);
+    void (*irqHandleOC_CH2)(void);
+    void (*irqHandleOC_CH3)(void);
+    void (*irqHandleOC_CH4)(void);
+    PinName pin;
+    volatile timerPinInfo_t pinInfo;
 };
 
 /* Exported constants --------------------------------------------------------*/


### PR DESCRIPTION
Adding on timer to make channel 1..4 IRQ callbacks possible

The timer.c and timer.h are modified such that you can now attach 
interrupt callbacks to all channels of the hardware timers. This feature 
should be fully backwards compatible with the previous implementation. 

The addition is done to make an arduino core implementation of 
HardwareTimers possible (Next step). That would be inline with what other
arduino stm32 cores offer.
 
This PR starts implementation of the following **bugs/features**
See issue #146