### PR TITLE
Add STM32F030F4 with internal rc oscillator

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -622,6 +622,14 @@ GenF0.menu.pnum.DEMO_F030F4_16M.build.board=DEMO_F030F4_16M
 GenF0.menu.pnum.DEMO_F030F4_16M.build.product_line=STM32F030x6
 GenF0.menu.pnum.DEMO_F030F4_16M.build.variant=DEMO_F030F4
 
+# DEMO_F030F4_HSI board
+GenF0.menu.pnum.DEMO_F030F4_HSI=STM32F030F4 Demo board (internal RC oscillator)
+GenF0.menu.pnum.DEMO_F030F4_HSI.upload.maximum_data_size=4096
+GenF0.menu.pnum.DEMO_F030F4_HSI.upload.maximum_size=16384
+GenF0.menu.pnum.DEMO_F030F4_HSI.build.board=DEMO_F030F4_HSI
+GenF0.menu.pnum.DEMO_F030F4_HSI.build.product_line=STM32F030x6
+GenF0.menu.pnum.DEMO_F030F4_HSI.build.variant=DEMO_F030F4
+
 # Upload menu
 GenF0.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
 GenF0.menu.upload_method.swdMethod.upload.protocol=0

--- a/variants/DEMO_F030F4/variant.cpp
+++ b/variants/DEMO_F030F4/variant.cpp
@@ -88,17 +88,27 @@ WEAK void SystemClock_Config(void)
   RCC_ClkInitTypeDef RCC_ClkInitStruct;
 
   /* Initializes the CPU, AHB and APB busses clocks */
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+#ifdef ARDUINO_DEMO_F030F4_HSI
+  /* Internal HSI, 48MHz system clock */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+  RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL12;
+  RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV1;
+#else
   RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI14 | RCC_OSCILLATORTYPE_HSE;
   RCC_OscInitStruct.HSEState = RCC_HSE_ON;
   RCC_OscInitStruct.HSI14State = RCC_HSI14_ON;
   RCC_OscInitStruct.HSI14CalibrationValue = 16;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
   RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL6;
-#ifdef ARDUINO_DEMO_F030F4_16M
-  RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV2;
-#else
-  RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV1;
+  #ifdef ARDUINO_DEMO_F030F4_16M
+    RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV2;
+  #else
+    RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV1;
+  #endif
 #endif
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
     _Error_Handler(__FILE__, __LINE__);

--- a/variants/DEMO_F030F4/variant.cpp
+++ b/variants/DEMO_F030F4/variant.cpp
@@ -104,11 +104,11 @@ WEAK void SystemClock_Config(void)
   RCC_OscInitStruct.HSI14CalibrationValue = 16;
   RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
   RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL6;
-  #ifdef ARDUINO_DEMO_F030F4_16M
-    RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV2;
-  #else
-    RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV1;
-  #endif
+#ifdef ARDUINO_DEMO_F030F4_16M
+  RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV2;
+#else
+  RCC_OscInitStruct.PLL.PREDIV = RCC_PREDIV_DIV1;
+#endif
 #endif
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
     _Error_Handler(__FILE__, __LINE__);


### PR DESCRIPTION
Currently STM32F030F4-Boards require a 8MHz or 16MHz external crystal for system clock. This variant allows for using the internal rc oscillator (HSI) to generate a 48MHz system clock without additional external components lowering BOM cost or complexity for boards without the need for high clock accuracy.