### PR TITLE
Add half-duplex support to HardwareSerial.

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -143,12 +143,24 @@ class HardwareSerial : public Stream {
     void setRx(PinName _rx);
     void setTx(PinName _tx);
 
+    // Enable half-duplex mode by setting the Rx pin to NC
+    // This needs to be done before the call to begin()
+    inline void setHalfDuplex()
+    {
+      setRx(NC);
+    }
+    inline bool isHalfDuplex() const
+    {
+      return _serial.pin_rx == NC;
+    }
+
     friend class STM32LowPower;
 
     // Interrupt handlers
     static void _rx_complete_irq(serial_t *obj);
     static int _tx_complete_irq(serial_t *obj);
   private:
+    bool _rx_enabled;
     uint8_t _config;
     unsigned long _baud;
     void init(void);

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -181,6 +181,9 @@ void uart_attach_tx_callback(serial_t *obj, int (*callback)(serial_t *));
 uint8_t serial_tx_active(serial_t *obj);
 uint8_t serial_rx_active(serial_t *obj);
 
+void uart_enable_tx(serial_t *obj);
+void uart_enable_rx(serial_t *obj);
+
 size_t uart_debug_write(uint8_t *data, uint32_t size);
 
 #endif /* HAL_UART_MODULE_ENABLED */


### PR DESCRIPTION
**Summary**
TMC2209 and 2208 drivers use UART communication with a single wire. Enabling half-duplex support in the HardwareSerial class would enable using these drivers without wasting another pin for the RX signal.

Proposed API is to enable half-duplex mode if the RX pin on the serial port is NC. Also added a method to set the half-duplex mode explicitly.

**Validation**

* Ensure Travis CI build is passed.
* Demonstrate the code is solid. [e.g. Provide a sketch]
Tested using:
https://gist.github.com/ghent360/dc2a7226919af522e4a5914da1ad5252

