### PR TITLE
Do not warn if start of section is changed

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -37,7 +37,7 @@ compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.wa
 
 compiler.ar.flags=rcs
 
-compiler.c.elf.flags=-mcpu={build.mcu} -mthumb {build.flags.optimize} {build.flags.ldspecs} -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align
+compiler.c.elf.flags=-mcpu={build.mcu} -mthumb {build.flags.optimize} {build.flags.ldspecs} -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common
 
 compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
 


### PR DESCRIPTION
Remove `ld `option '`warn-section-align`', as by default, **SECTIONS** command
does not specify a start address for the section, let `ld `do the work.
If a start address is specified no warn was displayed.

> --warn-section-align
>     Warn if the address of an output section is changed because of
>     alignment. Typically, the alignment will be set by an input section.
>     The address will only be changed if it not explicitly specified;
>     that is, if the SECTIONS command does not specify a start address
>     for the section.

Fix #465