### PR TITLE
Add -fno-use-cxa-atexit compiler option to reduce unused code

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -33,7 +33,7 @@ compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.stm.e
 
 compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -MMD {compiler.stm.extra_include}
 
-compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std={compiler.cpp.std} -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD {compiler.stm.extra_include}
+compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std={compiler.cpp.std} -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -fno-use-cxa-atexit -MMD {compiler.stm.extra_include}
 
 compiler.ar.flags=rcs
 


### PR DESCRIPTION
C++ requires that static object destructors are called when the
program terminates. Recent versions of GCC use `__cxa_atexit` to
register exit handlers which call these object destructors.

With the `-fno-use-cxa-atexit` command line option, GCC uses `atexit`
instead (same functionality, but only up to 32 exit handlers can
be registered).

Since the Arduino main process can not return, and calls to exit()
simply call an infinite loop - so all of this is completely
irrelevant. No exit handlers are ever called.

By removing the unused `__cxa_atexit` functionality we save a bit of
space.

See https://github.com/rogerclarkmelbourne/Arduino_STM32/pull/556/

Thanks @justinschoeman