### PR TITLE
[PR 496 rework] Disable USART IRQ in uart_write and uart_debug_write 

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -244,7 +244,7 @@ void HardwareSerial::configForLowPower(void)
   // Reconfigure properly Serial instance to use HSI as clock source
   end();
   uart_config_lowpower(&_serial);
-  begin(_serial.baudrate, _config);
+  begin(_baud, _config);
 #endif
 }
 
@@ -290,8 +290,10 @@ int HardwareSerial::_tx_complete_irq(serial_t *obj)
 void HardwareSerial::begin(unsigned long baud, byte config)
 {
   uint32_t databits = 0;
+  uint32_t stopbits = 0;
+  uint32_t parity = 0;
 
-  _serial.baudrate = (uint32_t)baud;
+  _baud = baud;
   _config = config;
 
   // Manage databits
@@ -311,32 +313,32 @@ void HardwareSerial::begin(unsigned long baud, byte config)
   }
 
   if ((config & 0x30) == 0x30) {
-    _serial.parity = UART_PARITY_ODD;
+    parity = UART_PARITY_ODD;
     databits++;
   } else if ((config & 0x20) == 0x20) {
-    _serial.parity = UART_PARITY_EVEN;
+    parity = UART_PARITY_EVEN;
     databits++;
   } else {
-    _serial.parity = UART_PARITY_NONE;
+    parity = UART_PARITY_NONE;
   }
 
   if ((config & 0x08) == 0x08) {
-    _serial.stopbits = UART_STOPBITS_2;
+    stopbits = UART_STOPBITS_2;
   } else {
-    _serial.stopbits = UART_STOPBITS_1;
+    stopbits = UART_STOPBITS_1;
   }
 
   switch (databits) {
 #ifdef UART_WORDLENGTH_7B
     case 7:
-      _serial.databits = UART_WORDLENGTH_7B;
+      databits = UART_WORDLENGTH_7B;
       break;
 #endif
     case 8:
-      _serial.databits = UART_WORDLENGTH_8B;
+      databits = UART_WORDLENGTH_8B;
       break;
     case 9:
-      _serial.databits = UART_WORDLENGTH_9B;
+      databits = UART_WORDLENGTH_9B;
       break;
     default:
     case 0:
@@ -344,7 +346,7 @@ void HardwareSerial::begin(unsigned long baud, byte config)
       break;
   }
 
-  uart_init(&_serial);
+  uart_init(&_serial, (uint32_t)baud, databits, parity, stopbits);
   uart_attach_rx_callback(&_serial, _rx_complete_irq);
 }
 

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -150,6 +150,7 @@ class HardwareSerial : public Stream {
     static int _tx_complete_irq(serial_t *obj);
   private:
     uint8_t _config;
+    unsigned long _baud;
     void init(void);
     void configForLowPower(void);
 };

--- a/cores/arduino/stm32/uart.c
+++ b/cores/arduino/stm32/uart.c
@@ -607,14 +607,24 @@ size_t uart_debug_write(uint8_t *data, uint32_t size)
       if (serial_debug.index >= UART_NUM) {
         return 0;
       }
+    } else {
+      serial_t *obj = rx_callback_obj[serial_debug.index];
+      if (obj) {
+        serial_debug.irq = obj->irq;
+      }
     }
   }
 
+  HAL_NVIC_DisableIRQ(serial_debug.irq);
+
   while (HAL_UART_Transmit(uart_handlers[serial_debug.index], data, size, TX_TIMEOUT) != HAL_OK) {
     if ((HAL_GetTick() - tickstart) >=  TX_TIMEOUT) {
-      return 0;
+      size = 0;
+      break;
     }
   }
+
+  HAL_NVIC_EnableIRQ(serial_debug.irq);
 
   return size;
 }

--- a/cores/arduino/stm32/uart.c
+++ b/cores/arduino/stm32/uart.c
@@ -104,6 +104,19 @@ static serial_t *tx_callback_obj[UART_NUM];
 
 static serial_t serial_debug = { .uart = NP, .index = UART_NUM };
 
+/* Aim of the function is to get serial_s pointer using huart pointer */
+/* Highly inspired from magical linux kernel's "container_of" */
+serial_t *get_serial_obj(UART_HandleTypeDef *huart)
+{
+  struct serial_s *obj_s;
+  serial_t *obj;
+
+  obj_s = (struct serial_s *)((char *)huart - offsetof(struct serial_s, handle));
+  obj = (serial_t *)((char *)obj_s - offsetof(serial_t, uart));
+
+  return (obj);
+}
+
 /**
   * @brief  Function called to initialize the uart interface
   * @param  obj : pointer to serial_t structure

--- a/cores/arduino/stm32/uart.c
+++ b/cores/arduino/stm32/uart.c
@@ -118,7 +118,7 @@ serial_t *get_serial_obj(UART_HandleTypeDef *huart)
   * @param  obj : pointer to serial_t structure
   * @retval None
   */
-void uart_init(serial_t *obj)
+void uart_init(serial_t *obj, uint32_t baudrate, uint32_t databits, uint32_t parity, uint32_t stopbits)
 {
   if (obj == NULL) {
     return;
@@ -293,10 +293,10 @@ void uart_init(serial_t *obj)
   /* Configure uart */
   uart_handlers[obj->index] = huart;
   huart->Instance          = (USART_TypeDef *)(obj->uart);
-  huart->Init.BaudRate     = obj->baudrate;
-  huart->Init.WordLength   = obj->databits;
-  huart->Init.StopBits     = obj->stopbits;
-  huart->Init.Parity       = obj->parity;
+  huart->Init.BaudRate     = baudrate;
+  huart->Init.WordLength   = databits;
+  huart->Init.StopBits     = stopbits;
+  huart->Init.Parity       = parity;
   huart->Init.Mode         = UART_MODE_TX_RX;
   huart->Init.HwFlowCtl    = UART_HWCONTROL_NONE;
   huart->Init.OverSampling = UART_OVERSAMPLING_16;
@@ -315,7 +315,7 @@ void uart_init(serial_t *obj)
    * check Reference Manual
    */
   if (obj->uart == LPUART1) {
-    if (obj->baudrate <= 9600) {
+    if (baudrate <= 9600) {
 #if defined(USART_CR3_UCESM)
       HAL_UARTEx_EnableClockStopMode(huart);
 #endif
@@ -332,7 +332,7 @@ void uart_init(serial_t *obj)
     }
     /* Trying to change LPUART clock source */
     /* If baudrate is lower than or equal to 9600 try to change to LSE */
-    if (obj->baudrate <= 9600) {
+    if (baudrate <= 9600) {
       /* Enable the clock if not already set by user */
       enableClock(LSE_CLOCK);
 
@@ -578,12 +578,8 @@ void uart_debug_init(void)
 #else
     serial_debug.pin_tx = pinmap_pin(DEBUG_UART, PinMap_UART_TX);
 #endif
-    serial_debug.baudrate = DEBUG_UART_BAUDRATE;
-    serial_debug.parity = UART_PARITY_NONE;
-    serial_debug.databits = UART_WORDLENGTH_8B;
-    serial_debug.stopbits = UART_STOPBITS_1;
 
-    uart_init(&serial_debug);
+    uart_init(&serial_debug, DEBUG_UART_BAUDRATE, UART_WORDLENGTH_8B, UART_PARITY_NONE, UART_STOPBITS_1);
   }
 }
 

--- a/cores/arduino/stm32/uart.c
+++ b/cores/arduino/stm32/uart.c
@@ -685,12 +685,14 @@ void uart_attach_rx_callback(serial_t *obj, void (*callback)(serial_t *))
   rx_callback[obj->index] = callback;
   rx_callback_obj[obj->index] = obj;
 
+  /* Must disable interrupt to prevent handle lock contention */
+  HAL_NVIC_DisableIRQ(obj->irq);
+
+  HAL_UART_Receive_IT(uart_handlers[obj->index], &(obj->recv), 1);
+
+  /* Enable interrupt */
   HAL_NVIC_SetPriority(obj->irq, 0, 1);
   HAL_NVIC_EnableIRQ(obj->irq);
-
-  if (HAL_UART_Receive_IT(uart_handlers[obj->index], &(obj->recv), 1) != HAL_OK) {
-    return;
-  }
 }
 
 /**
@@ -709,14 +711,15 @@ void uart_attach_tx_callback(serial_t *obj, int (*callback)(serial_t *))
   tx_callback[obj->index] = callback;
   tx_callback_obj[obj->index] = obj;
 
+  /* Must disable interrupt to prevent handle lock contention */
+  HAL_NVIC_DisableIRQ(obj->irq);
+
+  /* The following function will enable UART_IT_TXE and error interrupts */
+  HAL_UART_Transmit_IT(uart_handlers[obj->index], &obj->tx_buff[obj->tx_tail], 1);
+
   /* Enable interrupt */
   HAL_NVIC_SetPriority(obj->irq, 0, 2);
   HAL_NVIC_EnableIRQ(obj->irq);
-
-  /* The following function will enable UART_IT_TXE and error interrupts */
-  if (HAL_UART_Transmit_IT(uart_handlers[obj->index], &obj->tx_buff[obj->tx_tail], 1) != HAL_OK) {
-    return;
-  }
 }
 
 /**

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -53,6 +53,11 @@ extern "C" {
 typedef struct serial_s serial_t;
 
 struct serial_s {
+  /*  The 1st 2 members USART_TypeDef *uart
+   *  and UART_HandleTypeDef handle should
+   *  be kept as the first members of this struct
+   *  to have get_serial_obj() function work as expected
+   */
   USART_TypeDef *uart;
   UART_HandleTypeDef handle;
   uint32_t baudrate;

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -62,10 +62,6 @@ struct serial_s {
   UART_HandleTypeDef handle;
   void (*rx_callback)(serial_t *);
   int (*tx_callback)(serial_t *);
-  uint32_t baudrate;
-  uint32_t databits;
-  uint32_t stopbits;
-  uint32_t parity;
   PinName pin_tx;
   PinName pin_rx;
   IRQn_Type irq;
@@ -165,7 +161,7 @@ struct serial_s {
 
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */
-void uart_init(serial_t *obj);
+void uart_init(serial_t *obj, uint32_t baudrate, uint32_t databits, uint32_t parity, uint32_t stopbits);
 void uart_deinit(serial_t *obj);
 #if defined(HAL_PWR_MODULE_ENABLED) && defined(UART_IT_WUF)
 void uart_config_lowpower(serial_t *obj);

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -55,8 +55,6 @@ typedef struct serial_s serial_t;
 struct serial_s {
   USART_TypeDef *uart;
   UART_HandleTypeDef handle;
-  uint8_t index;
-  uint8_t recv;
   uint32_t baudrate;
   uint32_t databits;
   uint32_t stopbits;
@@ -64,11 +62,13 @@ struct serial_s {
   PinName pin_tx;
   PinName pin_rx;
   IRQn_Type irq;
+  uint8_t index;
+  uint8_t recv;
   uint8_t *rx_buff;
-  volatile uint16_t rx_head;
-  uint16_t rx_tail;
   uint8_t *tx_buff;
+  uint16_t rx_tail;
   uint16_t tx_head;
+  volatile uint16_t rx_head;
   volatile uint16_t tx_tail;
 };
 

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -60,6 +60,8 @@ struct serial_s {
    */
   USART_TypeDef *uart;
   UART_HandleTypeDef handle;
+  void (*rx_callback)(serial_t *);
+  int (*tx_callback)(serial_t *);
   uint32_t baudrate;
   uint32_t databits;
   uint32_t stopbits;


### PR DESCRIPTION
This PR is a rework of #496  and fixes issues #494 and #467 

It hardens and enhances the original PR.
I've tested several config and it works with Arduino Serial monitor.
Note that if the same U(S)ART is used for `Serial` and `printf()` some bytes could be lost due to IRQ disabling.

@ppescher  and @benwaffle could you review and test it on your side
