### PR TITLE
Discussion - Add Basic Dma Handler support

### DIFF
--- a/cores/arduino/stm32/dma.c
+++ b/cores/arduino/stm32/dma.c
@@ -38,6 +38,11 @@
 #include <stddef.h>
 #include "dma.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if defined(HAL_DMA_MODULE_ENABLED)
+
 #define NC -1
 
 typedef enum
@@ -366,5 +371,11 @@ void DMA2_Channel7_IRQHandler() {
 void DMA2_Channel8_IRQHandler() {
   if (dma_handles[DMA2_CHANNEL8_INDEX] != NULL)
     HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL8_INDEX]);
+}
+#endif
+
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef __cplusplus
 }
 #endif

--- a/cores/arduino/stm32/dma.c
+++ b/cores/arduino/stm32/dma.c
@@ -48,51 +48,51 @@ extern "C" {
 typedef enum
 {
 #ifdef DMA1_Channel1
-  DMA1_CHANNEL1_INDEX,
+    DMA1_CHANNEL1_INDEX,
 #endif
 #ifdef DMA1_Channel2
-  DMA1_CHANNEL2_INDEX,
+    DMA1_CHANNEL2_INDEX,
 #endif
 #ifdef DMA1_Channel3
-  DMA1_CHANNEL3_INDEX,
+    DMA1_CHANNEL3_INDEX,
 #endif
 #ifdef DMA1_Channel4
-  DMA1_CHANNEL4_INDEX,
+    DMA1_CHANNEL4_INDEX,
 #endif
 #ifdef DMA1_Channel5
-  DMA1_CHANNEL5_INDEX,
+    DMA1_CHANNEL5_INDEX,
 #endif
 #ifdef DMA1_Channel6
-  DMA1_CHANNEL6_INDEX,
+    DMA1_CHANNEL6_INDEX,
 #endif
 #ifdef DMA1_Channel7
-  DMA1_CHANNEL7_INDEX,
+    DMA1_CHANNEL7_INDEX,
 #endif
 #ifdef DMA2_Channel1
-  DMA2_CHANNEL1_INDEX,
+    DMA2_CHANNEL1_INDEX,
 #endif
 #ifdef DMA2_Channel2
-  DMA2_CHANNEL2_INDEX,
+    DMA2_CHANNEL2_INDEX,
 #endif
 #ifdef DMA2_Channel3
-  DMA2_CHANNEL3_INDEX,
+    DMA2_CHANNEL3_INDEX,
 #endif
 #ifdef DMA2_Channel4
-  DMA2_CHANNEL4_INDEX,
+    DMA2_CHANNEL4_INDEX,
 #endif
 #ifdef DMA2_Channel5
-  DMA2_CHANNEL5_INDEX,
+    DMA2_CHANNEL5_INDEX,
 #endif
 #ifdef DMA2_Channel6
-  DMA2_CHANNEL6_INDEX,
+    DMA2_CHANNEL6_INDEX,
 #endif
 #ifdef DMA2_Channel7
-  DMA2_CHANNEL7_INDEX,
+    DMA2_CHANNEL7_INDEX,
 #endif
 #ifdef DMA2_Channel8
-  DMA2_CHANNEL8_INDEX,
+    DMA2_CHANNEL8_INDEX,
 #endif
-  DMA_CHANNEL_NUM
+    DMA_CHANNEL_NUM
 } dma_index_t;
 
 static DMA_HandleTypeDef *dma_handles[DMA_CHANNEL_NUM] = {NULL};
@@ -103,70 +103,70 @@ static DMA_HandleTypeDef *dma_handles[DMA_CHANNEL_NUM] = {NULL};
   * @retval None
   */
 static dma_index_t get_dma_index(DMA_Channel_TypeDef *instance) {
-  switch ((uint32_t)instance) {
-    #ifdef DMA1_Channel1
-      case (uint32_t)DMA1_Channel1:
-      return DMA1_CHANNEL1_INDEX;
-    #endif
-    #ifdef DMA1_Channel2
-      case (uint32_t)DMA1_Channel2:
-      return DMA1_CHANNEL2_INDEX;
-    #endif
-    #ifdef DMA1_Channel3
-      case (uint32_t)DMA1_Channel3:
-      return DMA1_CHANNEL3_INDEX;
-    #endif
-    #ifdef DMA1_Channel4
-      case (uint32_t)DMA1_Channel4:
-      return DMA1_CHANNEL4_INDEX;
-    #endif
-    #ifdef DMA1_Channel5
-      case (uint32_t)DMA1_Channel5:
-      return DMA1_CHANNEL5_INDEX;
-    #endif
-    #ifdef DMA1_Channel6
-      case (uint32_t)DMA1_Channel6:
-      return DMA1_CHANNEL6_INDEX;
-    #endif
-    #ifdef DMA1_Channel7
-      case (uint32_t)DMA1_Channel7:
-      return DMA1_CHANNEL7_INDEX;
-    #endif
-    #ifdef DMA2_Channel1
-      case (uint32_t)DMA2_Channel1:
-      return DMA2_CHANNEL1_INDEX;
-    #endif
-    #ifdef DMA2_Channel2
-      case (uint32_t)DMA2_Channel2:
-      return DMA2_CHANNEL2_INDEX;
-    #endif
-    #ifdef DMA2_Channel3
-      case (uint32_t)DMA2_Channel3:
-      return DMA2_CHANNEL3_INDEX;
-    #endif
-    #ifdef DMA2_Channel4
-      case (uint32_t)DMA2_Channel4:
-      return DMA2_CHANNEL4_INDEX;
-    #endif
-    #ifdef DMA2_Channel5
-      case (uint32_t)DMA2_Channel5:
-      return DMA2_CHANNEL5_INDEX;
-    #endif
-    #ifdef DMA2_Channel6
-      case (uint32_t)DMA2_Channel6:
-      return DMA2_CHANNEL6_INDEX;
-    #endif
-    #ifdef DMA2_Channel7
-      case (uint32_t)DMA2_Channel7:
-      return DMA2_CHANNEL7_INDEX;
-    #endif
-    #ifdef DMA2_Channel8
-      case (uint32_t)DMA2_Channel8:
-      return DMA2_CHANNEL8_INDEX;
-    #endif
+    switch ((uint32_t)instance) {
+#ifdef DMA1_Channel1
+    case (uint32_t)DMA1_Channel1:
+        return DMA1_CHANNEL1_INDEX;
+#endif
+#ifdef DMA1_Channel2
+    case (uint32_t)DMA1_Channel2:
+        return DMA1_CHANNEL2_INDEX;
+#endif
+#ifdef DMA1_Channel3
+    case (uint32_t)DMA1_Channel3:
+        return DMA1_CHANNEL3_INDEX;
+#endif
+#ifdef DMA1_Channel4
+    case (uint32_t)DMA1_Channel4:
+        return DMA1_CHANNEL4_INDEX;
+#endif
+#ifdef DMA1_Channel5
+    case (uint32_t)DMA1_Channel5:
+        return DMA1_CHANNEL5_INDEX;
+#endif
+#ifdef DMA1_Channel6
+    case (uint32_t)DMA1_Channel6:
+        return DMA1_CHANNEL6_INDEX;
+#endif
+#ifdef DMA1_Channel7
+    case (uint32_t)DMA1_Channel7:
+        return DMA1_CHANNEL7_INDEX;
+#endif
+#ifdef DMA2_Channel1
+    case (uint32_t)DMA2_Channel1:
+        return DMA2_CHANNEL1_INDEX;
+#endif
+#ifdef DMA2_Channel2
+    case (uint32_t)DMA2_Channel2:
+        return DMA2_CHANNEL2_INDEX;
+#endif
+#ifdef DMA2_Channel3
+    case (uint32_t)DMA2_Channel3:
+        return DMA2_CHANNEL3_INDEX;
+#endif
+#ifdef DMA2_Channel4
+    case (uint32_t)DMA2_Channel4:
+        return DMA2_CHANNEL4_INDEX;
+#endif
+#ifdef DMA2_Channel5
+    case (uint32_t)DMA2_Channel5:
+        return DMA2_CHANNEL5_INDEX;
+#endif
+#ifdef DMA2_Channel6
+    case (uint32_t)DMA2_Channel6:
+        return DMA2_CHANNEL6_INDEX;
+#endif
+#ifdef DMA2_Channel7
+    case (uint32_t)DMA2_Channel7:
+        return DMA2_CHANNEL7_INDEX;
+#endif
+#ifdef DMA2_Channel8
+    case (uint32_t)DMA2_Channel8:
+        return DMA2_CHANNEL8_INDEX;
+#endif
     default:
-      return NC;
-  }
+        return NC;
+    }
 }
 
 /**
@@ -175,11 +175,11 @@ static dma_index_t get_dma_index(DMA_Channel_TypeDef *instance) {
   * @retval None
   */
 void prepare_dma(DMA_HandleTypeDef *dma_handle) {
-  dma_index_t dma_index = get_dma_index(dma_handle->Instance);
-  if (dma_index == NC) {
-    return;
-  }
-  dma_handles[dma_index] = dma_handle;
+    dma_index_t dma_index = get_dma_index(dma_handle->Instance);
+    if (dma_index == NC) {
+        return;
+    }
+    dma_handles[dma_index] = dma_handle;
 }
 
 /**
@@ -188,11 +188,11 @@ void prepare_dma(DMA_HandleTypeDef *dma_handle) {
   * @retval None
   */
 void end_dma(DMA_HandleTypeDef *dma_handle) {
-  dma_index_t dma_index = get_dma_index(dma_handle->Instance);
-  if (dma_index == NC) {
-    return;
-  }
-  dma_handles[dma_index] = NULL;
+    dma_index_t dma_index = get_dma_index(dma_handle->Instance);
+    if (dma_index == NC) {
+        return;
+    }
+    dma_handles[dma_index] = NULL;
 }
 
 #ifdef DMA1_Channel1
@@ -202,8 +202,8 @@ void end_dma(DMA_HandleTypeDef *dma_handle) {
   * @retval None
   */
 void DMA1_Channel1_IRQHandler() {
-  if (dma_handles[DMA1_CHANNEL1_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL1_INDEX]);
+    if (dma_handles[DMA1_CHANNEL1_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL1_INDEX]);
 }
 #endif
 
@@ -214,8 +214,8 @@ void DMA1_Channel1_IRQHandler() {
   * @retval None
   */
 void DMA1_Channel2_IRQHandler() {
-  if (dma_handles[DMA1_CHANNEL2_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL2_INDEX]);
+    if (dma_handles[DMA1_CHANNEL2_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL2_INDEX]);
 }
 #endif
 
@@ -226,8 +226,8 @@ void DMA1_Channel2_IRQHandler() {
   * @retval None
   */
 void DMA1_Channel3_IRQHandler() {
-  if (dma_handles[DMA1_CHANNEL3_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL3_INDEX]);
+    if (dma_handles[DMA1_CHANNEL3_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL3_INDEX]);
 }
 #endif
 
@@ -238,8 +238,8 @@ void DMA1_Channel3_IRQHandler() {
   * @retval None
   */
 void DMA1_Channel4_IRQHandler() {
-  if (dma_handles[DMA1_CHANNEL4_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL4_INDEX]);
+    if (dma_handles[DMA1_CHANNEL4_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL4_INDEX]);
 }
 #endif
 
@@ -250,8 +250,8 @@ void DMA1_Channel4_IRQHandler() {
   * @retval None
   */
 void DMA1_Channel5_IRQHandler() {
-  if (dma_handles[DMA1_CHANNEL5_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL5_INDEX]);
+    if (dma_handles[DMA1_CHANNEL5_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL5_INDEX]);
 }
 #endif
 
@@ -261,8 +261,8 @@ void DMA1_Channel5_IRQHandler() {
   * @retval None
   */
 void DMA1_Channel6_IRQHandler() {
-  if (dma_handles[DMA1_CHANNEL6_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL6_INDEX]);
+    if (dma_handles[DMA1_CHANNEL6_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL6_INDEX]);
 }
 #endif
 
@@ -273,8 +273,8 @@ void DMA1_Channel6_IRQHandler() {
   * @retval None
   */
 void DMA1_Channel7_IRQHandler() {
-  if (dma_handles[DMA1_CHANNEL7_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL7_INDEX]);
+    if (dma_handles[DMA1_CHANNEL7_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL7_INDEX]);
 }
 #endif
 
@@ -285,8 +285,8 @@ void DMA1_Channel7_IRQHandler() {
   * @retval None
   */
 void DMA2_Channel1_IRQHandler() {
-  if (dma_handles[DMA2_CHANNEL1_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL1_INDEX]);
+    if (dma_handles[DMA2_CHANNEL1_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL1_INDEX]);
 }
 #endif
 
@@ -297,8 +297,8 @@ void DMA2_Channel1_IRQHandler() {
   * @retval None
   */
 void DMA2_Channel1_IRQHandler() {
-  if (dma_handles[DMA2_CHANNEL2_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL2_INDEX]);
+    if (dma_handles[DMA2_CHANNEL2_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL2_INDEX]);
 }
 #endif
 
@@ -309,8 +309,8 @@ void DMA2_Channel1_IRQHandler() {
   * @retval None
   */
 void DMA2_Channel3_IRQHandler() {
-  if (dma_handles[DMA2_CHANNEL3_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL3_INDEX]);
+    if (dma_handles[DMA2_CHANNEL3_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL3_INDEX]);
 }
 #endif
 
@@ -321,8 +321,8 @@ void DMA2_Channel3_IRQHandler() {
   * @retval None
   */
 void DMA2_Channel4_IRQHandler() {
-  if (dma_handles[DMA2_CHANNEL4_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL4_INDEX]);
+    if (dma_handles[DMA2_CHANNEL4_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL4_INDEX]);
 }
 #endif
 
@@ -333,8 +333,8 @@ void DMA2_Channel4_IRQHandler() {
   * @retval None
   */
 void DMA2_Channel5_IRQHandler() {
-  if (dma_handles[DMA2_CHANNEL5_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL5_INDEX]);
+    if (dma_handles[DMA2_CHANNEL5_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL5_INDEX]);
 }
 #endif
 
@@ -345,8 +345,8 @@ void DMA2_Channel5_IRQHandler() {
   * @retval None
   */
 void DMA2_Channel6_IRQHandler() {
-  if (dma_handles[DMA2_CHANNEL6_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL6_INDEX]);
+    if (dma_handles[DMA2_CHANNEL6_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL6_INDEX]);
 }
 #endif
 
@@ -357,8 +357,8 @@ void DMA2_Channel6_IRQHandler() {
   * @retval None
   */
 void DMA2_Channel7_IRQHandler() {
-  if (dma_handles[DMA2_CHANNEL7_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL7_INDEX]);
+    if (dma_handles[DMA2_CHANNEL7_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL7_INDEX]);
 }
 #endif
 
@@ -369,8 +369,8 @@ void DMA2_Channel7_IRQHandler() {
   * @retval None
   */
 void DMA2_Channel8_IRQHandler() {
-  if (dma_handles[DMA2_CHANNEL8_INDEX] != NULL)
-    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL8_INDEX]);
+    if (dma_handles[DMA2_CHANNEL8_INDEX] != NULL)
+        HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL8_INDEX]);
 }
 #endif
 

--- a/cores/arduino/stm32/dma.c
+++ b/cores/arduino/stm32/dma.c
@@ -1,0 +1,370 @@
+/**
+  ******************************************************************************
+  * @file    dma.c
+  * @author  xC0000005
+  * @version V1.0.0
+  * @date    12-July-2019
+  * @brief   provide dma callbacks for dma
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+#include <stddef.h>
+#include "dma.h"
+
+#define NC -1
+
+typedef enum
+{
+#ifdef DMA1_Channel1
+  DMA1_CHANNEL1_INDEX,
+#endif
+#ifdef DMA1_Channel2
+  DMA1_CHANNEL2_INDEX,
+#endif
+#ifdef DMA1_Channel3
+  DMA1_CHANNEL3_INDEX,
+#endif
+#ifdef DMA1_Channel4
+  DMA1_CHANNEL4_INDEX,
+#endif
+#ifdef DMA1_Channel5
+  DMA1_CHANNEL5_INDEX,
+#endif
+#ifdef DMA1_Channel6
+  DMA1_CHANNEL6_INDEX,
+#endif
+#ifdef DMA1_Channel7
+  DMA1_CHANNEL7_INDEX,
+#endif
+#ifdef DMA2_Channel1
+  DMA2_CHANNEL1_INDEX,
+#endif
+#ifdef DMA2_Channel2
+  DMA2_CHANNEL2_INDEX,
+#endif
+#ifdef DMA2_Channel3
+  DMA2_CHANNEL3_INDEX,
+#endif
+#ifdef DMA2_Channel4
+  DMA2_CHANNEL4_INDEX,
+#endif
+#ifdef DMA2_Channel5
+  DMA2_CHANNEL5_INDEX,
+#endif
+#ifdef DMA2_Channel6
+  DMA2_CHANNEL6_INDEX,
+#endif
+#ifdef DMA2_Channel7
+  DMA2_CHANNEL7_INDEX,
+#endif
+#ifdef DMA2_Channel8
+  DMA2_CHANNEL8_INDEX,
+#endif
+  DMA_CHANNEL_NUM
+} dma_index_t;
+
+static DMA_HandleTypeDef *dma_handles[DMA_CHANNEL_NUM] = {NULL};
+
+/**
+  * @brief  This function determines the dma index
+  * @param  instance : dma instance
+  * @retval None
+  */
+static dma_index_t get_dma_index(DMA_Channel_TypeDef *instance) {
+  switch ((uint32_t)instance) {
+    #ifdef DMA1_Channel1
+      case (uint32_t)DMA1_Channel1:
+      return DMA1_CHANNEL1_INDEX;
+    #endif
+    #ifdef DMA1_Channel2
+      case (uint32_t)DMA1_Channel2:
+      return DMA1_CHANNEL2_INDEX;
+    #endif
+    #ifdef DMA1_Channel3
+      case (uint32_t)DMA1_Channel3:
+      return DMA1_CHANNEL3_INDEX;
+    #endif
+    #ifdef DMA1_Channel4
+      case (uint32_t)DMA1_Channel4:
+      return DMA1_CHANNEL4_INDEX;
+    #endif
+    #ifdef DMA1_Channel5
+      case (uint32_t)DMA1_Channel5:
+      return DMA1_CHANNEL5_INDEX;
+    #endif
+    #ifdef DMA1_Channel6
+      case (uint32_t)DMA1_Channel6:
+      return DMA1_CHANNEL6_INDEX;
+    #endif
+    #ifdef DMA1_Channel7
+      case (uint32_t)DMA1_Channel7:
+      return DMA1_CHANNEL7_INDEX;
+    #endif
+    #ifdef DMA2_Channel1
+      case (uint32_t)DMA2_Channel1:
+      return DMA2_CHANNEL1_INDEX;
+    #endif
+    #ifdef DMA2_Channel2
+      case (uint32_t)DMA2_Channel2:
+      return DMA2_CHANNEL2_INDEX;
+    #endif
+    #ifdef DMA2_Channel3
+      case (uint32_t)DMA2_Channel3:
+      return DMA2_CHANNEL3_INDEX;
+    #endif
+    #ifdef DMA2_Channel4
+      case (uint32_t)DMA2_Channel4:
+      return DMA2_CHANNEL4_INDEX;
+    #endif
+    #ifdef DMA2_Channel5
+      case (uint32_t)DMA2_Channel5:
+      return DMA2_CHANNEL5_INDEX;
+    #endif
+    #ifdef DMA2_Channel6
+      case (uint32_t)DMA2_Channel6:
+      return DMA2_CHANNEL6_INDEX;
+    #endif
+    #ifdef DMA2_Channel7
+      case (uint32_t)DMA2_Channel7:
+      return DMA2_CHANNEL7_INDEX;
+    #endif
+    #ifdef DMA2_Channel8
+      case (uint32_t)DMA2_Channel8:
+      return DMA2_CHANNEL8_INDEX;
+    #endif
+    default:
+      return NC;
+  }
+}
+
+/**
+  * @brief  This function will store the DMA handle in the appropriate slot
+  * @param  dma_handle : dma handle
+  * @retval None
+  */
+void prepare_dma(DMA_HandleTypeDef *dma_handle) {
+  dma_index_t dma_index = get_dma_index(dma_handle->Instance);
+  if (dma_index == NC) {
+    return;
+  }
+  dma_handles[dma_index] = dma_handle;
+}
+
+/**
+  * @brief  This function will remove the DMA handle from the appropriate slot
+  * @param  dma_handle : dma handle
+  * @retval None
+  */
+void end_dma(DMA_HandleTypeDef *dma_handle) {
+  dma_index_t dma_index = get_dma_index(dma_handle->Instance);
+  if (dma_index == NC) {
+    return;
+  }
+  dma_handles[dma_index] = NULL;
+}
+
+#ifdef DMA1_Channel1
+/**
+  * @brief  DMA1 Channel1 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA1_Channel1_IRQHandler() {
+  if (dma_handles[DMA1_CHANNEL1_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL1_INDEX]);
+}
+#endif
+
+#ifdef DMA1_Channel2
+/**
+  * @brief  DMA1 Channel2 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA1_Channel2_IRQHandler() {
+  if (dma_handles[DMA1_CHANNEL2_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL2_INDEX]);
+}
+#endif
+
+#ifdef DMA1_Channel3
+/**
+  * @brief  DMA1 Channel3 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA1_Channel3_IRQHandler() {
+  if (dma_handles[DMA1_CHANNEL3_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL3_INDEX]);
+}
+#endif
+
+#ifdef DMA1_Channel4
+/**
+  * @brief  DMA1 Channel4 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA1_Channel4_IRQHandler() {
+  if (dma_handles[DMA1_CHANNEL4_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL4_INDEX]);
+}
+#endif
+
+#ifdef DMA1_Channel5
+/**
+  * @brief  DMA1 Channel5 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA1_Channel5_IRQHandler() {
+  if (dma_handles[DMA1_CHANNEL5_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL5_INDEX]);
+}
+#endif
+
+#ifdef DMA1_Channel6/**
+  * @brief  DMA1 Channel6 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA1_Channel6_IRQHandler() {
+  if (dma_handles[DMA1_CHANNEL6_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL6_INDEX]);
+}
+#endif
+
+#ifdef DMA1_Channel7
+/**
+  * @brief  DMA1 Channel3 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA1_Channel7_IRQHandler() {
+  if (dma_handles[DMA1_CHANNEL7_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA1_CHANNEL7_INDEX]);
+}
+#endif
+
+#ifdef DMA2_Channel1
+/**
+  * @brief  DMA2 Channel1 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA2_Channel1_IRQHandler() {
+  if (dma_handles[DMA2_CHANNEL1_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL1_INDEX]);
+}
+#endif
+
+#ifdef DMA2_Channel2
+/**
+  * @brief  DMA2 Channel2 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA2_Channel1_IRQHandler() {
+  if (dma_handles[DMA2_CHANNEL2_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL2_INDEX]);
+}
+#endif
+
+#ifdef DMA2_Channel3
+/**
+  * @brief  DMA2 Channel3 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA2_Channel3_IRQHandler() {
+  if (dma_handles[DMA2_CHANNEL3_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL3_INDEX]);
+}
+#endif
+
+#ifdef DMA2_Channel4
+/**
+  * @brief  DMA2 Channel4 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA2_Channel4_IRQHandler() {
+  if (dma_handles[DMA2_CHANNEL4_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL4_INDEX]);
+}
+#endif
+
+#ifdef DMA2_Channel5
+/**
+  * @brief  DMA2 Channel5 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA2_Channel5_IRQHandler() {
+  if (dma_handles[DMA2_CHANNEL5_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL5_INDEX]);
+}
+#endif
+
+#ifdef DMA2_Channel6
+/**
+  * @brief  DMA2 Channel6 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA2_Channel6_IRQHandler() {
+  if (dma_handles[DMA2_CHANNEL6_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL6_INDEX]);
+}
+#endif
+
+#ifdef DMA2_Channel7
+/**
+  * @brief  DMA2 Channel7 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA2_Channel7_IRQHandler() {
+  if (dma_handles[DMA2_CHANNEL7_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL7_INDEX]);
+}
+#endif
+
+#ifdef DMA2_Channel8
+/**
+  * @brief  DMA2 Channel8 IRQHandler
+  * @param  None
+  * @retval None
+  */
+void DMA2_Channel8_IRQHandler() {
+  if (dma_handles[DMA2_CHANNEL8_INDEX] != NULL)
+    HAL_DMA_IRQHandler(dma_handles[DMA2_CHANNEL8_INDEX]);
+}
+#endif

--- a/cores/arduino/stm32/dma.h
+++ b/cores/arduino/stm32/dma.h
@@ -1,0 +1,59 @@
+/**
+  ******************************************************************************
+  * @file    dma.h
+  * @author  xC0000005
+  * @version V1.0.0
+  * @date    12-July-2019
+  * @brief   provide dma callbacks for dma
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __DMA_H
+#define __DMA_H
+
+#include <stm32_def.h>
+
+/**
+  * @brief  This function will store the DMA handle in the appropriate slot
+  * @param  dma_handle : dma handle
+  * @retval None
+  */
+void prepare_dma(DMA_HandleTypeDef *dma_handle);
+
+/**
+  * @brief  This function will remove the DMA handle from the appropriate slot
+  * @param  dma_handle : dma handle
+  * @retval None
+  */
+void end_dma(DMA_HandleTypeDef *dma_handle);
+
+#endif


### PR DESCRIPTION
**Summary**

While working on Neopixel library support, I discovered that sketches had to implement DMA ISR handlers in order to receive DMA updates. This doesn't work in a library, since an ADC library might need to also implement them, and like timers, that should be part of the core.

This PR fixes/implements the following **bugs/features**

It takes the same basic form as timer support - an array of DMA handle pointers is maintained and DMA ISR handlers are added. If a DMA handler exists for a given IRQ, it is dispatched.

The usage is simple - call prepare_dma() with the DMA handle to add it, and dma_end() to remove it. In theory, prepare_dma should do more, but I don't understand enough of the DMA use cases to be able to confidently say what should or should not happen for any given call sequence.

The result is that without ISR handlers defined, sketches (and libraries) can use DMA.

There are limitations to this PR - There are DMA "stream" handlers I see, but I don't need these, and haven't added them because I don't know of a good way to test it.

Are there other types of handlers that should be added?