### PR TITLE
Fixed error, when host send some buffer, less then minimum.

### DIFF
--- a/cores/arduino/stm32/usb/cdc/usbd_cdc.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc.c
@@ -882,6 +882,18 @@ uint8_t  USBD_CDC_ReceivePacket(USBD_HandleTypeDef *pdev)
   }
 }
 
+uint8_t USBD_CDC_ClearBuffer(USBD_HandleTypeDef *pdev)
+{
+  /* Suspend or Resume USB Out process */
+  if (pdev->pClassData != NULL) {
+    /* Prepare Out endpoint to receive next packet */
+    USBD_LL_PrepareReceive(pdev, CDC_OUT_EP, 0, 0);
+    return USBD_OK;
+  } else {
+    return USBD_FAIL;
+  }
+}
+
 #endif /* USBD_USE_CDC */
 #endif /* USBCON */
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc.h
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc.h
@@ -156,6 +156,8 @@ uint8_t  USBD_CDC_SetRxBuffer(USBD_HandleTypeDef   *pdev,
 
 uint8_t  USBD_CDC_ReceivePacket(USBD_HandleTypeDef *pdev);
 
+uint8_t  USBD_CDC_ClearBuffer(USBD_HandleTypeDef *pdev);
+
 uint8_t  USBD_CDC_TransmitPacket(USBD_HandleTypeDef *pdev);
 /**
   * @}

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
@@ -205,7 +205,9 @@ static int8_t USBD_CDC_Receive(uint8_t *Buf, uint32_t *Len)
   CDC_ReceiveQueue_CommitBlock(&ReceiveQueue, (uint16_t)(*Len));
   receivePended = false;
   /* If enough space in the queue for a full buffer then continue receive */
-  CDC_resume_receive();
+  if (!CDC_resume_receive()) {
+    USBD_CDC_ClearBuffer(&hUSBD_Device_CDC);
+  }
   return USBD_OK;
 }
 
@@ -271,7 +273,7 @@ void CDC_continue_transmit(void)
   }
 }
 
-void CDC_resume_receive(void)
+bool CDC_resume_receive(void)
 {
   /*
    * TS: main and IRQ threads can't pass it at same time, because
@@ -284,7 +286,9 @@ void CDC_resume_receive(void)
       /* Set new buffer */
       USBD_CDC_SetRxBuffer(&hUSBD_Device_CDC, block);
       USBD_CDC_ReceivePacket(&hUSBD_Device_CDC);
+      return true;
     }
+    return false;
   }
 }
 

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.h
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.h
@@ -47,7 +47,7 @@ extern CDC_ReceiveQueue_TypeDef ReceiveQueue;
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */
 void CDC_continue_transmit(void);
-void CDC_resume_receive(void);
+bool CDC_resume_receive(void);
 void CDC_init(void);
 void CDC_deInit(void);
 


### PR DESCRIPTION
Fixed error, when host send some buffer, less then minimum, and new buffer can't be allocated

I found error in my buffer flipping technology (for usb CDC). When host sends some buffer, less than maxpacket and queue is full, USBD_CDC_Receive does nothing... But, it means, that usb pcd try to fill the rest of previously allocated buffer, and it will expect, that host will send buffer, smaller that maxpacket. But as a rule it is not. So, we must clear pcd buffer in this case. 