### PR TITLE
[USBD] Clean descriptors and string formatting method

### DIFF
--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
@@ -237,7 +237,7 @@ void CDC_init(void)
 {
   if (!CDC_initialized) {
     /* Init Device Library */
-    if (USBD_Init(&hUSBD_Device_CDC, &CDC_Desc, 0) == USBD_OK) {
+    if (USBD_Init(&hUSBD_Device_CDC, &USBD_Desc, 0) == USBD_OK) {
       /* Add Supported Class */
       if (USBD_RegisterClass(&hUSBD_Device_CDC, USBD_CDC_CLASS) == USBD_OK) {
         /* Add CDC Interface Class */

--- a/cores/arduino/stm32/usb/hid/usbd_hid_composite_if.c
+++ b/cores/arduino/stm32/usb/hid/usbd_hid_composite_if.c
@@ -59,7 +59,7 @@ void HID_Composite_Init(HID_Interface device)
   if (IS_HID_INTERFACE(device) &&
       !HID_keyboard_initialized && !HID_mouse_initialized) {
     /* Init Device Library */
-    if (USBD_Init(&hUSBD_Device_HID, &HID_Desc, 0) == USBD_OK) {
+    if (USBD_Init(&hUSBD_Device_HID, &USBD_Desc, 0) == USBD_OK) {
       /* Add Supported Class */
       if (USBD_RegisterClass(&hUSBD_Device_HID, USBD_COMPOSITE_HID_CLASS) == USBD_OK) {
         /* Start Device Process */

--- a/cores/arduino/stm32/usb/usbd_desc.c
+++ b/cores/arduino/stm32/usb/usbd_desc.c
@@ -39,23 +39,23 @@
 #define USBD_LANGID_STRING            0x409   /* 1033 US.S English */
 
 #ifdef USBD_USE_HID_COMPOSITE
-#define USBD_HID_PID                      0x5711
-#define USBD_HID_PRODUCT_HS_STRING        CONCATS(USB_PRODUCT, "HID in HS Mode")
-#define USBD_HID_PRODUCT_FS_STRING        CONCATS(USB_PRODUCT, "HID in FS Mode")
-#define USBD_HID_CONFIGURATION_HS_STRING  CONCATS(USB_PRODUCT, "HID Config")
-#define USBD_HID_INTERFACE_HS_STRING      CONCATS(USB_PRODUCT, "HID Interface")
-#define USBD_HID_CONFIGURATION_FS_STRING  CONCATS(USB_PRODUCT, "HID Config")
-#define USBD_HID_INTERFACE_FS_STRING      CONCATS(USB_PRODUCT, "HID Interface")
+#define USBD_CLASS_PID                      0x5711
+#define USBD_CLASS_PRODUCT_HS_STRING        CONCATS(USB_PRODUCT, "HID in HS Mode")
+#define USBD_CLASS_PRODUCT_FS_STRING        CONCATS(USB_PRODUCT, "HID in FS Mode")
+#define USBD_CLASS_CONFIGURATION_HS_STRING  CONCATS(USB_PRODUCT, "HID Config")
+#define USBD_CLASS_INTERFACE_HS_STRING      CONCATS(USB_PRODUCT, "HID Interface")
+#define USBD_CLASS_CONFIGURATION_FS_STRING  CONCATS(USB_PRODUCT, "HID Config")
+#define USBD_CLASS_INTERFACE_FS_STRING      CONCATS(USB_PRODUCT, "HID Interface")
 #endif /* USBD_USE_HID_COMPOSITE */
 
 #ifdef USBD_USE_CDC
-#define USBD_CDC_PID                      0x5740
-#define USBD_CDC_PRODUCT_HS_STRING        CONCATS(USB_PRODUCT, "CDC in HS Mode")
-#define USBD_CDC_PRODUCT_FS_STRING        CONCATS(USB_PRODUCT, "CDC in FS Mode")
-#define USBD_CDC_CONFIGURATION_HS_STRING  CONCATS(USB_PRODUCT, "CDC Config")
-#define USBD_CDC_INTERFACE_HS_STRING      CONCATS(USB_PRODUCT, "CDC Interface")
-#define USBD_CDC_CONFIGURATION_FS_STRING  CONCATS(USB_PRODUCT, "CDC Config")
-#define USBD_CDC_INTERFACE_FS_STRING      CONCATS(USB_PRODUCT, "CDC Interface")
+#define USBD_CLASS_PID                      0x5740
+#define USBD_CLASS_PRODUCT_HS_STRING        CONCATS(USB_PRODUCT, "CDC in HS Mode")
+#define USBD_CLASS_PRODUCT_FS_STRING        CONCATS(USB_PRODUCT, "CDC in FS Mode")
+#define USBD_CLASS_CONFIGURATION_HS_STRING  CONCATS(USB_PRODUCT, "CDC Config")
+#define USBD_CLASS_INTERFACE_HS_STRING      CONCATS(USB_PRODUCT, "CDC Interface")
+#define USBD_CLASS_CONFIGURATION_FS_STRING  CONCATS(USB_PRODUCT, "CDC Config")
+#define USBD_CLASS_INTERFACE_FS_STRING      CONCATS(USB_PRODUCT, "CDC Interface")
 #endif /* USBD_USE_CDC */
 
 /* Private macro -------------------------------------------------------------*/
@@ -66,37 +66,29 @@ uint8_t *USBD_ManufacturerStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *lengt
 uint8_t *USBD_SerialStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
 
 /* Class specific */
-#ifdef USBD_USE_HID_COMPOSITE
-uint8_t *USBD_HID_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
-uint8_t *USBD_HID_ProductStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
-uint8_t *USBD_HID_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
-uint8_t *USBD_HID_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
-#endif /* USBD_USE_HID_COMPOSITE */
-#ifdef USBD_USE_CDC
-uint8_t *USBD_CDC_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
-uint8_t *USBD_CDC_ProductStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
-uint8_t *USBD_CDC_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
-uint8_t *USBD_CDC_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
-#endif /* USBD_USE_CDC */
+uint8_t *USBD_Class_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+uint8_t *USBD_Class_ProductStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+uint8_t *USBD_Class_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+uint8_t *USBD_Class_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
 
 #ifdef USB_SUPPORT_USER_STRING_DESC
 uint8_t *USBD_Class_USRStringDesc(USBD_SpeedTypeDef speed, uint8_t idx, uint16_t *length);
 #endif /* USB_SUPPORT_USER_STRING_DESC */
 
 /* Private variables ---------------------------------------------------------*/
-#ifdef USBD_USE_HID_COMPOSITE
-USBD_DescriptorsTypeDef HID_Desc = {
-  USBD_HID_DeviceDescriptor,
+USBD_DescriptorsTypeDef USBD_Desc = {
+  USBD_Class_DeviceDescriptor,
   USBD_LangIDStrDescriptor,
   USBD_ManufacturerStrDescriptor,
-  USBD_HID_ProductStrDescriptor,
+  USBD_Class_ProductStrDescriptor,
   USBD_SerialStrDescriptor,
-  USBD_HID_ConfigStrDescriptor,
-  USBD_HID_InterfaceStrDescriptor,
+  USBD_Class_ConfigStrDescriptor,
+  USBD_Class_InterfaceStrDescriptor,
 };
 
+#ifdef USBD_USE_HID_COMPOSITE
 /* USB Standard Device Descriptor */
-__ALIGN_BEGIN uint8_t USBD_HID_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
+__ALIGN_BEGIN uint8_t USBD_Class_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   0x12,                       /* bLength */
   USB_DESC_TYPE_DEVICE,       /* bDescriptorType */
   0x00,                       /* bcdUSB */
@@ -107,8 +99,8 @@ __ALIGN_BEGIN uint8_t USBD_HID_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   USB_MAX_EP0_SIZE,           /* bMaxPacketSize */
   LOBYTE(USBD_VID),           /* idVendor */
   HIBYTE(USBD_VID),           /* idVendor */
-  LOBYTE(USBD_HID_PID),           /* idVendor */
-  HIBYTE(USBD_HID_PID),           /* idVendor */
+  LOBYTE(USBD_CLASS_PID),           /* idVendor */
+  HIBYTE(USBD_CLASS_PID),           /* idVendor */
   0x00,                       /* bcdDevice rel. 2.00 */
   0x02,
   USBD_IDX_MFC_STR,           /* Index of manufacturer string */
@@ -119,18 +111,8 @@ __ALIGN_BEGIN uint8_t USBD_HID_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
 #endif /* USBD_USE_HID_COMPOSITE */
 
 #ifdef USBD_USE_CDC
-USBD_DescriptorsTypeDef CDC_Desc = {
-  USBD_CDC_DeviceDescriptor,
-  USBD_LangIDStrDescriptor,
-  USBD_ManufacturerStrDescriptor,
-  USBD_CDC_ProductStrDescriptor,
-  USBD_SerialStrDescriptor,
-  USBD_CDC_ConfigStrDescriptor,
-  USBD_CDC_InterfaceStrDescriptor,
-};
-
 /* USB Standard Device Descriptor */
-__ALIGN_BEGIN uint8_t USBD_CDC_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
+__ALIGN_BEGIN uint8_t USBD_Class_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   0x12,                       /* bLength */
   USB_DESC_TYPE_DEVICE,       /* bDescriptorType */
   0x00,                       /* bcdUSB */
@@ -141,8 +123,8 @@ __ALIGN_BEGIN uint8_t USBD_CDC_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   USB_MAX_EP0_SIZE,           /* bMaxPacketSize */
   LOBYTE(USBD_VID),           /* idVendor */
   HIBYTE(USBD_VID),           /* idVendor */
-  LOBYTE(USBD_CDC_PID),           /* idVendor */
-  HIBYTE(USBD_CDC_PID),           /* idVendor */
+  LOBYTE(USBD_CLASS_PID),           /* idVendor */
+  HIBYTE(USBD_CLASS_PID),           /* idVendor */
   0x00,                       /* bcdDevice rel. 2.00 */
   0x02,
   USBD_IDX_MFC_STR,           /* Index of manufacturer string */
@@ -177,22 +159,13 @@ static void Get_SerialNum(void);
   * @param  length: Pointer to data length variable
   * @retval Pointer to descriptor buffer
   */
-#ifdef USBD_USE_HID_COMPOSITE
-uint8_t *USBD_HID_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
+uint8_t *USBD_Class_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
 {
   UNUSED(speed);
-  *length = sizeof(USBD_HID_DeviceDesc);
-  return (uint8_t *)USBD_HID_DeviceDesc;
+  *length = sizeof(USBD_Class_DeviceDesc);
+  return (uint8_t *)USBD_Class_DeviceDesc;
 }
-#endif
-#ifdef USBD_USE_CDC
-uint8_t *USBD_CDC_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
-{
-  UNUSED(speed);
-  *length = sizeof(USBD_CDC_DeviceDesc);
-  return (uint8_t *)USBD_CDC_DeviceDesc;
-}
-#endif
+
 /**
   * @brief  Returns the LangID string descriptor.
   * @param  speed: Current device speed
@@ -212,28 +185,15 @@ uint8_t *USBD_LangIDStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
   * @param  length: Pointer to data length variable
   * @retval Pointer to descriptor buffer
   */
-#ifdef USBD_USE_HID_COMPOSITE
-uint8_t *USBD_HID_ProductStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
+uint8_t *USBD_Class_ProductStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
 {
   if (speed == USBD_SPEED_HIGH) {
-    USBD_GetString((uint8_t *)USBD_HID_PRODUCT_HS_STRING, USBD_StrDesc, length);
+    USBD_GetString((uint8_t *)USBD_CLASS_PRODUCT_HS_STRING, USBD_StrDesc, length);
   } else {
-    USBD_GetString((uint8_t *)USBD_HID_PRODUCT_FS_STRING, USBD_StrDesc, length);
+    USBD_GetString((uint8_t *)USBD_CLASS_PRODUCT_FS_STRING, USBD_StrDesc, length);
   }
   return USBD_StrDesc;
 }
-#endif /* USBD_USE_HID_COMPOSITE */
-#ifdef USBD_USE_CDC
-uint8_t *USBD_CDC_ProductStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
-{
-  if (speed == USBD_SPEED_HIGH) {
-    USBD_GetString((uint8_t *)USBD_CDC_PRODUCT_HS_STRING, USBD_StrDesc, length);
-  } else {
-    USBD_GetString((uint8_t *)USBD_CDC_PRODUCT_FS_STRING, USBD_StrDesc, length);
-  }
-  return USBD_StrDesc;
-}
-#endif /* USBD_USE_CDC */
 
 /**
   * @brief  Returns the manufacturer string descriptor.
@@ -271,28 +231,15 @@ uint8_t *USBD_SerialStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
   * @param  length: Pointer to data length variable
   * @retval Pointer to descriptor buffer
   */
-#ifdef USBD_USE_HID_COMPOSITE
-uint8_t *USBD_HID_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
+uint8_t *USBD_Class_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
 {
   if (speed == USBD_SPEED_HIGH) {
-    USBD_GetString((uint8_t *)USBD_HID_CONFIGURATION_HS_STRING, USBD_StrDesc, length);
+    USBD_GetString((uint8_t *)USBD_CLASS_CONFIGURATION_HS_STRING, USBD_StrDesc, length);
   } else {
-    USBD_GetString((uint8_t *)USBD_HID_CONFIGURATION_FS_STRING, USBD_StrDesc, length);
+    USBD_GetString((uint8_t *)USBD_CLASS_CONFIGURATION_FS_STRING, USBD_StrDesc, length);
   }
   return USBD_StrDesc;
 }
-#endif /* USBD_USE_HID_COMPOSITE */
-#ifdef USBD_USE_CDC
-uint8_t *USBD_CDC_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
-{
-  if (speed == USBD_SPEED_HIGH) {
-    USBD_GetString((uint8_t *)USBD_CDC_CONFIGURATION_HS_STRING, USBD_StrDesc, length);
-  } else {
-    USBD_GetString((uint8_t *)USBD_CDC_CONFIGURATION_FS_STRING, USBD_StrDesc, length);
-  }
-  return USBD_StrDesc;
-}
-#endif /* USBD_USE_CDC */
 
 /**
   * @brief  Returns the interface string descriptor.
@@ -300,28 +247,15 @@ uint8_t *USBD_CDC_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
   * @param  length: Pointer to data length variable
   * @retval Pointer to descriptor buffer
   */
-#ifdef USBD_USE_HID_COMPOSITE
-uint8_t *USBD_HID_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
+uint8_t *USBD_Class_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
 {
   if (speed == USBD_SPEED_HIGH) {
-    USBD_GetString((uint8_t *)USBD_HID_INTERFACE_HS_STRING, USBD_StrDesc, length);
+    USBD_GetString((uint8_t *)USBD_CLASS_INTERFACE_HS_STRING, USBD_StrDesc, length);
   } else {
-    USBD_GetString((uint8_t *)USBD_HID_INTERFACE_FS_STRING, USBD_StrDesc, length);
+    USBD_GetString((uint8_t *)USBD_CLASS_INTERFACE_FS_STRING, USBD_StrDesc, length);
   }
   return USBD_StrDesc;
 }
-#endif /* USBD_USE_HID_COMPOSITE */
-#ifdef USBD_USE_CDC
-uint8_t *USBD_CDC_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
-{
-  if (speed == USBD_SPEED_HIGH) {
-    USBD_GetString((uint8_t *)USBD_CDC_INTERFACE_HS_STRING, USBD_StrDesc, length);
-  } else {
-    USBD_GetString((uint8_t *)USBD_CDC_INTERFACE_FS_STRING, USBD_StrDesc, length);
-  }
-  return USBD_StrDesc;
-}
-#endif /* USBD_USE_CDC */
 
 /**
   * @brief  Create the serial number string descriptor

--- a/cores/arduino/stm32/usb/usbd_desc.h
+++ b/cores/arduino/stm32/usb/usbd_desc.h
@@ -34,12 +34,8 @@
 
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */
-#ifdef USBD_USE_HID_COMPOSITE
-extern USBD_DescriptorsTypeDef HID_Desc;
-#endif
-#ifdef USBD_USE_CDC
-extern USBD_DescriptorsTypeDef CDC_Desc;
-#endif
+extern USBD_DescriptorsTypeDef USBD_Desc;
+
 #endif /* USBCON */
 #endif /* __USBD_DESC_H*/
 


### PR DESCRIPTION
**Summary**

This PR clean descriptors and string formatting method in `usbd_desc.*`
This avoid duplicated functions handled by define. Only dedicated values are handled by USBD class define. This would ease further USB device class addition.
