### PR TITLE
Fix callbacks array init. Move nptr check in the start of CCcb

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -90,7 +90,7 @@ HardwareTimer::HardwareTimer(TIM_TypeDef *instance)
     _channelIC[i].ICPrescaler = TIM_ICPSC_DIV1;
     _channelIC[i].ICFilter = 0;
 
-    for (int i = 0; i < TIMER_CHANNELS ; i++) {
+    for (int i = 0; i < TIMER_CHANNELS + 1 ; i++) {
       callbacks[i] = NULL;
     }
   }
@@ -723,6 +723,9 @@ void HardwareTimer::updateCallback(TIM_HandleTypeDef *htim)
   */
 void HardwareTimer::captureCompareCallback(TIM_HandleTypeDef *htim)
 {
+  if (htim == NULL) {
+    Error_Handler();
+  }
   uint32_t channel = htim->Channel;
 
   switch (htim->Channel) {
@@ -744,10 +747,6 @@ void HardwareTimer::captureCompareCallback(TIM_HandleTypeDef *htim)
       }
     default:
       return;
-  }
-
-  if (htim == NULL) {
-    Error_Handler();
   }
 
   HardwareTimerObj_t *obj = get_timer_obj(htim);


### PR DESCRIPTION
**Summary**

HardwareTimer does not 0 all callbacks in the array, resulting in invoking random code

