### PR TITLE
Fix String::remove warning

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -829,7 +829,7 @@ void String::remove(unsigned int index, unsigned int count)
   }
   char *writeTo = buffer + index;
   len = len - count;
-  strncpy(writeTo, buffer + index + count, len - index);
+  memmove(writeTo, buffer + index + count, len - index);
   buffer[len] = 0;
 }
 


### PR DESCRIPTION
Replace `strncpy()` usage in `String::remove` method by `memmove()`.
Destination and source shall not overlap when using `strncpy()` while
`memmove()` is safer alternative when overlapping.

Warning raised after moved from arm-none-eabi-gcc 6-2017-q2-update
to 8-2018-q4-major:
```
cores\arduino\WString.cpp: In member function 'void String::remove(unsigned int, unsigned int)':
cores\arduino\WString.cpp:832:10: warning: 'char* strncpy(char*, const char*, size_t)' accessing 0 or more bytes at offsets [0, 2147483647] and [0, 2147483647] may overlap up to 4294967295 bytes at offset [6442450941, 2147483647] [-Wrestrict]
   strncpy(writeTo, buffer + index + count, len - index);
   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```