### PR TITLE
I2C Timing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 astyle.out
 boards.local.txt
 platform.local.txt
+*.code-workspace

--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -125,7 +125,7 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
     obj->irq = I2C1_EV_IRQn;
 #if !defined(STM32F0xx) && !defined(STM32G0xx) && !defined(STM32L0xx)
     obj->irqER = I2C1_ER_IRQn;
-#endif // !defined(STM32F0xx) && !defined(STM32G0xx) && !defined(STM32L0xx)
+#endif /* !STM32F0xx && !STM32G0xx && !STM32L0xx */
     i2c_handles[I2C1_INDEX] = handle;
   }
 #endif // I2C1_BASE
@@ -138,7 +138,7 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
     obj->irq = I2C2_EV_IRQn;
 #if !defined(STM32F0xx) && !defined(STM32G0xx) && !defined(STM32L0xx)
     obj->irqER = I2C2_ER_IRQn;
-#endif // !defined(STM32F0xx) && !defined(STM32G0xx) && !defined(STM32L0xx)
+#endif /* !STM32F0xx && !STM32G0xx && !STM32L0xx */
     i2c_handles[I2C2_INDEX] = handle;
   }
 #endif // I2C2_BASE
@@ -149,9 +149,9 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
     __HAL_RCC_I2C3_FORCE_RESET();
     __HAL_RCC_I2C3_RELEASE_RESET();
     obj->irq = I2C3_EV_IRQn;
-#if !defined(STM32F0xx) && !defined(STM32L0xx)
+#if !defined(STM32L0xx)
     obj->irqER = I2C3_ER_IRQn;
-#endif // !defined(STM32F0xx) && !defined(STM32L0xx)
+#endif /* !STM32L0xx */
     i2c_handles[I2C3_INDEX] = handle;
   }
 #endif // I2C3_BASE
@@ -162,9 +162,7 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
     __HAL_RCC_I2C4_FORCE_RESET();
     __HAL_RCC_I2C4_RELEASE_RESET();
     obj->irq = I2C4_EV_IRQn;
-#if !defined(STM32F0xx) && !defined(STM32L0xx)
     obj->irqER = I2C4_ER_IRQn;
-#endif // !defined(STM32F0xx) && !defined(STM32L0xx)
     i2c_handles[I2C4_INDEX] = handle;
   }
 #endif // I2C4_BASE
@@ -199,10 +197,10 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
 
   HAL_NVIC_SetPriority(obj->irq, I2C_IRQ_PRIO, I2C_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(obj->irq);
-#if !defined(STM32F0xx) && !defined(STM32L0xx)
+#if !defined(STM32F0xx) && !defined(STM32G0xx) && !defined(STM32L0xx)
   HAL_NVIC_SetPriority(obj->irqER, I2C_IRQ_PRIO, I2C_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(obj->irqER);
-#endif // !defined(STM32F0xx) && !defined(STM32L0xx)
+#endif /* !STM32F0xx && !STM32G0xx && !STM32L0xx */
 
   /* Init the I2C */
   if (HAL_I2C_Init(handle) != HAL_OK) {
@@ -223,9 +221,9 @@ void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode, u
 void i2c_deinit(i2c_t *obj)
 {
   HAL_NVIC_DisableIRQ(obj->irq);
-#if !defined(STM32F0xx) && !defined(STM32L0xx)
+#if !defined(STM32F0xx) && !defined(STM32G0xx) && !defined(STM32L0xx)
   HAL_NVIC_DisableIRQ(obj->irqER);
-#endif // !defined(STM32F0xx) && !defined(STM32L0xx)
+#endif /* !STM32F0xx && !STM32G0xx && !STM32L0xx */
   HAL_I2C_DeInit(&(obj->handle));
 }
 
@@ -588,12 +586,12 @@ void I2C1_EV_IRQHandler(void)
 {
   I2C_HandleTypeDef *handle = i2c_handles[I2C1_INDEX];
   HAL_I2C_EV_IRQHandler(handle);
-#if defined(STM32F0xx) || defined(STM32L0xx)
+#if defined(STM32F0xx) || defined(STM32G0xx) || defined(STM32L0xx)
   HAL_I2C_ER_IRQHandler(handle);
-#endif // defined(STM32F0xx) || defined(STM32L0xx)
+#endif /* STM32F0xx || STM32G0xx || STM32L0xx */
 }
 
-#if !defined(STM32F0xx) && !defined(STM32L0xx)
+#if !defined(STM32F0xx) && !defined(STM32G0xx) && !defined(STM32L0xx)
 /**
 * @brief  This function handles I2C1 interrupt.
 * @param  None
@@ -604,7 +602,7 @@ void I2C1_ER_IRQHandler(void)
   I2C_HandleTypeDef *handle = i2c_handles[I2C1_INDEX];
   HAL_I2C_ER_IRQHandler(handle);
 }
-#endif // !defined(STM32F0xx) && !defined(STM32L0xx)
+#endif /* !STM32F0xx && !STM32G0xx && !STM32L0xx */
 #endif // I2C1_BASE
 
 #if defined(I2C2_BASE)
@@ -617,12 +615,12 @@ void I2C2_EV_IRQHandler(void)
 {
   I2C_HandleTypeDef *handle = i2c_handles[I2C2_INDEX];
   HAL_I2C_EV_IRQHandler(handle);
-#if defined(STM32F0xx) || defined(STM32L0xx)
+#if defined(STM32F0xx) || defined(STM32G0xx) || defined(STM32L0xx)
   HAL_I2C_ER_IRQHandler(handle);
-#endif // defined(STM32F0xx) || defined(STM32L0xx)
+#endif /* STM32F0xx || STM32G0xx || STM32L0xx */
 }
 
-#if !defined(STM32F0xx) && !defined(STM32L0xx)
+#if !defined(STM32F0xx) && !defined(STM32G0xx) && !defined(STM32L0xx)
 /**
 * @brief  This function handles I2C2 interrupt.
 * @param  None
@@ -633,7 +631,7 @@ void I2C2_ER_IRQHandler(void)
   I2C_HandleTypeDef *handle = i2c_handles[I2C2_INDEX];
   HAL_I2C_ER_IRQHandler(handle);
 }
-#endif // !defined(STM32F0xx) && !defined(STM32L0xx)
+#endif /* !STM32F0xx && !STM32G0xx && !STM32L0xx */
 #endif // I2C2_BASE
 
 #if defined(I2C3_BASE)
@@ -646,12 +644,12 @@ void I2C3_EV_IRQHandler(void)
 {
   I2C_HandleTypeDef *handle = i2c_handles[I2C3_INDEX];
   HAL_I2C_EV_IRQHandler(handle);
-#if defined(STM32F0xx) || defined(STM32L0xx)
+#if defined(STM32L0xx)
   HAL_I2C_ER_IRQHandler(handle);
-#endif // defined(STM32F0xx) || defined(STM32L0xx)
+#endif /* STM32L0xx */
 }
 
-#if !defined(STM32F0xx) && !defined(STM32L0xx)
+#if !defined(STM32L0xx)
 /**
 * @brief  This function handles I2C3 interrupt.
 * @param  None
@@ -662,7 +660,7 @@ void I2C3_ER_IRQHandler(void)
   I2C_HandleTypeDef *handle = i2c_handles[I2C3_INDEX];
   HAL_I2C_ER_IRQHandler(handle);
 }
-#endif // !defined(STM32F0xx) && !defined(STM32L0xx)
+#endif /* !STM32L0xx */
 #endif // I2C3_BASE
 
 #if defined(I2C4_BASE)
@@ -675,12 +673,9 @@ void I2C4_EV_IRQHandler(void)
 {
   I2C_HandleTypeDef *handle = i2c_handles[I2C4_INDEX];
   HAL_I2C_EV_IRQHandler(handle);
-#if defined(STM32F0xx) || defined(STM32L0xx)
   HAL_I2C_ER_IRQHandler(handle);
-#endif // defined(STM32F0xx) || defined(STM32L0xx)
 }
 
-#if !defined(STM32F0xx) && !defined(STM32L0xx)
 /**
 * @brief  This function handles I2C4 interrupt.
 * @param  None
@@ -691,7 +686,6 @@ void I2C4_ER_IRQHandler(void)
   I2C_HandleTypeDef *handle = i2c_handles[I2C4_INDEX];
   HAL_I2C_ER_IRQHandler(handle);
 }
-#endif // !defined(STM32F0xx) && !defined(STM32L0xx)
 #endif // I2C4_BASE
 #endif /* HAL_I2C_MODULE_ENABLED */
 

--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -476,13 +476,25 @@ static uint32_t i2c_getTiming(i2c_t *obj, uint32_t frequency)
     switch (i2c_speed) {
       default:
       case 100000:
+#ifdef I2C_TIMING_SM
+        ret = I2C_TIMING_SM;
+#else
         ret = i2c_computeTiming(i2c_getClkFreq(obj->i2c), I2C_SPEED_FREQ_STANDARD);
+#endif
         break;
       case 400000:
+#ifdef I2C_TIMING_FM
+        ret = I2C_TIMING_FM;
+#else
         ret = i2c_computeTiming(i2c_getClkFreq(obj->i2c), I2C_SPEED_FREQ_FAST);
+#endif
         break;
       case 1000000:
+#ifdef I2C_TIMING_FMP
+        ret = I2C_TIMING_FMP;
+#else
         ret = i2c_computeTiming(i2c_getClkFreq(obj->i2c), I2C_SPEED_FREQ_FAST_PLUS);
+#endif
         break;
     }
   }

--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -59,6 +59,9 @@ extern "C" {
 #endif
 
 #ifdef I2C_TIMING
+#ifndef I2C_VALID_TIMING_NBR
+#define I2C_VALID_TIMING_NBR          8U
+#endif
 #define I2C_SPEED_FREQ_STANDARD       0U /* 100 kHz */
 #define I2C_SPEED_FREQ_FAST           1U /* 400 kHz */
 #define I2C_SPEED_FREQ_FAST_PLUS      2U /* 1 MHz */
@@ -337,6 +340,7 @@ valid config.
 static uint32_t i2c_computeTiming(uint32_t clkSrcFreq, uint32_t i2c_speed)
 {
   uint32_t ret = 0xFFFFFFFFU;
+  uint32_t valid_timing_nbr = 0;
   uint32_t ti2cclk;
   uint32_t ti2cspeed;
   uint32_t prev_error;
@@ -399,6 +403,10 @@ static uint32_t i2c_computeTiming(uint32_t clkSrcFreq, uint32_t i2c_speed)
           if ((tsdadel >= (uint32_t)tsdadel_min) && (tsdadel <=
                                                      (uint32_t)tsdadel_max)) {
             if (presc != prev_presc) {
+              valid_timing_nbr ++;
+              if (valid_timing_nbr >= I2C_VALID_TIMING_NBR) {
+                return ret;
+              }
               /* tPRESC = (PRESC+1) x tI2CCLK*/
               uint32_t tpresc = (presc + 1U) * ti2cclk;
               for (scll = 0; scll < I2C_SCLL_MAX; scll++) {

--- a/cores/arduino/stm32/twi.h
+++ b/cores/arduino/stm32/twi.h
@@ -64,7 +64,7 @@ extern "C" {
 /* I2C Tx/Rx buffer size */
 #define I2C_TXRX_BUFFER_SIZE    32
 
-/* Redefinition of IRQ for F0 & L0 family */
+/* Redefinition of IRQ for F0/G0/L0 families */
 #if defined(STM32F0xx) || defined(STM32G0xx) || defined(STM32L0xx)
 #if defined(I2C1_BASE)
 #define I2C1_EV_IRQn        I2C1_IRQn
@@ -74,15 +74,17 @@ extern "C" {
 #define I2C2_EV_IRQn        I2C2_IRQn
 #define I2C2_EV_IRQHandler  I2C2_IRQHandler
 #endif // defined(I2C2_BASE)
+/* Only for STM32L0xx */
 #if defined(I2C3_BASE)
 #define I2C3_EV_IRQn        I2C3_IRQn
 #define I2C3_EV_IRQHandler  I2C3_IRQHandler
 #endif // defined(I2C3_BASE)
+/* Defined but no one has it */
 #if defined(I2C4_BASE)
 #define I2C4_EV_IRQn        I2C4_IRQn
 #define I2C4_EV_IRQHandler  I2C4_IRQHandler
-#endif // defined(I2C4_BASE)-
-#endif // defined(STM32F0xx) || defined(STM32L0xx)
+#endif // defined(I2C4_BASE)
+#endif /* STM32F0xx || STM32G0xx || STM32L0xx */
 
 typedef struct i2c_s i2c_t;
 
@@ -97,9 +99,9 @@ struct i2c_s {
   PinName sda;
   PinName scl;
   IRQn_Type irq;
-#if !defined(STM32F0xx) && !defined(STM32L0xx)
+#if !defined(STM32F0xx) && !defined(STM32G0xx) && !defined(STM32L0xx)
   IRQn_Type irqER;
-#endif //!defined(STM32F0xx) && !defined(STM32L0xx)
+#endif /* !STM32F0xx && !STM32G0xx && !STM32L0xx */
   volatile int slaveRxNbData; // Number of accumulated bytes received in Slave mode
   void (*i2c_onSlaveReceive)(uint8_t *, int);
   void (*i2c_onSlaveTransmit)(void);

--- a/cores/arduino/stm32/twi.h
+++ b/cores/arduino/stm32/twi.h
@@ -120,42 +120,9 @@ typedef enum {
   I2C_BUSY = 3
 } i2c_status_e;
 
-typedef enum {
-#if defined (STM32F0xx) || defined (STM32F3xx) || defined (STM32L0xx)
-  //calculated with SYSCLK = 64MHz at
-  /*https://www.google.fr/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&cad=rja&uact=8&ved=0ahUKEwiC4q6O7ojMAhWCOhoKHYlyBtIQFggmMAE&url=http%3A%2F%2Fuglyduck.ath.cx%2FPDF%2FSTMicro%2FARM%2FSTM32F0%2FI2C_Timing_Configuration_V1.0.1.xls&usg=AFQjCNGGjPSUAzVUdbUqMUxPub8Ojzhh9w&sig2=4YgzXFixj15GhqkAzVS4tA*/
-  I2C_10KHz =   0xE010A9FF,
-  I2C_50KHz =   0x2070A8FD,
-  I2C_100KHz =  0x10B07EBA,
-  I2C_200KHz =  0x00C034FF,
-  I2C_400KHz =  0x00C0246F,
-  I2C_600KHz =  0x00900E50,
-  I2C_800KHz =  0x00900E35,
-  I2C_1000KHz = 0x00900E25
-#elif defined (STM32L4xx)
-  I2C_10KHz =   0xF010F3FE,
-  I2C_50KHz =   0x30608CFF,
-  I2C_100KHz =  0x10D0A4E4,
-  I2C_200KHz =  0x00F082FF,
-  I2C_400KHz =  0x00F02E8B,
-  I2C_600KHz =  0x00B01265,
-  I2C_800KHz =  0x00B01243,
-  I2C_1000KHz = 0x00B0122F
-#else //STM32F4xx
-  I2C_10KHz =   10000,
-  I2C_50KHz =   50000,
-  I2C_100KHz =  100000,
-  I2C_200KHz =  200000,
-  I2C_400KHz =  400000,
-  /*  I2C_600KHz =  600000,
-    I2C_800KHz =  800000,
-    I2C_1000KHz = 1000000*/ //Not supported
-#endif
-} i2c_timing_e;
-
 /* Exported functions ------------------------------------------------------- */
 void i2c_init(i2c_t *obj);
-void i2c_custom_init(i2c_t *obj, i2c_timing_e timing, uint32_t addressingMode,
+void i2c_custom_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode,
                      uint32_t ownAddress);
 void i2c_deinit(i2c_t *obj);
 void i2c_setTiming(i2c_t *obj, uint32_t frequency);

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -82,7 +82,7 @@ void TwoWire::begin(uint8_t address, bool generalCall)
 
   _i2c.generalCall = (generalCall == true) ? 1 : 0;
 
-  i2c_custom_init(&_i2c, I2C_100KHz, I2C_ADDRESSINGMODE_7BIT, ownAddress);
+  i2c_custom_init(&_i2c, 100000, I2C_ADDRESSINGMODE_7BIT, ownAddress);
 
   if (_i2c.isMaster == 0) {
     // i2c_attachSlaveTxEvent(&_i2c, reinterpret_cast<void(*)(i2c_t*)>(&TwoWire::onRequestService));

--- a/variants/board_template/variant.h
+++ b/variants/board_template/variant.h
@@ -113,6 +113,14 @@ extern "C" {
 //#define PIN_WIRE_SDA            14 // Default for Arduino connector compatibility
 //#define PIN_WIRE_SCL            15 // Default for Arduino connector compatibility
 
+// I2C timing definitions (optional), avoid time spent to compute if defined
+// * I2C_TIMING_SM for Standard Mode (100kHz)
+// * I2C_TIMING_FM for Fast Mode (400kHz)
+// * I2C_TIMING_FMP for Fast Mode Plus (1000kHz)
+//#define I2C_TIMING_SM           0x00000000
+//#define I2C_TIMING_FM           0x00000000
+//#define I2C_TIMING_FMP          0x00000000
+
 // Timer Definitions (optional)
 //Do not use timer used by PWM pins when possible. See PinMap_PWM in PeripheralPins.c
 #define TIMER_TONE              TIMx


### PR DESCRIPTION
This PR review I2C speed for series requiring I2C timing calculation
Currently:
 * STM32F0
 * STM32F3
 * STM32F7
 * STM32G0
 * STM32H7
 * STM32L0
 * STM32L4
 * STM32WB
 
Previously, I2C timing value for the `TIMINGR` register was hard coded for a specific I2C clock source configuration which was wrong for several target.
This PR provides dynamic calculation of this value depending of the I2C clock sources.

As this calculation of all timing values can consume huge time. By default, only the first **8** valid timing will be computed:
```
#ifndef I2C_VALID_TIMING_NBR
#define I2C_VALID_TIMING_NBR          8U
#endif
```

 It can be redefined thanks the `variant.h` or `build_opt.h` or `hal_conf_extra.h` using: `I2C_VALID_TIMING_NBR`

Higher number ensure lowest clock error but require more time to compute depending of the board.

Moreover, to avoid time spent to compute the I2C timing, it can be defined in the `variant.h` or `build_opt.h` or `hal_conf_extra.h` with:

  * `I2C_TIMING_SM` for Standard Mode (100kHz)
  * `I2C_TIMING_FM` for Fast Mode (400kHz)
  * `I2C_TIMING_FMP` for Fast Mode Plus (1000kHz) 

### Example

For a **STM32F0xx** using `HSI` clock as I2C clock source, in variant.h:

```
#define I2C_TIMING_SM           0x00201D2B
#define I2C_TIMING_FM           0x0010020A
```

# Tests results:
One board per series was tested.

## Hardware:
The [CI test shield](https://github.com/ARMmbed/mbed-HDK/tree/master/Production%20Design%20Projects/ARM-mbed/CITestShield) was used to test I2C speed.
It includes two I2C components:
 * AT24LCXXXEIAJ: I2C EEPROM, 24LC family from Microchip
 * LM75BD: Temperature Sensor from NXP

## Software:
Sketch performs an I2C scan at 100kHz and 400kHz, Read/write on EEPROM at 400kHz and Read temperature at 100kHz and 400kHz for all possible I2C clock source.

![image](https://user-images.githubusercontent.com/20641798/61315398-f4acae00-a7fe-11e9-92de-a5d715593904.png)

Fix #507


/CC @geosmall 