### PR TITLE
Disable USART IRQ in uart_write and uart_debug_write

### DIFF
--- a/cores/arduino/stm32/uart.c
+++ b/cores/arduino/stm32/uart.c
@@ -607,12 +607,16 @@ size_t uart_debug_write(uint8_t *data, uint32_t size)
     index = serial_debug.index;
   }
 
+  HAL_NVIC_DisableIRQ(serial_debug.irq);
+
   while (HAL_UART_Transmit(uart_handlers[index], data, size, TX_TIMEOUT) != HAL_OK) {
     if ((HAL_GetTick() - tickstart) >=  TX_TIMEOUT) {
+      HAL_NVIC_EnableIRQ(serial_debug.irq);
       return 0;
     }
   }
 
+  HAL_NVIC_EnableIRQ(serial_debug.irq);
   return size;
 }
 

--- a/cores/arduino/stm32/uart.c
+++ b/cores/arduino/stm32/uart.c
@@ -797,16 +797,23 @@ void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
   }
 #else
   if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
-    tmpval = huart->Instance->RDR; /* Clear PE flag */
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF); /* Clear PE flag */
   } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
-    tmpval = huart->Instance->RDR; /* Clear FE flag */
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_FEF); /* Clear FE flag */
   } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
-    tmpval = huart->Instance->RDR; /* Clear NE flag */
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_NEF); /* Clear NE flag */
   } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-    tmpval = huart->Instance->RDR; /* Clear ORE flag */
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF); /* Clear ORE flag */
   }
 #endif
-
+  /* Restart receive interrupt after any error */
+  uint8_t index = uart_index(huart);
+  if (index < UART_NUM) {
+    serial_t *obj = rx_callback_obj[index];
+    if (!serial_rx_active(obj)) {
+      HAL_UART_Receive_IT(uart_handlers[obj->index], &(obj->recv), 1);
+    }
+  }
   UNUSED(tmpval);
 }
 


### PR DESCRIPTION
This PR fixes issues #494 and #467 for printf();

I want to be able to use printf() with Serial.write() and Serial.read(). See discussion in both issues mentioned above.

**Validation**

See the example code in #494

---

I'm not sure how to:

- Get IRQn_Type values from a UART_TypeDef
- Determine which UARTs are defined for a given device 
- Whether I need to set the priority when enabling the interrupt