### PR TITLE
Added the repeated-start feature in I2C driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :---: | --- | :---: | :--- |
 | :green_heart: | BluePill F103C(6-8-B) | *1.2.0* | USB CDC support since *1.5.0*, Maple bootloaders support since *1.6.0* |
 | :green_heart: | BlackPill F103C(8-B) | *1.5.0* |  |
-| :yellow_heart: | BlackPill F401CC | **1.7.0* |  |
+| :yellow_heart: | BlackPill F401CC | **1.7.0** |  |
 | :green_heart: | MapleMini F103CB | *1.2.0* | USB CDC support since *1.5.0*, Maple bootloaders support since *1.6.0* |
 | :green_heart: | HY-TinySTM103T | *1.5.0* |  |
 

--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -717,7 +717,7 @@ i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address,
   }
 
   do {
-    if (HAL_I2C_Master_Seq_Transmit_IT(&(obj->handle), dev_address, data, size,obj->handle.XferOptions) == HAL_OK) {
+    if (HAL_I2C_Master_Seq_Transmit_IT(&(obj->handle), dev_address, data, size, obj->handle.XferOptions) == HAL_OK) {
       ret = I2C_OK;
       // wait for transfer completion
       while ((HAL_I2C_GetState(&(obj->handle)) != HAL_I2C_STATE_READY)

--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -717,7 +717,7 @@ i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address,
   }
 
   do {
-    if (HAL_I2C_Master_Transmit_IT(&(obj->handle), dev_address, data, size) == HAL_OK) {
+    if (HAL_I2C_Master_Seq_Transmit_IT(&(obj->handle), dev_address, data, size,obj->handle.XferOptions) == HAL_OK) {
       ret = I2C_OK;
       // wait for transfer completion
       while ((HAL_I2C_GetState(&(obj->handle)) != HAL_I2C_STATE_READY)
@@ -778,7 +778,7 @@ i2c_status_e i2c_master_read(i2c_t *obj, uint8_t dev_address, uint8_t *data, uin
   uint32_t delta = 0;
 
   do {
-    if (HAL_I2C_Master_Receive_IT(&(obj->handle), dev_address, data, size) == HAL_OK) {
+    if (HAL_I2C_Master_Seq_Receive_IT(&(obj->handle), dev_address, data, size, obj->handle.XferOptions) == HAL_OK) {
       ret = I2C_OK;
       // wait for transfer completion
       while ((HAL_I2C_GetState(&(obj->handle)) != HAL_I2C_STATE_READY)

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -218,7 +218,7 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 {
   int8_t ret = 4;
   // check transfer options and store it in the I2C handle
-  if (sendStop == false) {
+  if (sendStop == 0) {
     _i2c.handle.XferOptions = I2C_FIRST_FRAME;
   } else {
     _i2c.handle.XferOptions = I2C_FIRST_AND_LAST_FRAME;

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -216,7 +216,6 @@ void TwoWire::beginTransmission(int address)
 //
 uint8_t TwoWire::endTransmission(uint8_t sendStop)
 {
-  //UNUSED(sendStop);
   int8_t ret = 4;
   // check transfer options and store it in the I2C handle
   if (sendStop == false) {

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -146,9 +146,9 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 
     // perform blocking read into buffer
     uint8_t read = 0;
-    if(sendStop!=false) {
+    if (sendStop != false) {
       _i2c.handle.XferOptions = I2C_LAST_FRAME;
-    }else{
+    } else {
       _i2c.handle.XferOptions = I2C_NO_OPTION_FRAME;
     }
     if (I2C_OK == i2c_master_read(&_i2c, address << 1, rxBuffer, quantity)) {
@@ -219,9 +219,9 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
   //UNUSED(sendStop);
   int8_t ret = 4;
   // check transfer options and store it in the I2C handle
-  if(sendStop==false) {
+  if (sendStop == false) {
     _i2c.handle.XferOptions = I2C_FIRST_FRAME;
-  }else{
+  } else {
     _i2c.handle.XferOptions = I2C_FIRST_AND_LAST_FRAME;
   }
 

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -146,7 +146,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 
     // perform blocking read into buffer
     uint8_t read = 0;
-    if (sendStop != false) {
+    if (sendStop != 0) {
       _i2c.handle.XferOptions = I2C_LAST_FRAME;
     } else {
       _i2c.handle.XferOptions = I2C_NO_OPTION_FRAME;

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -27,6 +27,7 @@ extern "C" {
 
 #include "Wire.h"
 
+#define I2C_NO_OPTION_FRAME       0xFFFF0000U /*!< XferOptions default value */
 // Initialize Class Variables //////////////////////////////////////////////////
 uint8_t *TwoWire::rxBuffer = nullptr;
 uint8_t TwoWire::rxBufferAllocated = 0;
@@ -116,7 +117,6 @@ void TwoWire::setClock(uint32_t frequency)
 
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddress, uint8_t isize, uint8_t sendStop)
 {
-  UNUSED(sendStop);
   if (_i2c.isMaster == 1) {
     allocateRxBuffer(quantity);
     // error if no memory block available to allocate the buffer
@@ -146,6 +146,11 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 
     // perform blocking read into buffer
     uint8_t read = 0;
+    if(sendStop!=false) {
+      _i2c.handle.XferOptions = I2C_LAST_FRAME;
+    }else{
+      _i2c.handle.XferOptions = I2C_NO_OPTION_FRAME;
+    }
     if (I2C_OK == i2c_master_read(&_i2c, address << 1, rxBuffer, quantity)) {
       read = quantity;
     }
@@ -211,8 +216,14 @@ void TwoWire::beginTransmission(int address)
 //
 uint8_t TwoWire::endTransmission(uint8_t sendStop)
 {
-  UNUSED(sendStop);
+  //UNUSED(sendStop);
   int8_t ret = 4;
+  // check transfer options and store it in the I2C handle
+  if(sendStop==false) {
+    _i2c.handle.XferOptions = I2C_FIRST_FRAME;
+  }else{
+    _i2c.handle.XferOptions = I2C_FIRST_AND_LAST_FRAME;
+  }
 
   if (_i2c.isMaster == 1) {
     // transmit buffer (blocking)


### PR DESCRIPTION
This solves the repeated-start issue #583 . Tested on F411RE using a MMA8451 accelerometer and OLED SSD1306 I2C peripherals. This seems to be ok but it's a little bit tricky.
It must hugely tested by the community with several I2C peripherals and several platforms.

