### PR TITLE
Support custom Usb reenumerate

### DIFF
--- a/cores/arduino/stm32/usb/usbd_if.c
+++ b/cores/arduino/stm32/usb/usbd_if.c
@@ -16,7 +16,7 @@
   * @retval None
   */
 
-__weak void USBD_reenumerate(void)
+WEAK void USBD_reenumerate(void)
 {
 #ifndef USBD_REENUM_DISABLED
   /* Re-enumerate the USB */

--- a/cores/arduino/stm32/usb/usbd_if.c
+++ b/cores/arduino/stm32/usb/usbd_if.c
@@ -16,7 +16,7 @@
   * @retval None
   */
 
-void USBD_reenumerate(void)
+__weak void USBD_reenumerate(void)
 {
 #ifndef USBD_REENUM_DISABLED
   /* Re-enumerate the USB */

--- a/variants/MALYANM200_F103CB/variant.cpp
+++ b/variants/MALYANM200_F103CB/variant.cpp
@@ -95,6 +95,16 @@ void initVariant()
   digitalWrite(PB9, 1);
 }
 
+void USBD_reenumerate(void)
+{
+  pinMode(PB9, OUTPUT);
+  digitalWrite(PB9, HIGH);
+  delay(10);
+  digitalWrite(PB9, LOW);
+  delay(10);
+  digitalWrite(PB9, HIGH);
+}
+
 /**
   * @brief  System Clock Configuration
   *         The system Clock is configured as follow :


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Supports USB custom reenumerate. The Malyan M200 V1 board has a pull up circuit that renders the DP pulldown method unreliable. 

making the renumerate function weak allows a variant to override it

**Validation**

* Ensure Travis CI build is passed.
Tested on Malyan M200 V1 rev 1, 3, and 4 (STM32F103) and on Malyan M200 V2 (STM32F070) to make sure it didn't affect others.

