### PR TITLE
SoftwareSerial implementation

### DIFF
--- a/libraries/SoftwareSerial/examples/SoftwareSerialExample/SoftwareSerialExample.ino
+++ b/libraries/SoftwareSerial/examples/SoftwareSerialExample/SoftwareSerialExample.ino
@@ -1,0 +1,46 @@
+/*
+  Software serial multple serial test
+
+ Receives from the hardware serial, sends to software serial.
+ Receives from software serial, sends to hardware serial.
+
+ The circuit:
+ * RX is digital pin 10 (connect to TX of other device)
+ * TX is digital pin 11 (connect to RX of other device)
+
+ created back in the mists of time
+ modified 25 May 2012
+ by Tom Igoe
+ based on Mikal Hart's example
+
+ This example code is in the public domain.
+
+ */
+#include <SoftwareSerial.h>
+
+SoftwareSerial mySerial(10, 11); // RX, TX
+
+void setup() {
+  // Open serial communications and wait for port to open:
+  Serial.begin(57600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+
+  Serial.println("Goodnight moon!");
+
+  // set the data rate for the SoftwareSerial port
+  mySerial.begin(4800);
+  mySerial.println("Hello, world?");
+}
+
+void loop() { // run over and over
+  if (mySerial.available()) {
+    Serial.write(mySerial.read());
+  }
+  if (Serial.available()) {
+    mySerial.write(Serial.read());
+  }
+}
+

--- a/libraries/SoftwareSerial/examples/TwoPortReceive/TwoPortReceive.ino
+++ b/libraries/SoftwareSerial/examples/TwoPortReceive/TwoPortReceive.ino
@@ -1,0 +1,83 @@
+/*
+  Software serial multple serial test
+
+ Receives from the two software serial ports,
+ sends to the hardware serial port.
+
+ In order to listen on a software port, you call port.listen().
+ When using two software serial ports, you have to switch ports
+ by listen()ing on each one in turn. Pick a logical time to switch
+ ports, like the end of an expected transmission, or when the
+ buffer is empty. This example switches ports when there is nothing
+ more to read from a port
+
+ The circuit:
+ Two devices which communicate serially are needed.
+ * First serial device's TX attached to digital pin 10(RX), RX to pin 11(TX)
+ * Second serial device's TX attached to digital pin 8(RX), RX to pin 9(TX)
+
+
+ created 18 Apr. 2011
+ modified 19 March 2016
+ by Tom Igoe
+ based on Mikal Hart's twoPortRXExample
+
+ This example code is in the public domain.
+
+ */
+
+#include <SoftwareSerial.h>
+// software serial #1: RX = digital pin 10, TX = digital pin 11
+SoftwareSerial portOne(10, 11);
+
+// software serial #2: RX = digital pin 8, TX = digital pin 9
+// on the Mega, use other pins instead, since 8 and 9 don't work on the Mega
+SoftwareSerial portTwo(8, 9);
+
+void setup() {
+  // Open serial communications and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+
+  // Start each software serial port
+  portOne.begin(9600);
+  portTwo.begin(9600);
+}
+
+void loop() {
+  // By default, the last intialized port is listening.
+  // when you want to listen on a port, explicitly select it:
+  portOne.listen();
+  Serial.println("Data from port one:");
+  // while there is data coming in, read it
+  // and send to the hardware serial port:
+  while (portOne.available() > 0) {
+    char inByte = portOne.read();
+    Serial.write(inByte);
+  }
+
+  // blank line to separate data from the two ports:
+  Serial.println();
+
+  // Now listen on the second port
+  portTwo.listen();
+  // while there is data coming in, read it
+  // and send to the hardware serial port:
+  Serial.println("Data from port two:");
+  while (portTwo.available() > 0) {
+    char inByte = portTwo.read();
+    Serial.write(inByte);
+  }
+
+  // blank line to separate data from the two ports:
+  Serial.println();
+}
+
+
+
+
+
+

--- a/libraries/SoftwareSerial/keywords.txt
+++ b/libraries/SoftwareSerial/keywords.txt
@@ -1,0 +1,30 @@
+#######################################
+# Syntax Coloring Map for SoftwareSerial
+# (formerly NewSoftSerial)
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+SoftwareSerial	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+begin	KEYWORD2
+end	KEYWORD2
+read	KEYWORD2
+write	KEYWORD2
+available	KEYWORD2
+isListening	KEYWORD2
+overflow	KEYWORD2
+flush	KEYWORD2
+listen	KEYWORD2
+peek	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+

--- a/libraries/SoftwareSerial/library.properties
+++ b/libraries/SoftwareSerial/library.properties
@@ -1,0 +1,10 @@
+name=SoftwareSerial
+version=1.0
+author=Arduino, Armin van der Togt
+maintainer=stm32duino
+sentence=Enables serial communication on any digital pin.
+paragraph=The SoftwareSerial library has been developed to allow serial communication on any digital pin of the board, using software to replicate the functionality of the hardware UART. It is possible to have multiple software serial ports. 
+category=Communication
+url=http://www.arduino.cc/en/Reference/SoftwareSerial
+architectures=stm32
+

--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -154,7 +154,7 @@ bool SoftwareSerial::listen()
     setSpeed(_speed);
     active_listener = this;
     if (!_half_duplex) {
-    active_in = this;
+      active_in = this;
     }
     return true;
   }
@@ -319,9 +319,9 @@ SoftwareSerial::SoftwareSerial(uint16_t receivePin, uint16_t transmitPin, bool i
   _receive_buffer_head(0)
 {
   if ((receivePin < NUM_DIGITAL_PINS) || (transmitPin < NUM_DIGITAL_PINS)) {
-  /* Enable GPIO clock for tx and rx pin*/
-  set_GPIO_Port_Clock(STM_PORT(digitalPinToPinName(transmitPin)));
-  set_GPIO_Port_Clock(STM_PORT(digitalPinToPinName(receivePin)));
+    /* Enable GPIO clock for tx and rx pin*/
+    set_GPIO_Port_Clock(STM_PORT(digitalPinToPinName(transmitPin)));
+    set_GPIO_Port_Clock(STM_PORT(digitalPinToPinName(receivePin)));
   } else {
     _Error_Handler("ERROR: invalid pin number\n", -1);
   }

--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -1,0 +1,432 @@
+/*
+ * SoftwareSerial.cpp (formerly NewSoftSerial.cpp)
+ *
+ * Multi-instance software serial library for Arduino/Wiring
+ * -- Interrupt-driven receive and other improvements by ladyada
+ *    (http://ladyada.net)
+ * -- Tuning, circular buffer, derivation from class Print/Stream,
+ *    multi-instance support, porting to 8MHz processors,
+ *    various optimizations, PROGMEM delay tables, inverse logic and
+ *    direct port writing by Mikal Hart (http://www.arduiniana.org)
+ * -- Pin change interrupt macros by Paul Stoffregen (http://www.pjrc.com)
+ * -- 20MHz processor support by Garrett Mace (http://www.macetech.com)
+ * -- ATmega1280/2560 support by Brett Hagman (http://www.roguerobotics.com/)
+ * -- STM32 support by Armin van der Togt
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * The latest version of this library can always be found at
+ * http://arduiniana.org.
+ */
+
+//
+// Includes
+//
+#include <stdint.h>
+#include <stdarg.h>
+
+#include <wiring_digital.h>
+#include <time.h>
+
+#include <Arduino.h>
+#include "SoftwareSerial.h"
+#include <HardwareTimer.h>
+#include <stm32_def.h>
+#include <digital_io.h>
+
+#define OVERSAMPLE 3 // in RX, Timer will generate interruption OVERSAMPLE time during a bit. Thus OVERSAMPLE ticks in a bit. (interrupt not synchonized with edge).
+
+// defined in bit-periods
+#define HALFDUPLEX_SWITCH_DELAY 5
+// It's best to define TIMER_SERIAL in variant.h. If not defined, we choose one here
+// The order is based on (lack of) features and compare channels, we choose the simplest available
+// because we only need an update interrupt
+#if !defined(TIMER_SERIAL)
+#if defined (TIM18_BASE)
+#define TIMER_SERIAL TIM18
+#elif defined (TIM7_BASE)
+#define TIMER_SERIAL TIM7
+#elif defined (TIM6_BASE)
+#define TIMER_SERIAL TIM6
+#elif defined (TIM22_BASE)
+#define TIMER_SERIAL TIM22
+#elif defined (TIM21_BASE)
+#define TIMER_SERIAL TIM21
+#elif defined (TIM17_BASE)
+#define TIMER_SERIAL TIM17
+#elif defined (TIM16_BASE)
+#define TIMER_SERIAL TIM16
+#elif defined (TIM15_BASE)
+#define TIMER_SERIAL TIM15
+#elif defined (TIM14_BASE)
+#define TIMER_SERIAL TIM14
+#elif defined (TIM13_BASE)
+#define TIMER_SERIAL TIM13
+#elif defined (TIM11_BASE)
+#define TIMER_SERIAL TIM11
+#elif defined (TIM10_BASE)
+#define TIMER_SERIAL TIM10
+#elif defined (TIM12_BASE)
+#define TIMER_SERIAL TIM12
+#elif defined (TIM19_BASE)
+#define TIMER_SERIAL TIM19
+#elif defined (TIM9_BASE)
+#define TIMER_SERIAL TIM9
+#elif defined (TIM5_BASE)
+#define TIMER_SERIAL TIM5
+#elif defined (TIM4_BASE)
+#define TIMER_SERIAL TIM4
+#elif defined (TIM3_BASE)
+#define TIMER_SERIAL TIM3
+#elif defined (TIM2_BASE)
+#define TIMER_SERIAL TIM2
+#elif defined (TIM20_BASE)
+#define TIMER_SERIAL TIM20
+#elif defined (TIM8_BASE)
+#define TIMER_SERIAL TIM8
+#elif defined (TIM1_BASE)
+#define TIMER_SERIAL TIM1
+#else
+#error No suitable timer found for SoftwareSerial, define TIMER_SERIAL in variant.h
+#endif
+#endif
+//
+// Statics
+//
+HardwareTimer SoftwareSerial::timer(TIMER_SERIAL);
+SoftwareSerial *SoftwareSerial::active_listener = nullptr;
+SoftwareSerial *volatile SoftwareSerial::active_out = nullptr;
+SoftwareSerial *volatile SoftwareSerial::active_in = nullptr;
+int32_t SoftwareSerial::tx_tick_cnt = 0; // OVERSAMPLE ticks needed for a bit
+int32_t volatile SoftwareSerial::rx_tick_cnt = 0;  // OVERSAMPLE ticks needed for a bit
+uint32_t SoftwareSerial::tx_buffer = 0;
+int32_t SoftwareSerial::tx_bit_cnt = 0;
+uint32_t SoftwareSerial::rx_buffer = 0;
+int32_t SoftwareSerial::rx_bit_cnt = -1; // rx_bit_cnt = -1 :  waiting for start bit
+uint32_t SoftwareSerial::cur_speed = 0;
+
+//
+// Private methods
+//
+
+void SoftwareSerial::setSpeed(uint32_t speed)
+{
+  if (speed != cur_speed) {
+    timer.pause();
+    if (speed != 0) {
+      // Disable the timer
+      uint32_t clock_rate, cmp_value;
+      // Get timer clock
+      clock_rate = timer.getTimerClkFreq();
+      int pre = 1;
+      // Calculate prescale an compare value
+      do {
+        cmp_value = clock_rate / (speed * OVERSAMPLE);
+        if (cmp_value >= UINT16_MAX) {
+          clock_rate = clock_rate / 2;
+          pre *= 2;
+        }
+      } while (cmp_value >= UINT16_MAX);
+      timer.setPrescaleFactor(pre);
+      timer.setOverflow(cmp_value);
+      timer.setCount(0);
+      timer.attachInterrupt(&handleInterrupt);
+      timer.resume();
+    } else {
+      timer.detachInterrupt();
+    }
+    cur_speed = speed;
+  }
+}
+
+// This function sets the current object as the "listening"
+// one and returns true if it replaces another
+bool SoftwareSerial::listen()
+{
+  if (_receivePin >= 0) {
+    // wait for any transmit to complete as we may change speed
+    while (active_out)
+      ;
+    if (active_listener) {
+      active_listener->stopListening();
+    }
+    rx_tick_cnt = 1; // 1 : next interrupt will decrease rx_tick_cnt to 0 which means RX pin level will be considered.
+    rx_bit_cnt = -1; // rx_bit_cnt = -1 :  waiting for start bit
+    setSpeed(_speed);
+    active_listener = this;
+    if (!_half_duplex) {
+      active_in = this;
+    }
+    return true;
+  }
+  return false;
+}
+
+// Stop listening. Returns true if we were actually listening.
+bool SoftwareSerial::stopListening()
+{
+  if (active_listener == this) {
+    // wait for any output to complete
+    while (active_out)
+      ;
+    if (_half_duplex) {
+      setRXTX(false);
+    }
+    active_listener = nullptr;
+    active_in = nullptr;
+    // turn off ints
+    setSpeed(0);
+    return true;
+  }
+  return false;
+}
+
+inline void SoftwareSerial::setTX()
+{
+  if (_inverse_logic) {
+    LL_GPIO_ResetOutputPin(_transmitPinPort, _transmitPinNumber);
+  } else {
+    LL_GPIO_SetOutputPin(_transmitPinPort, _transmitPinNumber);
+  }
+  pinMode(_transmitPin, OUTPUT);
+}
+
+inline void SoftwareSerial::setRX()
+{
+  if (_receivePin > 0) {
+    pinMode(_receivePin, _inverse_logic ? INPUT_PULLDOWN : INPUT_PULLUP); // pullup for normal logic!
+  }
+}
+
+inline void SoftwareSerial::setRXTX(bool input)
+{
+  if (_half_duplex) {
+    if (input) {
+      if (active_in != this) {
+        setRX();
+        rx_bit_cnt = -1; // rx_bit_cnt = -1 :  waiting for start bit
+        rx_tick_cnt = 2; // 2 : next interrupt will be discarded. 2 interrupts required to consider RX pin level
+        active_in = this;
+      }
+    } else {
+      if (active_in == this) {
+        setTX();
+        active_in = nullptr;
+      }
+    }
+  }
+}
+
+inline void SoftwareSerial::send()
+{
+  if (--tx_tick_cnt <= 0) { // if tx_tick_cnt > 0 interrupt is discarded. Only when tx_tick_cnt reach 0 we set TX pin.
+    if (tx_bit_cnt++ < 10) { // tx_bit_cnt < 10 transmission is not fiisehed (10 = 1 start +8 bits + 1 stop)
+      // send data (including start and stop bits)
+      if (tx_buffer & 1) {
+        LL_GPIO_SetOutputPin(_transmitPinPort, _transmitPinNumber);
+      } else {
+        LL_GPIO_ResetOutputPin(_transmitPinPort, _transmitPinNumber);
+      }
+      tx_buffer >>= 1;
+      tx_tick_cnt = OVERSAMPLE; // Wait OVERSAMPLE tick to send next bit
+    } else { // Transmission finished
+      tx_tick_cnt = 1;
+      if (_output_pending || !(_half_duplex && active_listener == this)) {
+        active_out = nullptr;
+        rx_bit_cnt = -1; // rx_bit_cnt = -1 :  waiting for start bit
+        rx_tick_cnt = 2; // 2 : next interrupt will be discarded. 2 interrupts required to consider RX pin level
+        active_in = this;
+        // When in half-duplex mode, we wait for HALFDUPLEX_SWITCH_DELAY bit-periods after the byte has
+        // been transmitted before allowing the switch to RX mode
+      } else if (tx_bit_cnt > 10 + OVERSAMPLE * HALFDUPLEX_SWITCH_DELAY) {
+        pinMode(_receivePin, _inverse_logic ? INPUT_PULLDOWN : INPUT_PULLUP); // pullup for normal logic!
+        active_out = nullptr;
+      }
+    }
+  }
+}
+
+//
+// The receive routine called by the interrupt handler
+//
+inline void SoftwareSerial::recv()
+{
+  if (--rx_tick_cnt <= 0) { // if rx_tick_cnt > 0 interrupt is discarded. Only when rx_tick_cnt reach 0 RX pin is considered
+    bool inbit = LL_GPIO_IsInputPinSet(_receivePinPort, _receivePinNumber) ^ _inverse_logic;
+    if (rx_bit_cnt == -1) {  // rx_bit_cnt = -1 :  waiting for start bit
+      if (!inbit) {
+        // got start bit
+        rx_bit_cnt = 0; // rx_bit_cnt == 0 : start bit received
+        rx_tick_cnt = OVERSAMPLE + 1; // Wait 1 bit (OVERSAMPLE ticks) + 1 tick in order to sample RX pin in the middle of the edge (and not too close to the edge)
+        rx_buffer = 0;
+      } else {
+        rx_tick_cnt = 1; // Waiting for start bit, but we don't get right level. Wait for next Interrupt to ckech RX pin level
+      }
+    } else if (rx_bit_cnt >= 8) { // rx_bit_cnt >= 8 : waiting for stop bit
+      if (inbit) {
+        // stop bit read complete add to buffer
+        uint8_t next = (_receive_buffer_tail + 1) % _SS_MAX_RX_BUFF;
+        if (next != _receive_buffer_head) {
+          // save new data in buffer: tail points to where byte goes
+          _receive_buffer[_receive_buffer_tail] = rx_buffer; // save new byte
+          _receive_buffer_tail = next;
+        } else { // rx_bit_cnt = x  with x = [0..7] correspond to new bit x received
+          _buffer_overflow = true;
+        }
+      }
+      // Full trame received. Resart wainting for sart bit at next interrupt
+      rx_tick_cnt = 1;
+      rx_bit_cnt = -1;
+    } else {
+      // data bits
+      rx_buffer >>= 1;
+      if (inbit) {
+        rx_buffer |= 0x80;
+      }
+      rx_bit_cnt++; // Preprare for next bit
+      rx_tick_cnt = OVERSAMPLE; // Wait OVERSAMPLE ticks before sampling next bit
+    }
+  }
+}
+
+//
+// Interrupt handling
+//
+
+/* static */
+inline void SoftwareSerial::handleInterrupt(HardwareTimer *timer)
+{
+  if (active_in) {
+    active_in->recv();
+  }
+  if (active_out) {
+    active_out->send();
+  }
+}
+//
+// Constructor
+//
+SoftwareSerial::SoftwareSerial(uint16_t receivePin, uint16_t transmitPin, bool inverse_logic /* = false */) :
+  _receivePin(receivePin),
+  _transmitPin(transmitPin),
+  _receivePinPort(digitalPinToPort(receivePin)),
+  _receivePinNumber(STM_LL_GPIO_PIN(digitalPinToPinName(receivePin))),
+  _transmitPinPort(digitalPinToPort(transmitPin)),
+  _transmitPinNumber(STM_LL_GPIO_PIN(digitalPinToPinName(transmitPin))),
+  _speed(0),
+  _buffer_overflow(false),
+  _inverse_logic(inverse_logic),
+  _half_duplex(receivePin == transmitPin),
+  _output_pending(0),
+  _receive_buffer_tail(0),
+  _receive_buffer_head(0)
+{
+  /* Enable GPIO clock for tx and rx pin*/
+  set_GPIO_Port_Clock(STM_PORT(digitalPinToPinName(transmitPin)));
+  set_GPIO_Port_Clock(STM_PORT(digitalPinToPinName(receivePin)));
+}
+
+//
+// Destructor
+//
+SoftwareSerial::~SoftwareSerial()
+{
+  end();
+}
+
+//
+// Public methods
+//
+
+void SoftwareSerial::begin(long speed)
+{
+#ifdef FORCE_BAUD_RATE
+  speed = FORCE_BAUD_RATE;
+#endif
+  _speed = speed;
+  if (!_half_duplex) {
+    setTX();
+    setRX();
+  } else {
+    setTX();
+  }
+
+  listen();
+}
+
+void SoftwareSerial::end()
+{
+  stopListening();
+}
+
+// Read data from buffer
+int SoftwareSerial::read()
+{
+  // Empty buffer?
+  if (_receive_buffer_head == _receive_buffer_tail) {
+    return -1;
+  }
+
+  // Read from "head"
+  uint8_t d = _receive_buffer[_receive_buffer_head]; // grab next byte
+  _receive_buffer_head = (_receive_buffer_head + 1) % _SS_MAX_RX_BUFF;
+  return d;
+}
+
+int SoftwareSerial::available()
+{
+  return (_receive_buffer_tail + _SS_MAX_RX_BUFF - _receive_buffer_head) % _SS_MAX_RX_BUFF;
+}
+
+size_t SoftwareSerial::write(uint8_t b)
+{
+  // wait for previous transmit to complete
+  _output_pending = 1;
+  while (active_out)
+    ;
+  // add start and stop bits.
+  tx_buffer = b << 1 | 0x200;
+  if (_inverse_logic) {
+    tx_buffer = ~tx_buffer;
+  }
+  tx_bit_cnt = 0;
+  tx_tick_cnt = OVERSAMPLE;
+  setSpeed(_speed);
+  if (_half_duplex) {
+    setRXTX(false);
+  }
+  _output_pending = 0;
+  // make us active
+  active_out = this;
+  return 1;
+}
+
+void SoftwareSerial::flush()
+{
+  noInterrupts();
+  _receive_buffer_head = _receive_buffer_tail = 0;
+  interrupts();
+}
+
+int SoftwareSerial::peek()
+{
+  // Empty buffer?
+  if (_receive_buffer_head == _receive_buffer_tail) {
+    return -1;
+  }
+
+  // Read from "head"
+  return _receive_buffer[_receive_buffer_head];
+}

--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -1,0 +1,137 @@
+/*
+ * SoftwareSerial.h (formerly NewSoftSerial.h)
+ *
+ * Multi-instance software serial library for Arduino/Wiring
+ * -- Interrupt-driven receive and other improvements by ladyada
+ *    (http://ladyada.net)
+ * -- Tuning, circular buffer, derivation from class Print/Stream,
+ *    multi-instance support, porting to 8MHz processors,
+ *    various optimizations, PROGMEM delay tables, inverse logic and
+ *    direct port writing by Mikal Hart (http://www.arduiniana.org)
+ * -- Pin change interrupt macros by Paul Stoffregen (http://www.pjrc.com)
+ * -- 20MHz processor support by Garrett Mace (http://www.macetech.com)
+ * -- ATmega1280/2560 support by Brett Hagman (http://www.roguerobotics.com/)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * The latest version of this library can always be found at
+ * http://arduiniana.org.
+ */
+
+#ifndef SOFTWARESERIAL_H
+#define SOFTWARESERIAL_H
+
+#include <Arduino.h>
+#include <stdint.h>
+#include <Stream.h>
+#include <Print.h>
+#include <HardwareTimer.h>
+
+/******************************************************************************
+* Definitions
+******************************************************************************/
+
+#define _SS_MAX_RX_BUFF 64 // RX buffer size
+
+class SoftwareSerial : public Stream {
+  private:
+    // per object data
+    uint16_t _receivePin;
+    uint16_t _transmitPin;
+    GPIO_TypeDef *_receivePinPort;
+    uint32_t _receivePinNumber;
+    GPIO_TypeDef *_transmitPinPort;
+    uint32_t _transmitPinNumber;
+    uint32_t _speed;
+
+    uint16_t _buffer_overflow: 1;
+    uint16_t _inverse_logic: 1;
+    uint16_t _half_duplex: 1;
+    uint16_t _output_pending: 1;
+
+    unsigned char _receive_buffer[_SS_MAX_RX_BUFF];
+    volatile uint8_t _receive_buffer_tail;
+    volatile uint8_t _receive_buffer_head;
+
+    uint32_t delta_start = 0;
+
+    // static data
+    static bool initialised;
+    static HardwareTimer timer;
+    static SoftwareSerial *active_listener;
+    static SoftwareSerial *volatile active_out;
+    static SoftwareSerial *volatile active_in;
+    static int32_t tx_tick_cnt;
+    static volatile int32_t rx_tick_cnt;
+    static uint32_t tx_buffer;
+    static int32_t tx_bit_cnt;
+    static uint32_t rx_buffer;
+    static int32_t rx_bit_cnt;
+    static uint32_t cur_speed;
+
+    // private methods
+    void send();
+    void recv();
+    void setTX();
+    void setRX();
+    void setSpeed(uint32_t speed);
+    void setRXTX(bool input);
+    static void handleInterrupt(HardwareTimer *timer);
+
+  public:
+    // public methods
+
+    SoftwareSerial(uint16_t receivePin, uint16_t transmitPin, bool inverse_logic = false);
+    virtual ~SoftwareSerial();
+    void begin(long speed);
+    bool listen();
+    void end();
+    bool isListening()
+    {
+      return active_listener == this;
+    }
+    bool stopListening();
+    bool overflow()
+    {
+      bool ret = _buffer_overflow;
+      if (ret) {
+        _buffer_overflow = false;
+      }
+      return ret;
+    }
+    int peek();
+
+    virtual size_t write(uint8_t byte);
+    virtual int read();
+    virtual int available();
+    virtual void flush();
+    operator bool()
+    {
+      return true;
+    }
+
+    using Print::write;
+};
+
+// Arduino 0012 workaround
+#undef int
+#undef char
+#undef long
+#undef byte
+#undef float
+#undef abs
+#undef round
+
+#endif // SOFTWARESERIAL_H


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->
This Pull Request is based on PR: Add SoftwareSerial #627 from @armint:
Add SoftwareSerial for STM32 boards.

This PR adds SoftwareSerial support for STM32 boards. The code was based on the SoftwareSerial implementation from the lpc176x arduino port and adapted for STM32. It uses the recently added HardwareTimer code for timing. The timer to be used can be defined in variant.h by defining TIMER_SERIAL. When no TIMER_SERIAL is defined it will use the simplest timer available.
Tested and working on STM32F446ZE and STM32F401RE. Works with existing SoftwareSerial example code. Tested at 9600 and 115200 baud by communicating with hardware serial interfaces and by logic analyser.


Besides PR #627, I also
* remove the actual oversampling because I already have issue with baudrate 115200 (on NUCLEO_STM32L476RG @ 80MHz) because I spend 100% CPU load in intterrup, waiting for some RX. And thus unable to handle TX even when nothing is received. And actual oversampling would increase Interrupt overhead.
* keep original (lpc176x) OVERSAMPLING management to sample in RX in the middle of the bit.
* add some comment to explain the management of bits/tick

Tested on NUCLEO_STM32L476RG: up to Baudrate 57600 test passed. Failed at 115200(too much time spend in IT).
Both examples working:
* SoftwareSerialExample
* TwoPortReceive 

Fixes #267  
