### PR TITLE
Fix `{build.mcu}` definition

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -39,7 +39,8 @@ Nucleo_144.menu.pnum.NUCLEO_F429ZI=Nucleo F429ZI
 Nucleo_144.menu.pnum.NUCLEO_F429ZI.node=NODE_F429ZI
 Nucleo_144.menu.pnum.NUCLEO_F429ZI.upload.maximum_size=2097152
 Nucleo_144.menu.pnum.NUCLEO_F429ZI.upload.maximum_data_size=262144
-Nucleo_144.menu.pnum.NUCLEO_F429ZI.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_144.menu.pnum.NUCLEO_F429ZI.build.mcu=cortex-m4
+Nucleo_144.menu.pnum.NUCLEO_F429ZI.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_144.menu.pnum.NUCLEO_F429ZI.build.board=NUCLEO_F429ZI
 Nucleo_144.menu.pnum.NUCLEO_F429ZI.build.series=STM32F4xx
 Nucleo_144.menu.pnum.NUCLEO_F429ZI.build.product_line=STM32F429xx
@@ -51,7 +52,8 @@ Nucleo_144.menu.pnum.NUCLEO_F767ZI=Nucleo F767ZI
 Nucleo_144.menu.pnum.NUCLEO_F767ZI.node=NODE_F767ZI
 Nucleo_144.menu.pnum.NUCLEO_F767ZI.upload.maximum_size=2097152
 Nucleo_144.menu.pnum.NUCLEO_F767ZI.upload.maximum_data_size=524288
-Nucleo_144.menu.pnum.NUCLEO_F767ZI.build.mcu=cortex-m7 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_144.menu.pnum.NUCLEO_F767ZI.build.mcu=cortex-m7
+Nucleo_144.menu.pnum.NUCLEO_F767ZI.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_144.menu.pnum.NUCLEO_F767ZI.build.board=NUCLEO_F767ZI
 Nucleo_144.menu.pnum.NUCLEO_F767ZI.build.series=STM32F7xx
 Nucleo_144.menu.pnum.NUCLEO_F767ZI.build.product_line=STM32F767xx
@@ -63,7 +65,8 @@ Nucleo_144.menu.pnum.NUCLEO_H743ZI=Nucleo H743ZI
 Nucleo_144.menu.pnum.NUCLEO_H743ZI.node=NODE_H743ZI
 Nucleo_144.menu.pnum.NUCLEO_H743ZI.upload.maximum_size=2097152
 Nucleo_144.menu.pnum.NUCLEO_H743ZI.upload.maximum_data_size=131072
-Nucleo_144.menu.pnum.NUCLEO_H743ZI.build.mcu=cortex-m7 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_144.menu.pnum.NUCLEO_H743ZI.build.mcu=cortex-m7
+Nucleo_144.menu.pnum.NUCLEO_H743ZI.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_144.menu.pnum.NUCLEO_H743ZI.build.board=NUCLEO_H743ZI
 Nucleo_144.menu.pnum.NUCLEO_H743ZI.build.series=STM32H7xx
 Nucleo_144.menu.pnum.NUCLEO_H743ZI.build.product_line=STM32H743xx
@@ -74,7 +77,8 @@ Nucleo_144.menu.pnum.NUCLEO_H743ZI2=Nucleo H743ZI2
 Nucleo_144.menu.pnum.NUCLEO_H743ZI2.node=NODE_H743ZI
 Nucleo_144.menu.pnum.NUCLEO_H743ZI2.upload.maximum_size=2097152
 Nucleo_144.menu.pnum.NUCLEO_H743ZI2.upload.maximum_data_size=131072
-Nucleo_144.menu.pnum.NUCLEO_H743ZI2.build.mcu=cortex-m7 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_144.menu.pnum.NUCLEO_H743ZI2.build.mcu=cortex-m7
+Nucleo_144.menu.pnum.NUCLEO_H743ZI2.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_144.menu.pnum.NUCLEO_H743ZI2.build.board=NUCLEO_H743ZI2
 Nucleo_144.menu.pnum.NUCLEO_H743ZI2.build.series=STM32H7xx
 Nucleo_144.menu.pnum.NUCLEO_H743ZI2.build.product_line=STM32H743xx
@@ -86,7 +90,8 @@ Nucleo_144.menu.pnum.NUCLEO_L496ZG=Nucleo L496ZG
 Nucleo_144.menu.pnum.NUCLEO_L496ZG.node=NODE_L496ZG
 Nucleo_144.menu.pnum.NUCLEO_L496ZG.upload.maximum_size=1048576
 Nucleo_144.menu.pnum.NUCLEO_L496ZG.upload.maximum_data_size=327680
-Nucleo_144.menu.pnum.NUCLEO_L496ZG.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_144.menu.pnum.NUCLEO_L496ZG.build.mcu=cortex-m4
+Nucleo_144.menu.pnum.NUCLEO_L496ZG.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_144.menu.pnum.NUCLEO_L496ZG.build.board=NUCLEO_L496ZG
 Nucleo_144.menu.pnum.NUCLEO_L496ZG.build.series=STM32L4xx
 Nucleo_144.menu.pnum.NUCLEO_L496ZG.build.product_line=STM32L496xx
@@ -98,7 +103,8 @@ Nucleo_144.menu.pnum.NUCLEO_L496ZG-P=Nucleo L496ZG-P
 Nucleo_144.menu.pnum.NUCLEO_L496ZG-P.node=NODE_L496ZG
 Nucleo_144.menu.pnum.NUCLEO_L496ZG-P.upload.maximum_size=1048576
 Nucleo_144.menu.pnum.NUCLEO_L496ZG-P.upload.maximum_data_size=327680
-Nucleo_144.menu.pnum.NUCLEO_L496ZG-P.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_144.menu.pnum.NUCLEO_L496ZG-P.build.mcu=cortex-m4
+Nucleo_144.menu.pnum.NUCLEO_L496ZG-P.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_144.menu.pnum.NUCLEO_L496ZG-P.build.board=NUCLEO_L496ZG_P
 Nucleo_144.menu.pnum.NUCLEO_L496ZG-P.build.series=STM32L4xx
 Nucleo_144.menu.pnum.NUCLEO_L496ZG-P.build.product_line=STM32L496xx
@@ -110,7 +116,8 @@ Nucleo_144.menu.pnum.NUCLEO_L4R5ZI=Nucleo L4R5ZI
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI.node=NODE_L4R5ZI
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI.upload.maximum_size=2097152
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI.upload.maximum_data_size=655360
-Nucleo_144.menu.pnum.NUCLEO_L4R5ZI.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_144.menu.pnum.NUCLEO_L4R5ZI.build.mcu=cortex-m4
+Nucleo_144.menu.pnum.NUCLEO_L4R5ZI.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI.build.board=NUCLEO_L4R5ZI
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI.build.series=STM32L4xx
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI.build.product_line=STM32L4R5xx
@@ -122,7 +129,8 @@ Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P=Nucleo L4R5ZI-P
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P.node=NODE_L4R5ZI
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P.upload.maximum_size=2097152
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P.upload.maximum_data_size=655360
-Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P.build.mcu=cortex-m4
+Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P.build.board=NUCLEO_L4R5ZI_P
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P.build.series=STM32L4xx
 Nucleo_144.menu.pnum.NUCLEO_L4R5ZI-P.build.product_line=STM32L4R5xx
@@ -200,7 +208,8 @@ Nucleo_64.menu.pnum.NUCLEO_F302R8=Nucleo F302R8
 Nucleo_64.menu.pnum.NUCLEO_F302R8.node=NODE_F302R8
 Nucleo_64.menu.pnum.NUCLEO_F302R8.upload.maximum_size=65536
 Nucleo_64.menu.pnum.NUCLEO_F302R8.upload.maximum_data_size=16384
-Nucleo_64.menu.pnum.NUCLEO_F302R8.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_F302R8.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_F302R8.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_F302R8.build.board=NUCLEO_F302R8
 Nucleo_64.menu.pnum.NUCLEO_F302R8.build.series=STM32F3xx
 Nucleo_64.menu.pnum.NUCLEO_F302R8.build.product_line=STM32F302x8
@@ -212,7 +221,8 @@ Nucleo_64.menu.pnum.NUCLEO_F303RE=Nucleo F303RE
 Nucleo_64.menu.pnum.NUCLEO_F303RE.node=NODE_F303RE
 Nucleo_64.menu.pnum.NUCLEO_F303RE.upload.maximum_size=524288
 Nucleo_64.menu.pnum.NUCLEO_F303RE.upload.maximum_data_size=65536
-Nucleo_64.menu.pnum.NUCLEO_F303RE.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_F303RE.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_F303RE.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_F303RE.build.board=NUCLEO_F303RE
 Nucleo_64.menu.pnum.NUCLEO_F303RE.build.series=STM32F3xx
 Nucleo_64.menu.pnum.NUCLEO_F303RE.build.product_line=STM32F303xE
@@ -224,7 +234,8 @@ Nucleo_64.menu.pnum.NUCLEO_F401RE=Nucleo F401RE
 Nucleo_64.menu.pnum.NUCLEO_F401RE.node=NODE_F401RE
 Nucleo_64.menu.pnum.NUCLEO_F401RE.upload.maximum_size=524288
 Nucleo_64.menu.pnum.NUCLEO_F401RE.upload.maximum_data_size=98304
-Nucleo_64.menu.pnum.NUCLEO_F401RE.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_F401RE.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_F401RE.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_F401RE.build.board=NUCLEO_F401RE
 Nucleo_64.menu.pnum.NUCLEO_F401RE.build.series=STM32F4xx
 Nucleo_64.menu.pnum.NUCLEO_F401RE.build.product_line=STM32F401xE
@@ -236,7 +247,8 @@ Nucleo_64.menu.pnum.NUCLEO_F411RE=Nucleo F411RE
 Nucleo_64.menu.pnum.NUCLEO_F411RE.node="NODE_F411RE,NUCLEO"
 Nucleo_64.menu.pnum.NUCLEO_F411RE.upload.maximum_size=524288
 Nucleo_64.menu.pnum.NUCLEO_F411RE.upload.maximum_data_size=131072
-Nucleo_64.menu.pnum.NUCLEO_F411RE.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_F411RE.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_F411RE.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_F411RE.build.board=NUCLEO_F411RE
 Nucleo_64.menu.pnum.NUCLEO_F411RE.build.series=STM32F4xx
 Nucleo_64.menu.pnum.NUCLEO_F411RE.build.product_line=STM32F411xE
@@ -248,7 +260,8 @@ Nucleo_64.menu.pnum.NUCLEO_F446RE=Nucleo F446RE
 Nucleo_64.menu.pnum.NUCLEO_F446RE.node=NODE_F446RE
 Nucleo_64.menu.pnum.NUCLEO_F446RE.upload.maximum_size=524288
 Nucleo_64.menu.pnum.NUCLEO_F446RE.upload.maximum_data_size=131072
-Nucleo_64.menu.pnum.NUCLEO_F446RE.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_F446RE.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_F446RE.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_F446RE.build.board=NUCLEO_F446RE
 Nucleo_64.menu.pnum.NUCLEO_F446RE.build.series=STM32F4xx
 Nucleo_64.menu.pnum.NUCLEO_F446RE.build.product_line=STM32F446xx
@@ -273,7 +286,8 @@ Nucleo_64.menu.pnum.NUCLEO_G431RB=Nucleo G431RB
 Nucleo_64.menu.pnum.NUCLEO_G431RB.node=NODE_G431RB
 Nucleo_64.menu.pnum.NUCLEO_G431RB.upload.maximum_size=131072
 Nucleo_64.menu.pnum.NUCLEO_G431RB.upload.maximum_data_size=32768
-Nucleo_64.menu.pnum.NUCLEO_G431RB.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_G431RB.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_G431RB.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_G431RB.build.board=NUCLEO_G431RB
 Nucleo_64.menu.pnum.NUCLEO_G431RB.build.series=STM32G4xx
 Nucleo_64.menu.pnum.NUCLEO_G431RB.build.product_line=STM32G431xx
@@ -285,7 +299,8 @@ Nucleo_64.menu.pnum.NUCLEO_G474RE=Nucleo G474RE
 Nucleo_64.menu.pnum.NUCLEO_G474RE.node=NODE_G474RE
 Nucleo_64.menu.pnum.NUCLEO_G474RE.upload.maximum_size=524288
 Nucleo_64.menu.pnum.NUCLEO_G474RE.upload.maximum_data_size=131072
-Nucleo_64.menu.pnum.NUCLEO_G474RE.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_G474RE.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_G474RE.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_G474RE.build.board=NUCLEO_G474RE
 Nucleo_64.menu.pnum.NUCLEO_G474RE.build.series=STM32G4xx
 Nucleo_64.menu.pnum.NUCLEO_G474RE.build.product_line=STM32G474xx
@@ -335,7 +350,8 @@ Nucleo_64.menu.pnum.NUCLEO_L452RE=Nucleo L452RE
 Nucleo_64.menu.pnum.NUCLEO_L452RE.node=NODE_L452RE
 Nucleo_64.menu.pnum.NUCLEO_L452RE.upload.maximum_size=524288
 Nucleo_64.menu.pnum.NUCLEO_L452RE.upload.maximum_data_size=163840
-Nucleo_64.menu.pnum.NUCLEO_L452RE.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_L452RE.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_L452RE.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_L452RE.build.board=NUCLEO_L452RE
 Nucleo_64.menu.pnum.NUCLEO_L452RE.build.series=STM32L4xx
 Nucleo_64.menu.pnum.NUCLEO_L452RE.build.product_line=STM32L452xx
@@ -348,7 +364,8 @@ Nucleo_64.menu.pnum.NUCLEO_L476RG=Nucleo L476RG
 Nucleo_64.menu.pnum.NUCLEO_L476RG.node=NODE_L476RG
 Nucleo_64.menu.pnum.NUCLEO_L476RG.upload.maximum_size=1048576
 Nucleo_64.menu.pnum.NUCLEO_L476RG.upload.maximum_data_size=98304
-Nucleo_64.menu.pnum.NUCLEO_L476RG.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_L476RG.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_L476RG.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.NUCLEO_L476RG.build.board=NUCLEO_L476RG
 Nucleo_64.menu.pnum.NUCLEO_L476RG.build.series=STM32L4xx
 Nucleo_64.menu.pnum.NUCLEO_L476RG.build.product_line=STM32L476xx
@@ -360,7 +377,8 @@ Nucleo_64.menu.pnum.PNUCLEO_WB55RG=P-Nucleo WB55RG
 Nucleo_64.menu.pnum.PNUCLEO_WB55RG.node=NODE_WB55RG
 Nucleo_64.menu.pnum.PNUCLEO_WB55RG.upload.maximum_size=524288
 Nucleo_64.menu.pnum.PNUCLEO_WB55RG.upload.maximum_data_size=196604
-Nucleo_64.menu.pnum.PNUCLEO_WB55RG.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_64.menu.pnum.PNUCLEO_WB55RG.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.PNUCLEO_WB55RG.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_64.menu.pnum.PNUCLEO_WB55RG.build.board=PNUCLEO_WB55RG
 Nucleo_64.menu.pnum.PNUCLEO_WB55RG.build.series=STM32WBxx
 Nucleo_64.menu.pnum.PNUCLEO_WB55RG.build.product_line=STM32WB55xx
@@ -414,7 +432,8 @@ Nucleo_32.menu.pnum.NUCLEO_L412KB=Nucleo L412KB
 Nucleo_32.menu.pnum.NUCLEO_L412KB.node=NODE_L412KB
 Nucleo_32.menu.pnum.NUCLEO_L412KB.upload.maximum_size=131072
 Nucleo_32.menu.pnum.NUCLEO_L412KB.upload.maximum_data_size=40960
-Nucleo_32.menu.pnum.NUCLEO_L412KB.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_32.menu.pnum.NUCLEO_L412KB.build.mcu=cortex-m4
+Nucleo_32.menu.pnum.NUCLEO_L412KB.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_32.menu.pnum.NUCLEO_L412KB.build.board=NUCLEO_L412KB
 Nucleo_32.menu.pnum.NUCLEO_L412KB.build.series=STM32L4xx
 Nucleo_32.menu.pnum.NUCLEO_L412KB.build.product_line=STM32L412xx
@@ -426,7 +445,8 @@ Nucleo_32.menu.pnum.NUCLEO_L432KC=Nucleo L432KC
 Nucleo_32.menu.pnum.NUCLEO_L432KC.node=NODE_L432KC
 Nucleo_32.menu.pnum.NUCLEO_L432KC.upload.maximum_size=262144
 Nucleo_32.menu.pnum.NUCLEO_L432KC.upload.maximum_data_size=65536
-Nucleo_32.menu.pnum.NUCLEO_L432KC.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_32.menu.pnum.NUCLEO_L432KC.build.mcu=cortex-m4
+Nucleo_32.menu.pnum.NUCLEO_L432KC.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_32.menu.pnum.NUCLEO_L432KC.build.board=NUCLEO_L432KC
 Nucleo_32.menu.pnum.NUCLEO_L432KC.build.series=STM32L4xx
 Nucleo_32.menu.pnum.NUCLEO_L432KC.build.product_line=STM32L432xx
@@ -438,7 +458,8 @@ Nucleo_32.menu.pnum.NUCLEO_F303K8=Nucleo F303K8
 Nucleo_32.menu.pnum.NUCLEO_F303K8.node=NODE_F303K8
 Nucleo_32.menu.pnum.NUCLEO_F303K8.upload.maximum_size=65536
 Nucleo_32.menu.pnum.NUCLEO_F303K8.upload.maximum_data_size=12288
-Nucleo_32.menu.pnum.NUCLEO_F303K8.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_32.menu.pnum.NUCLEO_F303K8.build.mcu=cortex-m4
+Nucleo_32.menu.pnum.NUCLEO_F303K8.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_32.menu.pnum.NUCLEO_F303K8.build.board=NUCLEO_F303K8
 Nucleo_32.menu.pnum.NUCLEO_F303K8.build.series=STM32F3xx
 Nucleo_32.menu.pnum.NUCLEO_F303K8.build.product_line=STM32F303x8
@@ -450,7 +471,8 @@ Nucleo_32.menu.pnum.NUCLEO_G431KB=Nucleo G431KB
 Nucleo_32.menu.pnum.NUCLEO_G431KB.node=NODE_G431KB
 Nucleo_32.menu.pnum.NUCLEO_G431KB.upload.maximum_size=131072
 Nucleo_32.menu.pnum.NUCLEO_G431KB.upload.maximum_data_size=32768
-Nucleo_32.menu.pnum.NUCLEO_G431KB.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Nucleo_32.menu.pnum.NUCLEO_G431KB.build.mcu=cortex-m4
+Nucleo_32.menu.pnum.NUCLEO_G431KB.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Nucleo_32.menu.pnum.NUCLEO_G431KB.build.board=NUCLEO_G431KB
 Nucleo_32.menu.pnum.NUCLEO_G431KB.build.series=STM32G4xx
 Nucleo_32.menu.pnum.NUCLEO_G431KB.build.product_line=STM32G431xx
@@ -528,7 +550,8 @@ Disco.menu.pnum.DISCO_F407VG=STM32F407G-DISC1
 Disco.menu.pnum.DISCO_F407VG.node=DIS_F407VG
 Disco.menu.pnum.DISCO_F407VG.upload.maximum_size=1048576
 Disco.menu.pnum.DISCO_F407VG.upload.maximum_data_size=196608
-Disco.menu.pnum.DISCO_F407VG.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Disco.menu.pnum.DISCO_F407VG.build.mcu=cortex-m4
+Disco.menu.pnum.DISCO_F407VG.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Disco.menu.pnum.DISCO_F407VG.build.board=DISCO_F407VG
 Disco.menu.pnum.DISCO_F407VG.build.series=STM32F4xx
 Disco.menu.pnum.DISCO_F407VG.build.product_line=STM32F407xx
@@ -540,7 +563,8 @@ Disco.menu.pnum.DISCO_F746NG=STM32F746G-DISCOVERY
 Disco.menu.pnum.DISCO_F746NG.node=DIS_F746NG
 Disco.menu.pnum.DISCO_F746NG.upload.maximum_size=1048576
 Disco.menu.pnum.DISCO_F746NG.upload.maximum_data_size=327680
-Disco.menu.pnum.DISCO_F746NG.build.mcu=cortex-m7 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Disco.menu.pnum.DISCO_F746NG.build.mcu=cortex-m7
+Disco.menu.pnum.DISCO_F746NG.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Disco.menu.pnum.DISCO_F746NG.build.board=DISCO_F746NG
 Disco.menu.pnum.DISCO_F746NG.build.series=STM32F7xx
 Disco.menu.pnum.DISCO_F746NG.build.product_line=STM32F746xx
@@ -552,7 +576,8 @@ Disco.menu.pnum.DISCO_L475VG_IOT=STM32L475VG-DISCOVERY-IOT
 Disco.menu.pnum.DISCO_L475VG_IOT.node=DIS_L4IOT
 Disco.menu.pnum.DISCO_L475VG_IOT.upload.maximum_size=1048576
 Disco.menu.pnum.DISCO_L475VG_IOT.upload.maximum_data_size=98304
-Disco.menu.pnum.DISCO_L475VG_IOT.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Disco.menu.pnum.DISCO_L475VG_IOT.build.mcu=cortex-m4
+Disco.menu.pnum.DISCO_L475VG_IOT.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Disco.menu.pnum.DISCO_L475VG_IOT.build.board=DISCO_L475VG_IOT
 Disco.menu.pnum.DISCO_L475VG_IOT.build.series=STM32L4xx
 Disco.menu.pnum.DISCO_L475VG_IOT.build.product_line=STM32L475xx
@@ -606,7 +631,8 @@ Eval.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
 Eval.menu.pnum.STEVAL_MKSBOX1V1=SensorTile.box
 Eval.menu.pnum.STEVAL_MKSBOX1V1.upload.maximum_size=2097152
 Eval.menu.pnum.STEVAL_MKSBOX1V1.upload.maximum_data_size=655360
-Eval.menu.pnum.STEVAL_MKSBOX1V1.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Eval.menu.pnum.STEVAL_MKSBOX1V1.build.mcu=cortex-m4
+Eval.menu.pnum.STEVAL_MKSBOX1V1.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Eval.menu.pnum.STEVAL_MKSBOX1V1.build.board=STEVAL_MKSBOX1V1
 Eval.menu.pnum.STEVAL_MKSBOX1V1.build.series=STM32L4xx
 Eval.menu.pnum.STEVAL_MKSBOX1V1.build.product_line=STM32L4R9xx
@@ -825,7 +851,8 @@ GenF3.build.vid=0x0483
 GenF3.build.core=arduino
 GenF3.build.board=GenF3
 GenF3.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
-GenF3.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+GenF3.build.mcu=cortex-m4
+GenF3.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 GenF3.build.series=STM32F3xx
 GenF3.build.cmsis_lib_gcc=arm_cortexM4l_math
 
@@ -866,7 +893,8 @@ GenF4.build.vid=0x0483
 GenF4.build.core=arduino
 GenF4.build.board=GenF4
 GenF4.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
-GenF4.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+GenF4.build.mcu=cortex-m4
+GenF4.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 GenF4.build.series=STM32F4xx
 GenF4.build.cmsis_lib_gcc=arm_cortexM4l_math
 
@@ -982,7 +1010,8 @@ Sparky.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSeria
 Sparky.menu.pnum.Sparky_V1=Sparky V1
 Sparky.menu.pnum.Sparky_V1.upload.maximum_size=262144
 Sparky.menu.pnum.Sparky_V1.upload.maximum_data_size=40960
-Sparky.menu.pnum.Sparky_V1.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Sparky.menu.pnum.Sparky_V1.build.mcu=cortex-m4
+Sparky.menu.pnum.Sparky_V1.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Sparky.menu.pnum.Sparky_V1.build.board=Sparky_V1
 Sparky.menu.pnum.Sparky_V1.build.series=STM32F3xx
 Sparky.menu.pnum.Sparky_V1.build.product_line=STM32F303xC
@@ -1063,7 +1092,8 @@ RAK.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.pnum.ARMED_V1=Armed V1
 3dprinter.menu.pnum.ARMED_V1.upload.maximum_size=1048576
 3dprinter.menu.pnum.ARMED_V1.upload.maximum_data_size=196608
-3dprinter.menu.pnum.ARMED_V1.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+3dprinter.menu.pnum.ARMED_V1.build.mcu=cortex-m4
+3dprinter.menu.pnum.ARMED_V1.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 3dprinter.menu.pnum.ARMED_V1.build.board=ARMED_V1
 3dprinter.menu.pnum.ARMED_V1.build.series=STM32F4xx
 3dprinter.menu.pnum.ARMED_V1.build.product_line=STM32F407xx
@@ -1076,7 +1106,8 @@ RAK.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.pnum.REMRAM_V1=RemRam v1
 3dprinter.menu.pnum.REMRAM_V1.upload.maximum_size=2097152
 3dprinter.menu.pnum.REMRAM_V1.upload.maximum_data_size=524288
-3dprinter.menu.pnum.REMRAM_V1.build.mcu=cortex-m7 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+3dprinter.menu.pnum.REMRAM_V1.build.mcu=cortex-m7
+3dprinter.menu.pnum.REMRAM_V1.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 3dprinter.menu.pnum.REMRAM_V1.build.board=REMRAM_V1
 3dprinter.menu.pnum.REMRAM_V1.build.series=STM32F7xx
 3dprinter.menu.pnum.REMRAM_V1.build.product_line=STM32F765xx
@@ -1087,7 +1118,8 @@ RAK.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.pnum.RUMBA32=RUMBA32
 3dprinter.menu.pnum.RUMBA32.upload.maximum_size=524288
 3dprinter.menu.pnum.RUMBA32.upload.maximum_data_size=131072
-3dprinter.menu.pnum.RUMBA32.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+3dprinter.menu.pnum.RUMBA32.build.mcu=cortex-m4
+3dprinter.menu.pnum.RUMBA32.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 3dprinter.menu.pnum.RUMBA32.build.board=RUMBA32_F446VE
 3dprinter.menu.pnum.RUMBA32.build.series=STM32F4xx
 3dprinter.menu.pnum.RUMBA32.build.product_line=STM32F446xx
@@ -1098,7 +1130,8 @@ RAK.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.pnum.ST3DP001_EVAL=STEVAL-3DP001V1
 3dprinter.menu.pnum.ST3DP001_EVAL.upload.maximum_size=524288
 3dprinter.menu.pnum.ST3DP001_EVAL.upload.maximum_data_size=98304
-3dprinter.menu.pnum.ST3DP001_EVAL.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+3dprinter.menu.pnum.ST3DP001_EVAL.build.mcu=cortex-m4
+3dprinter.menu.pnum.ST3DP001_EVAL.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 3dprinter.menu.pnum.ST3DP001_EVAL.build.board=ST3DP001_EVAL
 3dprinter.menu.pnum.ST3DP001_EVAL.build.series=STM32F4xx
 3dprinter.menu.pnum.ST3DP001_EVAL.build.product_line=STM32F401xE
@@ -1109,7 +1142,8 @@ RAK.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.pnum.PRNTR_F407_V1=PRNTR F407 v1
 3dprinter.menu.pnum.PRNTR_F407_V1.upload.maximum_size=524288
 3dprinter.menu.pnum.PRNTR_F407_V1.upload.maximum_data_size=196608
-3dprinter.menu.pnum.PRNTR_F407_V1.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+3dprinter.menu.pnum.PRNTR_F407_V1.build.mcu=cortex-m4
+3dprinter.menu.pnum.PRNTR_F407_V1.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 3dprinter.menu.pnum.PRNTR_F407_V1.build.board=PRNTR_F407_V1
 3dprinter.menu.pnum.PRNTR_F407_V1.build.series=STM32F4xx
 3dprinter.menu.pnum.PRNTR_F407_V1.build.product_line=STM32F407xx
@@ -1157,7 +1191,8 @@ RAK.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.pnum.VAKE_F446VE=VAkE v1.0
 3dprinter.menu.pnum.VAKE_F446VE.upload.maximum_size=524288
 3dprinter.menu.pnum.VAKE_F446VE.upload.maximum_data_size=131072
-3dprinter.menu.pnum.VAKE_F446VE.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+3dprinter.menu.pnum.VAKE_F446VE.build.mcu=cortex-m4
+3dprinter.menu.pnum.VAKE_F446VE.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 3dprinter.menu.pnum.VAKE_F446VE.build.board=VAKE403
 3dprinter.menu.pnum.VAKE_F446VE.build.series=STM32F4xx
 3dprinter.menu.pnum.VAKE_F446VE.build.product_line=STM32F446xx
@@ -1266,7 +1301,8 @@ Midatronics.menu.pnum.MKR_SHARKY=MKR Sharky
 Midatronics.menu.pnum.MKR_SHARKY.node=NODE_WB55CE
 Midatronics.menu.pnum.MKR_SHARKY.upload.maximum_size=524288
 Midatronics.menu.pnum.MKR_SHARKY.upload.maximum_data_size=196604
-Midatronics.menu.pnum.MKR_SHARKY.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+Midatronics.menu.pnum.MKR_SHARKY.build.mcu=cortex-m4
+Midatronics.menu.pnum.MKR_SHARKY.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Midatronics.menu.pnum.MKR_SHARKY.build.board=MKR_SHARKY
 Midatronics.menu.pnum.MKR_SHARKY.build.series=STM32WBxx
 Midatronics.menu.pnum.MKR_SHARKY.build.product_line=STM32WB55xx

--- a/platform.txt
+++ b/platform.txt
@@ -27,7 +27,7 @@ compiler.c.elf.cmd=arm-none-eabi-gcc
 compiler.objcopy.cmd=arm-none-eabi-objcopy
 compiler.elf2hex.cmd=arm-none-eabi-objcopy
 
-compiler.extra_flags=-mcpu={build.mcu} -mthumb "@{build.opt.path}"
+compiler.extra_flags=-mcpu={build.mcu} {build.flags.fp} -mthumb "@{build.opt.path}"
 
 compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.stm.extra_include}
 
@@ -37,7 +37,7 @@ compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.wa
 
 compiler.ar.flags=rcs
 
-compiler.c.elf.flags=-mcpu={build.mcu} -mthumb {build.flags.optimize} {build.flags.ldspecs} -Wl,--defsym=LD_FLASH_OFFSET={build.flash_offset} -Wl,--defsym=LD_MAX_SIZE={upload.maximum_size} -Wl,--defsym=LD_MAX_DATA_SIZE={upload.maximum_data_size} -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common
+compiler.c.elf.flags=-mcpu={build.mcu} {build.flags.fp} -mthumb {build.flags.optimize} {build.flags.ldspecs} -Wl,--defsym=LD_FLASH_OFFSET={build.flash_offset} -Wl,--defsym=LD_MAX_SIZE={upload.maximum_size} -Wl,--defsym=LD_MAX_DATA_SIZE={upload.maximum_data_size} -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common
 
 compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
 
@@ -82,6 +82,7 @@ build.xSerial=-DHAL_UART_MODULE_ENABLED
 build.enable_usb=
 build.usb_speed=
 build.startup_file=
+build.flags.fp=
 build.flags.optimize=-Os
 build.flags.ldspecs=--specs=nano.specs
 build.flash_offset=0


### PR DESCRIPTION
Library can provide a pre-compiled library.
See `precompiled` option here:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

The .a(archive)/.so(shared object) file must be located at: `src/{build.mcu}`

So the `build.mcu` could not contain `fpu` and `float-abi` options
and should only contain `cortex-mx` value.

Else Arduino IDE, instead of searching `cortex-mx`, searches
`cortex-mx -mfpu=fpv4-sp-d16 -mfloat-abi=hard` if floating-point
options are set.

`build.flags.fp` has been added to contain floating-point options if any.

Fixes #606