### PR TITLE
Allow F_CPU redefinition

### DIFF
--- a/cores/arduino/stm32/stm32_def.h
+++ b/cores/arduino/stm32/stm32_def.h
@@ -20,7 +20,6 @@
                                         |(STM32_CORE_VERSION_PATCH << 8U )\
                                         |(STM32_CORE_VERSION_EXTRA))
 
-#define F_CPU SystemCoreClock
 #define USE_HAL_DRIVER
 
 #ifdef STM32F0xx
@@ -51,6 +50,10 @@
 #include "stm32wbxx.h"
 #else
 #error "STM32YYxx chip series is not defined in boards.txt."
+#endif
+
+#ifndef F_CPU
+#define F_CPU SystemCoreClock
 #endif
 
 // Here define some compatibility


### PR DESCRIPTION
To avoid any issue with `F_CPU` value, it is defined by default to
`SystemCoreClock` value which is updated automatically after each
clock configuration update.

Some libraries use `F_CPU` at build time for conditional purpose (ex to #612).
This commit allow to redefine it at build time using `build_opt.h` or `hal_conf_extra.h`:
https://github.com/stm32duino/wiki/wiki/Custom-definitions
then it will be possible to define it as a constant.

**Important note:**
**User have to ensure to set it to the proper value.**
