### PR TITLE
Re-evaluate interrupt priority values

### DIFF
--- a/cores/arduino/stm32/interrupt.cpp
+++ b/cores/arduino/stm32/interrupt.cpp
@@ -35,7 +35,6 @@
   *
   ******************************************************************************
   */
-#include "stm32_def.h"
 #include "interrupt.h"
 
 /* Private Types */
@@ -163,8 +162,8 @@ void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin, callback_function_
 
   gpio_irq_conf[id].callback = callback;
 
-  // Enable and set Button EXTI Interrupt to the lowest priority
-  HAL_NVIC_SetPriority(gpio_irq_conf[id].irqnb, 0x06, 0);
+  // Enable and set EXTI Interrupt
+  HAL_NVIC_SetPriority(gpio_irq_conf[id].irqnb, EXTI_IRQ_PRIO, EXTI_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(gpio_irq_conf[id].irqnb);
 }
 

--- a/cores/arduino/stm32/interrupt.h
+++ b/cores/arduino/stm32/interrupt.h
@@ -40,11 +40,21 @@
 #define __INTERRUPT_H
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32_def.h"
-#include "PinNames.h"
+#include "variant.h"
 
 #if defined(STM32F3xx)
 #define EXTI2_IRQn    EXTI2_TSC_IRQn
+#endif
+
+#ifndef EXTI_IRQ_PRIO
+#if (__CORTEX_M == 0x00U)
+#define EXTI_IRQ_PRIO       3
+#else
+#define EXTI_IRQ_PRIO       6
+#endif /* __CORTEX_M */
+#endif /* EXTI_IRQ_PRIO */
+#ifndef EXTI_IRQ_SUBPRIO
+#define EXTI_IRQ_SUBPRIO    0
 #endif
 
 #ifdef __cplusplus

--- a/cores/arduino/stm32/rtc.c
+++ b/cores/arduino/stm32/rtc.c
@@ -335,7 +335,7 @@ void RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
   HAL_RTCEx_EnableBypassShadow(&RtcHandle);
 #endif /* !STM32F1xx && !STM32F2xx */
 
-  HAL_NVIC_SetPriority(RTC_Alarm_IRQn, 2, 0);
+  HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
   /* Ensure backup domain is enabled */
   enableBackupRegister();

--- a/cores/arduino/stm32/rtc.h
+++ b/cores/arduino/stm32/rtc.h
@@ -40,7 +40,7 @@
 #define __RTC_H
 
 /* Includes ------------------------------------------------------------------*/
-#include <stdbool.h>
+#include "variant.h"
 #include "backup.h"
 #include "clock.h"
 
@@ -77,6 +77,14 @@ typedef enum {
 typedef void(*voidCallbackPtr)(void *);
 
 /* Exported constants --------------------------------------------------------*/
+/* Interrupt priority */
+#ifndef RTC_IRQ_PRIO
+#define RTC_IRQ_PRIO       2
+#endif
+#ifndef RTC_IRQ_SUBPRIO
+#define RTC_IRQ_SUBPRIO    0
+#endif
+
 
 #define HSE_RTC_MAX 1000000U
 

--- a/cores/arduino/stm32/timer.c
+++ b/cores/arduino/stm32/timer.c
@@ -142,7 +142,7 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim_base)
 {
   timer_enable_clock(htim_base);
 
-  HAL_NVIC_SetPriority(getTimerIrq(htim_base->Instance), 15, 0);
+  HAL_NVIC_SetPriority(getTimerIrq(htim_base->Instance), TIM_IRQ_PRIO, TIM_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(getTimerIrq(htim_base->Instance));
 }
 
@@ -1131,7 +1131,7 @@ void attachIntHandleOC(stimer_t *obj, void (*irqHandle)(void), uint16_t timChann
   sConfig.OCIdleState   = TIM_OCIDLESTATE_RESET;
   sConfig.OCNIdleState  = TIM_OCNIDLESTATE_RESET;
 #endif
-  HAL_NVIC_SetPriority(getTimerIrq(obj->timer), 14, 0);
+  HAL_NVIC_SetPriority(getTimerIrq(obj->timer), TIM_IRQ_PRIO, TIM_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(getTimerIrq(obj->timer));
 
   if (HAL_TIM_OC_Init(handle) != HAL_OK) {

--- a/cores/arduino/stm32/timer.h
+++ b/cores/arduino/stm32/timer.h
@@ -40,8 +40,7 @@
 #define __TIMER_H
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32_def.h"
-#include "PeripheralPins.h"
+#include "variant.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,6 +76,17 @@ struct timer_s {
 };
 
 /* Exported constants --------------------------------------------------------*/
+#ifndef TIM_IRQ_PRIO
+#if (__CORTEX_M == 0x00U)
+#define TIM_IRQ_PRIO       3
+#else
+#define TIM_IRQ_PRIO       14
+#endif /* __CORTEX_M */
+#endif /* TIM_IRQ_PRIO */
+#ifndef TIM_IRQ_SUBPRIO
+#define TIM_IRQ_SUBPRIO    0
+#endif
+
 #define MAX_FREQ  65535
 
 #if defined(TIM1_BASE) && !defined(TIM1_IRQn)

--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -36,7 +36,6 @@
   ******************************************************************************
   */
 #include "core_debug.h"
-#include "stm32_def.h"
 #include "twi.h"
 #include "PinAF_STM32F1.h"
 
@@ -198,10 +197,10 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
 
   handle->State = HAL_I2C_STATE_RESET;
 
-  HAL_NVIC_SetPriority(obj->irq, 0, 1);
+  HAL_NVIC_SetPriority(obj->irq, I2C_IRQ_PRIO, I2C_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(obj->irq);
 #if !defined(STM32F0xx) && !defined(STM32L0xx)
-  HAL_NVIC_SetPriority(obj->irqER, 0, 1);
+  HAL_NVIC_SetPriority(obj->irqER, I2C_IRQ_PRIO, I2C_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(obj->irqER);
 #endif // !defined(STM32F0xx) && !defined(STM32L0xx)
 

--- a/cores/arduino/stm32/twi.h
+++ b/cores/arduino/stm32/twi.h
@@ -41,8 +41,7 @@
 #define __TWI_H__
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32_def.h"
-#include "PeripheralPins.h"
+#include "variant.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,6 +50,14 @@ extern "C" {
 /* Exported types ------------------------------------------------------------*/
 /* offsetof is a gcc built-in function, this is the manual implementation */
 #define OFFSETOF(type, member) ((uint32_t) (&(((type *)(0))->member)))
+
+/* Interrupt priority */
+#ifndef I2C_IRQ_PRIO
+#define I2C_IRQ_PRIO       2
+#endif
+#ifndef I2C_IRQ_SUBPRIO
+#define I2C_IRQ_SUBPRIO    0
+#endif
 
 /* I2C Tx/Rx buffer size */
 #define I2C_TXRX_BUFFER_SIZE    32

--- a/cores/arduino/stm32/uart.c
+++ b/cores/arduino/stm32/uart.c
@@ -703,7 +703,7 @@ void uart_attach_rx_callback(serial_t *obj, void (*callback)(serial_t *))
   HAL_UART_Receive_IT(uart_handlers[obj->index], &(obj->recv), 1);
 
   /* Enable interrupt */
-  HAL_NVIC_SetPriority(obj->irq, 0, 1);
+  HAL_NVIC_SetPriority(obj->irq, UART_IRQ_PRIO, UART_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(obj->irq);
 }
 
@@ -728,7 +728,7 @@ void uart_attach_tx_callback(serial_t *obj, int (*callback)(serial_t *))
   HAL_UART_Transmit_IT(uart_handlers[obj->index], &obj->tx_buff[obj->tx_tail], 1);
 
   /* Enable interrupt */
-  HAL_NVIC_SetPriority(obj->irq, 0, 2);
+  HAL_NVIC_SetPriority(obj->irq, UART_IRQ_PRIO, UART_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(obj->irq);
 }
 

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -38,7 +38,6 @@
 #define __UART_H
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32_def.h"
 #include "variant.h"
 
 #ifdef __cplusplus
@@ -48,6 +47,13 @@ extern "C" {
 #if !defined(HAL_UART_MODULE_ENABLED)
 #define serial_t void*
 #else
+
+#ifndef UART_IRQ_PRIO
+#define UART_IRQ_PRIO       1
+#endif
+#ifndef UART_IRQ_SUBPRIO
+#define UART_IRQ_SUBPRIO    0
+#endif
 
 /* Exported types ------------------------------------------------------------*/
 typedef struct serial_s serial_t;

--- a/cores/arduino/stm32/usb/usbd_conf.c
+++ b/cores/arduino/stm32/usb/usbd_conf.c
@@ -89,13 +89,13 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
 #endif
 
 #if defined(STM32WBxx)
-    HAL_NVIC_SetPriority(USB_HP_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(USB_HP_IRQn, USBD_IRQ_PRIO, USBD_IRQ_SUBPRIO);
     HAL_NVIC_EnableIRQ(USB_HP_IRQn);
-    HAL_NVIC_SetPriority(USB_LP_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(USB_LP_IRQn, USBD_IRQ_PRIO, USBD_IRQ_SUBPRIO);
     HAL_NVIC_EnableIRQ(USB_LP_IRQn);
 #else
     /* Set USB FS Interrupt priority */
-    HAL_NVIC_SetPriority(USB_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(USB_IRQn, USBD_IRQ_PRIO, USBD_IRQ_SUBPRIO);
 
     /* Enable USB FS Interrupt */
     HAL_NVIC_EnableIRQ(USB_IRQn);
@@ -134,7 +134,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
     __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
 
     /* Set USB FS Interrupt priority */
-    HAL_NVIC_SetPriority(OTG_FS_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(OTG_FS_IRQn, USBD_IRQ_PRIO, USBD_IRQ_SUBPRIO);
 
     /* Enable USB FS Interrupt */
     HAL_NVIC_EnableIRQ(OTG_FS_IRQn);
@@ -146,7 +146,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
       __HAL_USB_OTG_FS_WAKEUP_EXTI_ENABLE_IT();
 #if !defined(STM32L4xx)
       /* Set EXTI Wakeup Interrupt priority */
-      HAL_NVIC_SetPriority(OTG_FS_WKUP_IRQn, 0, 0);
+      HAL_NVIC_SetPriority(OTG_FS_WKUP_IRQn, USBD_IRQ_PRIO, USBD_IRQ_SUBPRIO);
 
       /* Enable EXTI Interrupt */
       HAL_NVIC_EnableIRQ(OTG_FS_WKUP_IRQn);
@@ -169,8 +169,8 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
     /* Enable USB HS Clocks */
     __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
 
-    /* Set USBHS Interrupt to the lowest priority */
-    HAL_NVIC_SetPriority(OTG_HS_IRQn, 5, 0);
+    /* Set USBHS Interrupt priority */
+    HAL_NVIC_SetPriority(OTG_HS_IRQn, USBD_IRQ_PRIO, USBD_IRQ_SUBPRIO);
 
     /* Enable USB HS Interrupt */
     HAL_NVIC_EnableIRQ(OTG_HS_IRQn);
@@ -182,7 +182,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
       __HAL_USB_OTG_HS_WAKEUP_EXTI_ENABLE_IT();
 
       /* Set EXTI Wakeup Interrupt priority */
-      HAL_NVIC_SetPriority(OTG_HS_WKUP_IRQn, 0, 0);
+      HAL_NVIC_SetPriority(OTG_HS_WKUP_IRQn, USBD_IRQ_PRIO, USBD_IRQ_SUBPRIO);
 
       /* Enable EXTI Interrupt */
       HAL_NVIC_EnableIRQ(OTG_HS_WKUP_IRQn);

--- a/cores/arduino/stm32/usb/usbd_conf.h
+++ b/cores/arduino/stm32/usb/usbd_conf.h
@@ -27,7 +27,6 @@ extern "C" {
 
 #ifdef USBCON
 /* Includes ------------------------------------------------------------------*/
-#include "stm32_def.h"
 #include "variant.h"
 
 #if !defined(USB_BASE) && !defined(USB_OTG_DEVICE_BASE)
@@ -104,6 +103,14 @@ extern "C" {
 #ifndef USBD_AUDIO_FREQ
 #define USBD_AUDIO_FREQ                     22100U
 #endif /* USBD_AUDIO_FREQ */
+
+/* Interrupt priority */
+#ifndef USBD_IRQ_PRIO
+#define USBD_IRQ_PRIO                       1
+#endif /* USBD_IRQ_PRIO */
+#ifndef USBD_IRQ_SUBPRIO
+#define USBD_IRQ_SUBPRIO                    0
+#endif /* USBD_IRQ_SUBPRIO */
 
 /* Memory management macros */
 #ifndef USBD_malloc


### PR DESCRIPTION
Can be redefined thanks `variant.h` or `build_opt.h`

Fix #472 

| IRQ | Old | New |
| --- | --- | --- |
| Systick | 0 | 0 |
| U(S)ART | 0 | 1 |
| USB | 5 | 1 |
| I2C | 0 | 2 |
| EXTI | 6 | 3/6 |
| TIM | 14 | 3/14 |
| RTC | 2 | 2 |

_With **x/y** = x for Cortex-M0 else y_