### PR TITLE
[Review #553] Add STM32F030F4 Demo board 16MHz

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -565,18 +565,26 @@ GenF0.name=Generic STM32F0 series
 
 GenF0.build.core=arduino
 GenF0.build.board=GenF0
+GenF0.build.mcu=cortex-m0
+GenF0.build.series=STM32F0xx
+GenF0.build.cmsis_lib_gcc=arm_cortexM0l_math
 GenF0.build.extra_flags=-D{build.product_line} {build.xSerial}
 
 # DEMO_F030F4 board
 GenF0.menu.pnum.DEMO_F030F4=STM32F030F4 Demo board
 GenF0.menu.pnum.DEMO_F030F4.upload.maximum_data_size=4096
 GenF0.menu.pnum.DEMO_F030F4.upload.maximum_size=16384
-GenF0.menu.pnum.DEMO_F030F4.build.mcu=cortex-m0
 GenF0.menu.pnum.DEMO_F030F4.build.board=DEMO_F030F4
-GenF0.menu.pnum.DEMO_F030F4.build.series=STM32F0xx
 GenF0.menu.pnum.DEMO_F030F4.build.product_line=STM32F030x6
 GenF0.menu.pnum.DEMO_F030F4.build.variant=DEMO_F030F4
-GenF0.menu.pnum.DEMO_F030F4.build.cmsis_lib_gcc=arm_cortexM0l_math
+
+# DEMO_F030F4_16M board
+GenF0.menu.pnum.DEMO_F030F4_16M=STM32F030F4 Demo board (16Mhz)
+GenF0.menu.pnum.DEMO_F030F4_16M.upload.maximum_data_size=4096
+GenF0.menu.pnum.DEMO_F030F4_16M.upload.maximum_size=16384
+GenF0.menu.pnum.DEMO_F030F4_16M.build.board=DEMO_F030F4_16M
+GenF0.menu.pnum.DEMO_F030F4_16M.build.product_line=STM32F030x6
+GenF0.menu.pnum.DEMO_F030F4_16M.build.variant=DEMO_F030F4
 
 # Upload menu
 GenF0.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)

--- a/variants/DEMO_F030F4/variant.cpp
+++ b/variants/DEMO_F030F4/variant.cpp
@@ -95,7 +95,11 @@ WEAK void SystemClock_Config(void)
   RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
   RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL6;
+#ifdef ARDUINO_DEMO_F030F4_16M
+  RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV2;
+#else
   RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV1;
+#endif
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
     _Error_Handler(__FILE__, __LINE__);
   }

--- a/variants/DEMO_F030F4/variant.h
+++ b/variants/DEMO_F030F4/variant.h
@@ -89,6 +89,10 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
+#ifdef ARDUINO_DEMO_F030F4_16M
+#define HSE_VALUE               16000000U  /*!< Value of the External oscillator in Hz */
+#endif
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
This PR would replace #553 from @kgamecarter.

This avoid to duplicate the variant **DEMO_F030F4** to only change HSE value.
Simply define a new board entry with the same variant and use the `-DARDUINO_{build.board}` definition
to update the HSE value and clock config.