### PR TITLE
Fix to build with ISO C standard

### DIFF
--- a/cores/arduino/avr/dtostrf.c
+++ b/cores/arduino/avr/dtostrf.c
@@ -80,7 +80,8 @@ char *dtostrf(double val, signed char width, unsigned char prec, char *sout)
     memset(fmt, ' ', 128);
     fmt[w - strlen(sout)] = '\0';
     if (negative == 0) {
-      char *tmp = strdup(sout);
+      char *tmp = malloc(strlen(sout) + 1);
+      strcpy(tmp, sout);
       strcpy(sout, fmt);
       strcat(sout, tmp);
       free(tmp);

--- a/cores/arduino/stm32/dwt.c
+++ b/cores/arduino/stm32/dwt.c
@@ -43,9 +43,9 @@ uint32_t dwt_init(void)
   DWT->CTRL |=  DWT_CTRL_CYCCNTENA_Msk;
 
   /* 3 NO OPERATION instructions */
-  asm volatile(" nop      \n\t"
-               " nop      \n\t"
-               " nop      \n\t");
+  __asm volatile(" nop      \n\t"
+                 " nop      \n\t"
+                 " nop      \n\t");
 
   /* Check if clock cycle counter has started */
   return (DWT->CYCCNT) ? 0 : 1;


### PR DESCRIPTION
This allow to build with c11 instead of gnu11 (GNU dialect of ISO C11)
Avoid `strdup `usage and use correct `asm `keyword.

Should replace #510 

Tested with `std=c99`/`11`/`17`/`18`
Also with some libraries.

