### PR TITLE
Fix issue #478.

### DIFF
--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
@@ -263,8 +263,9 @@ void CDC_deInit(void)
 
 bool CDC_connected()
 {
-  uint32_t transmitTime = 0;
-  if (transmitStart) {
+  // Save the transmitStart value in a local variable - fix #478
+  uint32_t transmitTime = transmitStart;
+  if (transmitTime) {
     transmitTime = HAL_GetTick() - transmitStart;
   }
   return hUSBD_Device_CDC.dev_state == USBD_STATE_CONFIGURED


### PR DESCRIPTION
This PR fixes/implements the following **bugs/features**

* [ #478 ] Bug USBSerial loosing characters on Linux

In CDC_connected the core reads the value of the global variable transmitStart twice. This is a problem because the variable is modified inside ISR and the value can change between the two reads. It can lead to calculating the wrong value for transmitTime which can lead to loss of data.

This proposed fix would save the value of transmitStart in a local variable, so we read the value only once.

Fixes #478 
