### PR TITLE
Fix dtostrf() comilation error

### DIFF
--- a/cores/arduino/avr/dtostrf.c
+++ b/cores/arduino/avr/dtostrf.c
@@ -18,6 +18,10 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE // to enable strdup() availability
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fixes the following error:

"/usr/bin/arm-none-eabi-gcc" -std=c11   -pipe -c -g3 -Os -DVERSION="-git-dirty" -Wall -Werror -Wextra -Werror=format-security -Wformat=2 -Wformat-overflow=2 -fshort-enums -fno-exceptions -ffunction-sections -fdata-sections -MMD -flto -MMD -I/home/sw/Arduino/DS18B20Test -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino/avr -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino/stm32 -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino/stm32/LL -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino/stm32/usb -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino/stm32/usb/hid -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino/stm32/usb/cdc -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/system/Drivers/STM32F1xx_HAL_Driver/Inc/ -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/system/Drivers/STM32F1xx_HAL_Driver/Src/ -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/system/STM32F1xx/ -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/system/Middlewares/ST/STM32_USB_Device_Library/Core/Inc -I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/system/Middlewares/ST/STM32_USB_Device_Library/Core/Src -Wno-unused-variable -DSTM32F1xx -DARDUINO=10600 -DARDUINO_BLUEPILL_F103C8 -DARDUINO_ARCH_STM32 -DBOARD_NAME="BLUEPILL_F103C8"  -DSTM32F103xB  -DHAL_UART_MODULE_ENABLED "-I/home/sw/.arduino15/packages/STM32/tools/CMSIS/5.3.0/CMSIS/Core/Include/" "-I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/system/Drivers/CMSIS/Device/ST/STM32F1xx/Include/" "-I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/system/Drivers/CMSIS/Device/ST/STM32F1xx/Source/Templates/gcc/" "-I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino" "-I/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/variants/BLUEPILL_F103XX" "/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino/avr/dtostrf.c" -o "/home/sw/Arduino/DS18B20Test/.build/core/avr/dtostrf.c.o"
/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino/avr/dtostrf.c: In function 'dtostrf':
/home/sw/.arduino15/packages/STM32/hardware/stm32/1.5.0/cores/arduino/avr/dtostrf.c:80:19: error: implicit declaration of function 'strdup'; did you mean 'strcmp'? [-Werror=implicit-function-declaration]
       char *tmp = strdup(sout);
                   ^~~~~~

$ /usr/bin/arm-none-eabi-gcc --version
arm-none-eabi-gcc (Fedora 7.4.0-1.fc28) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Note: As per https://sourceware.org/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=newlib/libc/include/string.h;h=04c4d182894ff3395134b629797a73d13a2a2c20;hb=440559c40a4879ddfe0a73282aab994c53955cef#l83
strdup() is not available by default.
