### PR TITLE
[Time] delayMicroseconds() accuracy + Fix ticks per ms value used to compute micros

### DIFF
--- a/cores/arduino/stm32/clock.c
+++ b/cores/arduino/stm32/clock.c
@@ -53,12 +53,13 @@ uint32_t getCurrentMicros(void)
   /* Ensure COUNTFLAG is reset by reading SysTick control and status register */
   LL_SYSTICK_IsActiveCounterFlag();
   uint32_t m = HAL_GetTick();
-  uint32_t u = SysTick->LOAD - SysTick->VAL;
+  const uint32_t tms = SysTick->LOAD + 1;
+  __IO uint32_t u = tms - SysTick->VAL;
   if (LL_SYSTICK_IsActiveCounterFlag()) {
     m = HAL_GetTick();
-    u = SysTick->LOAD - SysTick->VAL;
+    u = tms - SysTick->VAL;
   }
-  return (m * 1000 + (u * 1000) / SysTick->LOAD);
+  return (m * 1000 + (u * 1000) / tms);
 }
 
 /**

--- a/cores/arduino/wiring_time.h
+++ b/cores/arduino/wiring_time.h
@@ -69,8 +69,20 @@ static inline void delayMicroseconds(uint32_t us)
 
   while ((int32_t)dwt_getCycles() - start < cycles);
 #else
-  uint32_t start = getCurrentMicros();
-  while (getCurrentMicros() - start < us);
+  __IO uint32_t currentTicks = SysTick->VAL;
+  /* Number of ticks per millisecond */
+  const uint32_t tickPerMs = SysTick->LOAD + 1;
+  /* Number of ticks to count */
+  const uint32_t nbTicks = ((us - ((us > 0) ? 1 : 0)) * tickPerMs) / 1000;
+  /* Number of elapsed ticks */
+  uint32_t elapsedTicks = 0;
+  __IO uint32_t oldTicks = currentTicks;
+  do {
+    currentTicks = SysTick->VAL;
+    elapsedTicks += (oldTicks < currentTicks) ? tickPerMs + oldTicks - currentTicks :
+                    oldTicks - currentTicks;
+    oldTicks = currentTicks;
+  } while (nbTicks > elapsedTicks);
 #endif
 }
 


### PR DESCRIPTION
This PR mainly fixes issue with `delayMicroseconds()` on Cortex-M0 as for other series it uses `DWT->CYCCNT` which is more accurate.

Then OneWire is now functional on all series.

### GPIO toggling at 5µs on a NUCLEO-L053R8:
With old implementation:
![image](https://user-images.githubusercontent.com/20641798/63944007-09709880-ca71-11e9-8e51-14922f9db156.png)
With new implementation:
![image](https://user-images.githubusercontent.com/20641798/63944675-4be6a500-ca72-11e9-8e52-307ed9dea6ee.png)

Fixes #412 