### PR TITLE
Allow not to have analog pin

### DIFF
--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -51,6 +51,13 @@ enum {
 };
 
 // Arduino analog pins
+#ifndef NUM_ANALOG_INPUTS
+#define NUM_ANALOG_INPUTS 0
+#endif
+#ifndef NUM_ANALOG_FIRST
+#define NUM_ANALOG_FIRST NUM_DIGITAL_PINS
+#endif
+
 // Analog pins must be contiguous to be able to loop on each value
 #define MAX_ANALOG_INPUTS 24
 _Static_assert(NUM_ANALOG_INPUTS <= MAX_ANALOG_INPUTS,
@@ -230,8 +237,12 @@ extern const PinName digitalPin[];
 uint32_t pinNametoDigitalPin(PinName p);
 
 // Convert an analog pin number to a digital pin number
+#if defined(NUM_ANALOG_INPUTS) && (NUM_ANALOG_INPUTS>0)
 // Used by analogRead api to have A0 == 0
 #define analogInputToDigitalPin(p)  (((uint32_t)p < NUM_ANALOG_INPUTS) ? (p+A0) : p)
+#else
+#define analogInputToDigitalPin(p)  (NUM_DIGITAL_PINS)
+#endif
 // Convert an analog pin number Axx to a PinName PX_n
 PinName analogInputToPinName(uint32_t pin);
 

--- a/cores/arduino/stm32/analog.cpp
+++ b/cores/arduino/stm32/analog.cpp
@@ -47,8 +47,7 @@ extern "C" {
 
 
 /* Private_Variables */
-#if defined(HAL_ADC_MODULE_ENABLED) || defined(HAL_DAC_MODULE_ENABLED) ||\
-  defined(HAL_TIM_MODULE_ENABLED)
+#if defined(HAL_ADC_MODULE_ENABLED) || defined(HAL_DAC_MODULE_ENABLED)
 static PinName g_current_pin = NC;
 #endif
 

--- a/variants/board_template/variant.h
+++ b/variants/board_template/variant.h
@@ -51,6 +51,8 @@ extern "C" {
 #define NUM_DIGITAL_PINS        0
 
 // Allow to define Arduino style alias for analog input pin number --> Ax
+// If no analog pin required then NUM_ANALOG_INPUTS and NUM_ANALOG_FIRST
+// could not be defined or set to respectively `0` and `NUM_DIGITAL_PINS`
 // All pins are digital, analog inputs are a subset of digital pins
 // and must be contiguous to be able to loop on each value
 // This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS


### PR DESCRIPTION
If no analog pin required then `NUM_ANALOG_INPUTS` and `NUM_ANALOG_FIRST` could be not defined or set to respectively `0` and `NUM_DIGITAL_PINS`.
    
Nevertheless, this kept ADC internal channels functional if  `HAL_ADC_MODULE_ENABLED` still defined.
