### PR TITLE
[Superseded by #541] twi: enable ack'ing general calls

### DIFF
--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -193,7 +193,7 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
   handle->Init.OwnAddress2     = 0xFF;
   handle->Init.AddressingMode  = addressingMode;
   handle->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-  handle->Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+  handle->Init.GeneralCallMode = I2C_GENERALCALL_ENABLE;
   handle->Init.NoStretchMode   = I2C_NOSTRETCH_DISABLE;
 
   handle->State = HAL_I2C_STATE_RESET;


### PR DESCRIPTION
In I2C, sending data to address 0 sends it to all devices on the bus. This is called a general call. This setting controls whether the slave device ACKs general calls or not.

I'm not sure if this will break existing code.