### PR TITLE
Receive double buffering for STM32F1xx

### DIFF
--- a/cores/arduino/stm32/usb/cdc/usbd_cdc.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc.c
@@ -651,9 +651,9 @@ static uint8_t  USBD_CDC_DataIn(USBD_HandleTypeDef *pdev, uint8_t epnum)
   USBD_CDC_ItfTypeDef *ctrl = (USBD_CDC_ItfTypeDef *)pdev->pUserData;
 
   if (pdev->pClassData != NULL) {
-    if ((pdev->ep_in[epnum].total_length > 0U) && ((pdev->ep_in[epnum].total_length % hpcd->IN_ep[epnum].maxpacket) == 0U)) {
+    if ((hcdc->TxLastLength > 0U) && ((hcdc->TxLastLength % hpcd->IN_ep[epnum].maxpacket) == 0U)) {
       /* Update the packet total length */
-      pdev->ep_in[epnum].total_length = 0U;
+      hcdc->TxLastLength = 0U;
 
       /* Send ZLP */
       USBD_LL_Transmit(pdev, epnum, NULL, 0U);
@@ -835,7 +835,7 @@ uint8_t  USBD_CDC_TransmitPacket(USBD_HandleTypeDef *pdev)
       hcdc->TxState = 1U;
 
       /* Update the packet total length */
-      pdev->ep_in[CDC_IN_EP & 0xFU].total_length = hcdc->TxLength;
+      hcdc->TxLastLength = hcdc->TxLength;
 
       /* Transmit next packet */
       USBD_LL_Transmit(pdev, CDC_IN_EP, hcdc->TxBuffer,

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc.h
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc.h
@@ -41,9 +41,9 @@ extern "C" {
 /** @defgroup usbd_cdc_Exported_Defines
   * @{
   */
-#define CDC_IN_EP                                   0x81U  /* EP1 for data IN */
+#define CDC_IN_EP                                   0x82U  /* EP1 for data IN */
 #define CDC_OUT_EP                                  0x01U  /* EP1 for data OUT */
-#define CDC_CMD_EP                                  0x82U  /* EP2 for CDC commands */
+#define CDC_CMD_EP                                  0x83U  /* EP2 for CDC commands */
 
 #ifndef CDC_HS_BINTERVAL
 #define CDC_HS_BINTERVAL                          0x10U

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc.h
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc.h
@@ -115,6 +115,7 @@ typedef struct {
   uint8_t  *TxBuffer;
   uint32_t RxLength;
   uint32_t TxLength;
+  uint32_t TxLastLength;
 
   __IO uint32_t TxState;
   __IO uint32_t RxState;

--- a/cores/arduino/stm32/usb/usbd_conf.c
+++ b/cores/arduino/stm32/usb/usbd_conf.c
@@ -28,10 +28,12 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Size in words, byte size divided by 2 */
-#define PMA_EP0_OUT_ADDR (8 * 3)
+#define PMA_EP0_OUT_ADDR (8 * 4)
 #define PMA_EP0_IN_ADDR (PMA_EP0_OUT_ADDR + USB_MAX_EP0_SIZE)
-#define PMA_CDC_OUT_ADDR (PMA_EP0_IN_ADDR + USB_MAX_EP0_SIZE)
-#define PMA_CDC_IN_ADDR (PMA_CDC_OUT_ADDR + USB_FS_MAX_PACKET_SIZE)
+#define PMA_CDC_OUT_BASE (PMA_EP0_IN_ADDR + USB_MAX_EP0_SIZE)
+#define PMA_CDC_OUT_ADDR ((PMA_CDC_OUT_BASE + USB_FS_MAX_PACKET_SIZE) | \
+                         (PMA_CDC_OUT_BASE << 16U))
+#define PMA_CDC_IN_ADDR (PMA_CDC_OUT_BASE + USB_FS_MAX_PACKET_SIZE * 2)
 #define PMA_CDC_CMD_ADDR (PMA_CDC_IN_ADDR + USB_FS_MAX_PACKET_SIZE)
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
@@ -520,9 +522,9 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
 #else
   HAL_PCDEx_PMAConfig(&g_hpcd, 0x00, PCD_SNG_BUF, PMA_EP0_OUT_ADDR);
   HAL_PCDEx_PMAConfig(&g_hpcd, 0x80, PCD_SNG_BUF, PMA_EP0_IN_ADDR);
-  HAL_PCDEx_PMAConfig(&g_hpcd, 0x01, PCD_SNG_BUF, PMA_CDC_OUT_ADDR);
-  HAL_PCDEx_PMAConfig(&g_hpcd, 0x81, PCD_SNG_BUF, PMA_CDC_IN_ADDR);
-  HAL_PCDEx_PMAConfig(&g_hpcd, 0x82, PCD_SNG_BUF, PMA_CDC_CMD_ADDR);
+  HAL_PCDEx_PMAConfig(&g_hpcd, 0x01, PCD_DBL_BUF, PMA_CDC_OUT_ADDR);
+  HAL_PCDEx_PMAConfig(&g_hpcd, 0x82, PCD_SNG_BUF, PMA_CDC_IN_ADDR);
+  HAL_PCDEx_PMAConfig(&g_hpcd, 0x83, PCD_SNG_BUF, PMA_CDC_CMD_ADDR);
 #endif
 #endif /* USE_USB_HS */
   return USBD_OK;

--- a/system/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_ll_usb.h
+++ b/system/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_ll_usb.h
@@ -160,6 +160,9 @@ typedef struct
   uint32_t  xfer_len;       /*!< Current transfer length                                                  */
   
   uint32_t  xfer_count;     /*!< Partial transfer length in case of multi packet transfer                 */
+
+  uint16_t  pending0;        /*!, Fact, that double buffering transfer have pended data                    */
+  uint16_t  pending1;        /*!, Fact, that double buffering transfer have pended data                    */
 }USB_OTG_EPTypeDef;
 
 typedef struct
@@ -269,8 +272,8 @@ typedef struct
   
   uint8_t   doublebuffer;    /*!< Double buffer enable
                                  This parameter can be 0 or 1                                             */
-  
-  uint16_t  tx_fifo_num;    /*!< This parameter is not required by USB Device FS peripheral, it is used 
+
+  uint16_t  tx_fifo_num;    /*!< This parameter is not required by USB Device FS peripheral, it is used
                                  only by USB OTG FS peripheral    
                                  This parameter is added to ensure compatibility across USB peripherals   */
   
@@ -278,10 +281,14 @@ typedef struct
                                  This parameter must be a number between Min_Data = 0 and Max_Data = 64KB */
   
   uint8_t   *xfer_buff;     /*!< Pointer to transfer buffer                                               */
-  
+
+
   uint32_t  xfer_len;       /*!< Current transfer length                                                  */
   
   uint32_t  xfer_count;     /*!< Partial transfer length in case of multi packet transfer                 */
+
+  uint16_t  pending0;        /*!, Fact, that double buffering transfer have pended data                    */
+  uint16_t  pending1;        /*!, Fact, that double buffering transfer have pended data                    */
 
 } USB_EPTypeDef;
 #endif /* USB */

--- a/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_pcd.c
+++ b/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_pcd.c
@@ -873,9 +873,6 @@ HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint
   {
     ep = &hpcd->OUT_ep[ep_addr & 0x7FU];
   }
-  ep->num   = ep_addr & 0x7FU;
-  
-  ep->is_in = (0x80U & ep_addr) != 0U;
   ep->maxpacket = ep_mps;
   ep->type = ep_type;
     
@@ -903,10 +900,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   {
     ep = &hpcd->OUT_ep[ep_addr & 0x7FU];
   }
-  ep->num   = ep_addr & 0x7FU;
-  
-  ep->is_in = (0x80U & ep_addr) != 0U;
-  
+
   __HAL_LOCK(hpcd);
   USB_DeactivateEndpoint(hpcd->Instance , ep);
   __HAL_UNLOCK(hpcd);
@@ -932,8 +926,6 @@ HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, u
   ep->xfer_buff = pBuf;  
   ep->xfer_len = len;
   ep->xfer_count = 0U;
-  ep->is_in = 0U;
-  ep->num = ep_addr & 0x7FU;
 
   if ((ep_addr & 0x7FU) == 0U)
   {
@@ -975,8 +967,6 @@ HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, 
   ep->xfer_buff = pBuf;  
   ep->xfer_len = len;
   ep->xfer_count = 0U;
-  ep->is_in = 1U;
-  ep->num = ep_addr & 0x7FU;
 
   if ((ep_addr & 0x7FU) == 0U)
   {
@@ -1010,9 +1000,7 @@ HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   }
   
   ep->is_stall = 1U;
-  ep->num   = ep_addr & 0x7FU;
-  ep->is_in = ((ep_addr & 0x80U) == 0x80U);
-  
+
   __HAL_LOCK(hpcd);
   USB_EPSetStall(hpcd->Instance , ep);
   if((ep_addr & 0x7FU) == 0U)
@@ -1044,9 +1032,7 @@ HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   }
   
   ep->is_stall = 0U;
-  ep->num   = ep_addr & 0x7FU;
-  ep->is_in = ((ep_addr & 0x80U) == 0x80U);
-  
+
   __HAL_LOCK(hpcd); 
   USB_EPClearStall(hpcd->Instance , ep);
   __HAL_UNLOCK(hpcd); 

--- a/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_pcd.c
+++ b/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_pcd.c
@@ -1364,6 +1364,7 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
             ep->pending1 = (uint16_t) (count == 0 ? PCD_PENDED_ZLP : count);
             return HAL_OK;
           }
+          ep->pending0 = 0;
         }
         else
         {
@@ -1374,14 +1375,6 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
             ep->pending0 = (uint16_t) (count == 0 ? PCD_PENDED_ZLP : count);
             return HAL_OK;
           }
-        }
-
-        if (PCD_OUT_SW(wEPVal))
-        {
-          ep->pending0 = 0;
-        }
-        else
-        {
           ep->pending1 = 0;
         }
 

--- a/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_pcd.c
+++ b/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_pcd.c
@@ -1353,10 +1353,6 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
         if (ep->doublebuffer == 0U)
         {
           ep->xfer_count = PCD_GET_EP_TX_CNT(hpcd->Instance, ep->num);
-          if (ep->xfer_count != 0U)
-          {
-            USB_WritePMA(hpcd->Instance, ep->xfer_buff, ep->pmaadress, ep->xfer_count);
-          }
         }
         else
         {
@@ -1364,19 +1360,11 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
           {
             /*read from endpoint BUF0Addr buffer*/
             ep->xfer_count = PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
-            if (ep->xfer_count != 0U)
-            {
-              USB_WritePMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr0, ep->xfer_count);
-            }
           }
           else
           {
             /*read from endpoint BUF1Addr buffer*/
             ep->xfer_count = PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
-            if (ep->xfer_count != 0U)
-            {
-              USB_WritePMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, ep->xfer_count);
-            }
           }
           PCD_FreeUserBuffer(hpcd->Instance, ep->num, PCD_EP_DBUF_IN);  
         }

--- a/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_ll_usb.c
+++ b/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_ll_usb.c
@@ -1757,7 +1757,7 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
       /* Clear the data toggle bits for the endpoint IN/OUT */
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
       PCD_CLEAR_TX_DTOG(USBx, ep->num);
-      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_VALID);
       PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
     }
     else
@@ -1887,35 +1887,11 @@ HAL_StatusTypeDef USB_EPStartXfer(USB_TypeDef *USBx , USB_EPTypeDef *ep)
       PCD_FreeUserBuffer(USBx, ep->num, ep->is_in);
     }
   }
-  else /* OUT endpoint */
+  else
   {
-    /* Multi packet transfer*/
-    if (ep->xfer_len > ep->maxpacket)
-    {
-      len=ep->maxpacket;
-      ep->xfer_len-=len; 
-    }
-    else
-    {
-      len=ep->xfer_len;
-      ep->xfer_len =0;
-    }
-    
-    /* configure and validate Rx endpoint */
-    if (ep->doublebuffer == 0) 
-    {
-      /*Set RX buffer count*/
-      PCD_SET_EP_RX_CNT(USBx, ep->num, len);
-    }
-    else
-    {
-      /*Set the Double buffer counter*/
-      PCD_SET_EP_DBUF_CNT(USBx, ep->num, ep->is_in, len);
-    }
-    
     PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
   }
-  
+
   return HAL_OK;
 }
 

--- a/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_ll_usb.c
+++ b/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_ll_usb.c
@@ -1835,13 +1835,13 @@ HAL_StatusTypeDef USB_DeactivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
   */
 HAL_StatusTypeDef USB_EPStartXfer(USB_TypeDef *USBx , USB_EPTypeDef *ep)
 {
-  uint16_t pmabuffer = 0;
-  uint32_t len = ep->xfer_len;
+  uint16_t pmabuffer;
+  uint32_t len;
   
   /* IN endpoint */
   if (ep->is_in == 1)
   {
-    /*Multi packet transfer*/
+    /* Multi packet transfer */
     if (ep->xfer_len > ep->maxpacket)
     {
       len=ep->maxpacket;
@@ -1856,8 +1856,8 @@ HAL_StatusTypeDef USB_EPStartXfer(USB_TypeDef *USBx , USB_EPTypeDef *ep)
     /* configure and validate Tx endpoint */
     if (ep->doublebuffer == 0) 
     {
-      USB_WritePMA(USBx, ep->xfer_buff, ep->pmaadress, len);
       PCD_SET_EP_TX_CNT(USBx, ep->num, len);
+      pmabuffer = ep->pmaadress;
     }
     else
     {
@@ -1874,11 +1874,18 @@ HAL_StatusTypeDef USB_EPStartXfer(USB_TypeDef *USBx , USB_EPTypeDef *ep)
         PCD_SET_EP_DBUF0_CNT(USBx, ep->num, ep->is_in, len);
         pmabuffer = ep->pmaaddr0;
       }
-      USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, len);
+    }
+
+    USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t) len);
+
+    if (ep->doublebuffer == 0)
+    {
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_VALID);
+    }
+    else
+    {
       PCD_FreeUserBuffer(USBx, ep->num, ep->is_in);
     }
-    
-    PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_VALID);
   }
   else /* OUT endpoint */
   {

--- a/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_ll_usb.c
+++ b/system/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_ll_usb.c
@@ -1725,54 +1725,51 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
   
   if (ep->doublebuffer == 0) 
   {
-    if (ep->is_in)
+    if (ep->is_in == 1)
     {
-      /*Set the endpoint Transmit buffer address */
+      /* Set the endpoint Transmit buffer address */
       PCD_SET_EP_TX_ADDRESS(USBx, ep->num, ep->pmaadress);
       PCD_CLEAR_TX_DTOG(USBx, ep->num);
-      /* Configure NAK status for the Endpoint*/
-      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_NAK); 
+      /* Configure NAK status for the Endpoint */
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_NAK);
     }
     else
     {
-      /*Set the endpoint Receive buffer address */
+      /* Set the endpoint Receive buffer address */
       PCD_SET_EP_RX_ADDRESS(USBx, ep->num, ep->pmaadress);
-      /*Set the endpoint Receive buffer counter*/
+      /* Set the endpoint Receive buffer counter */
       PCD_SET_EP_RX_CNT(USBx, ep->num, ep->maxpacket);
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
-      /* Configure VALID status for the Endpoint*/
-      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+      /* All ep must NAK to every host request before PrepareReceive */
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_NAK);
     }
   }
-  /*Double Buffer*/
+  /* Double Buffer */
   else
   {
-    /*Set the endpoint as double buffered*/
+    /* Set the endpoint as double buffered */
     PCD_SET_EP_DBUF(USBx, ep->num);
-    /*Set buffer address for double buffered mode*/
+    /* Set buffer address for double buffered mode */
     PCD_SET_EP_DBUF_ADDR(USBx, ep->num,ep->pmaaddr0, ep->pmaaddr1);
     
-    if (ep->is_in==0)
+    if (ep->is_in == 1)
     {
-      /* Clear the data toggle bits for the endpoint IN/OUT*/
+      /* Clear the data toggle bits for the endpoint IN/OUT */
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
       PCD_CLEAR_TX_DTOG(USBx, ep->num);
-      
-      /* Reset value of the data toggle bits for the endpoint out*/
-      PCD_TX_DTOG(USBx, ep->num);
-      
-      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
-      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
     }
     else
     {
-      /* Clear the data toggle bits for the endpoint IN/OUT*/
+      PCD_SET_EP_DBUF_CNT(USBx, ep->num, ep->is_in, ep->maxpacket);
+      /* Clear the data toggle bits for the endpoint IN/OUT */
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
       PCD_CLEAR_TX_DTOG(USBx, ep->num);
-      PCD_RX_DTOG(USBx, ep->num);
-      /* Configure DISABLE status for the Endpoint*/
+      /* All ep must NAK to every host request before PrepareReceive */
+      /* Reset value of the data toggle bits for the endpoint out */
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
       PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
-      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
     }
   }
   
@@ -1789,11 +1786,11 @@ HAL_StatusTypeDef USB_DeactivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
 {
   if (ep->doublebuffer == 0) 
   {
-    if (ep->is_in)
+    if (ep->is_in == 1)
     {
       PCD_CLEAR_TX_DTOG(USBx, ep->num);
       /* Configure DISABLE status for the Endpoint*/
-      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS); 
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
     }
     else
     {
@@ -1805,19 +1802,7 @@ HAL_StatusTypeDef USB_DeactivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
   /*Double Buffer*/
   else
   { 
-    if (ep->is_in==0)
-    {
-      /* Clear the data toggle bits for the endpoint IN/OUT*/
-      PCD_CLEAR_RX_DTOG(USBx, ep->num);
-      PCD_CLEAR_TX_DTOG(USBx, ep->num);
-      
-      /* Reset value of the data toggle bits for the endpoint out*/
-      PCD_TX_DTOG(USBx, ep->num);
-      
-      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
-      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
-    }
-    else
+    if (ep->is_in == 1)
     {
       /* Clear the data toggle bits for the endpoint IN/OUT*/
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
@@ -1826,6 +1811,16 @@ HAL_StatusTypeDef USB_DeactivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
       /* Configure DISABLE status for the Endpoint*/
       PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
       PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
+    }
+    else
+    {
+      /* Clear the data toggle bits for the endpoint IN/OUT*/
+      PCD_CLEAR_RX_DTOG(USBx, ep->num);
+      PCD_CLEAR_TX_DTOG(USBx, ep->num);
+      /* Reset value of the data toggle bits for the endpoint out*/
+      PCD_TX_DTOG(USBx, ep->num);
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
     }
   }
   

--- a/system/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc/usbd_cdc.h
+++ b/system/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc/usbd_cdc.h
@@ -154,6 +154,7 @@ uint8_t  USBD_CDC_SetRxBuffer(USBD_HandleTypeDef   *pdev,
                               uint8_t  *pbuff);
 
 uint8_t  USBD_CDC_ReceivePacket(USBD_HandleTypeDef *pdev);
+uint8_t  USBD_CDC_ClearBuffer(USBD_HandleTypeDef *pdev);
 
 uint8_t  USBD_CDC_TransmitPacket(USBD_HandleTypeDef *pdev);
 /**

--- a/system/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
+++ b/system/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
@@ -877,6 +877,25 @@ uint8_t  USBD_CDC_ReceivePacket(USBD_HandleTypeDef *pdev)
     return USBD_FAIL;
   }
 }
+
+uint8_t USBD_CDC_ClearBuffer(USBD_HandleTypeDef *pdev)
+{
+  USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef *) pdev->pClassData;
+
+  /* Suspend or Resume USB Out process */
+  if (pdev->pClassData != NULL) {
+    if (pdev->dev_speed == USBD_SPEED_HIGH) {
+      /* Prepare Out endpoint to receive next packet */
+      USBD_LL_PrepareReceive(pdev, CDC_OUT_EP, 0, 0);
+    } else {
+      /* Prepare Out endpoint to receive next packet */
+      USBD_LL_PrepareReceive(pdev, CDC_OUT_EP, 0, 0);
+    }
+    return USBD_OK;
+  } else {
+    return USBD_FAIL;
+  }
+}
 /**
   * @}
   */

--- a/system/Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_def.h
+++ b/system/Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_def.h
@@ -223,8 +223,6 @@ typedef struct {
 typedef struct {
   uint32_t                status;
   uint32_t                is_used;
-  uint32_t                total_length;
-  uint32_t                rem_length;
 } USBD_EndpointTypeDef;
 
 /* USB Device handle structure */
@@ -238,6 +236,8 @@ typedef struct _USBD_HandleTypeDef {
   USBD_EndpointTypeDef    ep_out[15];
   uint32_t                ep0_state;
   uint32_t                ep0_data_len;
+  uint32_t                ep0_rem_len;
+  uint32_t                ep0_total_len;
   uint8_t                 dev_state;
   uint8_t                 dev_old_state;
   uint8_t                 dev_address;

--- a/system/Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_def.h
+++ b/system/Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_def.h
@@ -241,7 +241,6 @@ typedef struct _USBD_HandleTypeDef {
   uint8_t                 dev_state;
   uint8_t                 dev_old_state;
   uint8_t                 dev_address;
-  uint8_t                 dev_connection_status;
   uint8_t                 dev_test_mode;
   uint32_t                dev_remote_wakeup;
 

--- a/system/Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_def.h
+++ b/system/Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_def.h
@@ -225,7 +225,6 @@ typedef struct {
   uint32_t                is_used;
   uint32_t                total_length;
   uint32_t                rem_length;
-  uint32_t                maxpacket;
 } USBD_EndpointTypeDef;
 
 /* USB Device handle structure */

--- a/system/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c
+++ b/system/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c
@@ -295,12 +295,12 @@ USBD_StatusTypeDef USBD_LL_DataOutStage(USBD_HandleTypeDef *pdev,
     pep = &pdev->ep_out[0];
 
     if (pdev->ep0_state == USBD_EP0_DATA_OUT) {
-      if (pep->rem_length > pep->maxpacket) {
-        pep->rem_length -=  pep->maxpacket;
+      if (pep->rem_length > USB_MAX_EP0_SIZE) {
+        pep->rem_length -=  USB_MAX_EP0_SIZE;
 
         USBD_CtlContinueRx(pdev,
                            pdata,
-                           (uint16_t)MIN(pep->rem_length, pep->maxpacket));
+                           (uint16_t)MIN(pep->rem_length, USB_MAX_EP0_SIZE));
       } else {
         if ((pdev->pClass->EP0_RxReady != NULL) &&
             (pdev->dev_state == USBD_STATE_CONFIGURED)) {
@@ -344,8 +344,8 @@ USBD_StatusTypeDef USBD_LL_DataInStage(USBD_HandleTypeDef *pdev, uint8_t epnum,
     pep = &pdev->ep_in[0];
 
     if (pdev->ep0_state == USBD_EP0_DATA_IN) {
-      if (pep->rem_length > pep->maxpacket) {
-        pep->rem_length -= pep->maxpacket;
+      if (pep->rem_length > USB_MAX_EP0_SIZE) {
+        pep->rem_length -= USB_MAX_EP0_SIZE;
 
         USBD_CtlContinueSendData(pdev, pdata, (uint16_t)pep->rem_length);
 
@@ -353,8 +353,8 @@ USBD_StatusTypeDef USBD_LL_DataInStage(USBD_HandleTypeDef *pdev, uint8_t epnum,
         USBD_LL_PrepareReceive(pdev, 0U, NULL, 0U);
       } else {
         /* last packet is MPS multiple, so send ZLP packet */
-        if ((pep->total_length % pep->maxpacket == 0U) &&
-            (pep->total_length >= pep->maxpacket) &&
+        if ((pep->total_length % USB_MAX_EP0_SIZE == 0U) &&
+            (pep->total_length >= USB_MAX_EP0_SIZE) &&
             (pep->total_length < pdev->ep0_data_len)) {
           USBD_CtlContinueSendData(pdev, NULL, 0U);
           pdev->ep0_data_len = 0U;
@@ -410,13 +410,10 @@ USBD_StatusTypeDef USBD_LL_Reset(USBD_HandleTypeDef  *pdev)
   USBD_LL_OpenEP(pdev, 0x00U, USBD_EP_TYPE_CTRL, USB_MAX_EP0_SIZE);
   pdev->ep_out[0x00U & 0xFU].is_used = 1U;
 
-  pdev->ep_out[0].maxpacket = USB_MAX_EP0_SIZE;
-
   /* Open EP0 IN */
   USBD_LL_OpenEP(pdev, 0x80U, USBD_EP_TYPE_CTRL, USB_MAX_EP0_SIZE);
   pdev->ep_in[0x80U & 0xFU].is_used = 1U;
 
-  pdev->ep_in[0].maxpacket = USB_MAX_EP0_SIZE;
   /* Upon Reset call user call back */
   pdev->dev_state = USBD_STATE_DEFAULT;
   pdev->ep0_state = USBD_EP0_IDLE;

--- a/system/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c
+++ b/system/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c
@@ -89,8 +89,8 @@ USBD_StatusTypeDef USBD_CtlSendData(USBD_HandleTypeDef *pdev, uint8_t *pbuf,
 {
   /* Set EP0 State */
   pdev->ep0_state = USBD_EP0_DATA_IN;
-  pdev->ep_in[0].total_length = len;
-  pdev->ep_in[0].rem_length   = len;
+  pdev->ep0_total_len = len;
+  pdev->ep0_rem_len   = len;
 
   /* Start the transfer */
   USBD_LL_Transmit(pdev, 0x00U, pbuf, len);
@@ -128,8 +128,8 @@ USBD_StatusTypeDef USBD_CtlPrepareRx(USBD_HandleTypeDef *pdev, uint8_t *pbuf,
 {
   /* Set EP0 State */
   pdev->ep0_state = USBD_EP0_DATA_OUT;
-  pdev->ep_out[0].total_length = len;
-  pdev->ep_out[0].rem_length   = len;
+  pdev->ep0_total_len = len;
+  pdev->ep0_rem_len   = len;
 
   /* Start the transfer */
   USBD_LL_PrepareReceive(pdev, 0U, pbuf, len);


### PR DESCRIPTION
### Receive double buffering for STM32F103 and others. Milestone 1

Affected devices:

- STM32F103x6
- STM32F103xB
- STM32F103xG
- STM32F103xE
- STM32F102x6
- STM32F102xB

Transmission double buffering not tested yet.

Reception works. It achieve maximum CDC speed, available for this devices.
It also contains a set of fixes and improvements.