### PR TITLE
[USB] Fix endpoints configurations

### DIFF
--- a/cores/arduino/stm32/usb/cdc/usbd_cdc.h
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc.h
@@ -26,7 +26,8 @@ extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-#include  "usbd_ioreq.h"
+#include "usbd_ioreq.h"
+#include "usbd_ep_conf.h"
 
 /** @addtogroup STM32_USB_DEVICE_LIBRARY
   * @{
@@ -37,26 +38,18 @@ extern "C" {
   * @{
   */
 
-
 /** @defgroup usbd_cdc_Exported_Defines
   * @{
   */
-#define CDC_IN_EP                                   0x82U  /* EP1 for data IN */
-#define CDC_OUT_EP                                  0x01U  /* EP1 for data OUT */
-#define CDC_CMD_EP                                  0x83U  /* EP2 for CDC commands */
-
 #ifndef CDC_HS_BINTERVAL
-#define CDC_HS_BINTERVAL                          0x10U
+#define CDC_HS_BINTERVAL                            0x10U
 #endif /* CDC_HS_BINTERVAL */
 
 #ifndef CDC_FS_BINTERVAL
-#define CDC_FS_BINTERVAL                          0x10U
+#define CDC_FS_BINTERVAL                            0x10U
 #endif /* CDC_FS_BINTERVAL */
 
-/* CDC Endpoints parameters: you can fine tune these values depending on the needed baudrates and performance. */
-#define CDC_DATA_HS_MAX_PACKET_SIZE                 512U  /* Endpoint IN & OUT Packet size */
-#define CDC_DATA_FS_MAX_PACKET_SIZE                 64U  /* Endpoint IN & OUT Packet size */
-#define CDC_CMD_PACKET_SIZE                         8U  /* Control Endpoint Packet size */
+/* CDC Endpoints parameters */
 
 #define USB_CDC_CONFIG_DESC_SIZ                     67U
 #define CDC_DATA_HS_IN_PACKET_SIZE                  CDC_DATA_HS_MAX_PACKET_SIZE

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.h
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.h
@@ -50,7 +50,7 @@ void CDC_continue_transmit(void);
 bool CDC_resume_receive(void);
 void CDC_init(void);
 void CDC_deInit(void);
-bool CDC_connected();
+bool CDC_connected(void);
 
 #ifdef __cplusplus
 }

--- a/cores/arduino/stm32/usb/hid/usbd_hid_composite.h
+++ b/cores/arduino/stm32/usb/hid/usbd_hid_composite.h
@@ -29,7 +29,8 @@ extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-#include  "usbd_ioreq.h"
+#include "usbd_ioreq.h"
+#include "usbd_ep_conf.h"
 
 /** @addtogroup STM32_USB_DEVICE_LIBRARY
   * @{
@@ -45,12 +46,6 @@ extern "C" {
   */
 #define HID_MOUSE_INTERFACE           0x00U
 #define HID_KEYBOARD_INTERFACE        0x01U
-
-#define HID_MOUSE_EPIN_ADDR           0x81U
-#define HID_MOUSE_EPIN_SIZE           0x04U
-
-#define HID_KEYBOARD_EPIN_ADDR        0x82U
-#define HID_KEYBOARD_EPIN_SIZE        0x08U
 
 #define USB_COMPOSITE_HID_CONFIG_DESC_SIZ       59U
 #define USB_HID_DESC_SIZ              9U

--- a/cores/arduino/stm32/usb/usbd_conf.c
+++ b/cores/arduino/stm32/usb/usbd_conf.c
@@ -20,6 +20,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "usbd_core.h"
 #include "usbd_if.h"
+#include "usbd_ep_conf.h"
 #include "stm32yyxx_ll_pwr.h"
 
 #ifndef HAL_PCD_MODULE_ENABLED
@@ -27,14 +28,7 @@
 #else
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-/* Size in words, byte size divided by 2 */
-#define PMA_EP0_OUT_ADDR (8 * 4)
-#define PMA_EP0_IN_ADDR (PMA_EP0_OUT_ADDR + USB_MAX_EP0_SIZE)
-#define PMA_CDC_OUT_BASE (PMA_EP0_IN_ADDR + USB_MAX_EP0_SIZE)
-#define PMA_CDC_OUT_ADDR ((PMA_CDC_OUT_BASE + USB_FS_MAX_PACKET_SIZE) | \
-                         (PMA_CDC_OUT_BASE << 16U))
-#define PMA_CDC_IN_ADDR (PMA_CDC_OUT_BASE + USB_FS_MAX_PACKET_SIZE * 2)
-#define PMA_CDC_CMD_ADDR (PMA_CDC_IN_ADDR + USB_FS_MAX_PACKET_SIZE)
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 PCD_HandleTypeDef g_hpcd;
@@ -465,7 +459,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
 {
   USBD_reenumerate();
   /* Set common LL Driver parameters */
-  g_hpcd.Init.dev_endpoints = 4;
+  g_hpcd.Init.dev_endpoints = DEV_NUM_EP;
   g_hpcd.Init.ep0_mps = DEP0CTL_MPS_64;
 #if !defined(STM32F1xx) && !defined(STM32F2xx) || defined(USB)
   g_hpcd.Init.lpm_enable = DISABLE;
@@ -510,26 +504,17 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
     Error_Handler();
   }
 
-#ifdef USE_USB_HS
+
+#if !defined (USB)
   /* configure EPs FIFOs */
-  HAL_PCDEx_SetRxFiFo(&g_hpcd, 0x200);
-  HAL_PCDEx_SetTxFiFo(&g_hpcd, 0, 0x80);
-  HAL_PCDEx_SetTxFiFo(&g_hpcd, 1, 0x40);
-  HAL_PCDEx_SetTxFiFo(&g_hpcd, 2, 0x160);
-#else /* USE_USB_FS */
-#ifdef USB_OTG_FS
-  /* configure EPs FIFOs */
-  HAL_PCDEx_SetRxFiFo(&g_hpcd, 0x80);
-  HAL_PCDEx_SetTxFiFo(&g_hpcd, 0, 0x40);
-  HAL_PCDEx_SetTxFiFo(&g_hpcd, 1, 0x40);
-  HAL_PCDEx_SetTxFiFo(&g_hpcd, 2, 0x40);
+  HAL_PCDEx_SetRxFiFo(&g_hpcd, ep_def[0].ep_size);
+  for (uint32_t i = 1; i < (DEV_NUM_EP + 1); i++) {
+    HAL_PCDEx_SetTxFiFo(&g_hpcd, ep_def[i].ep_adress & 0xF, ep_def[i].ep_size);
+  }
 #else
-  HAL_PCDEx_PMAConfig(&g_hpcd, 0x00, PCD_SNG_BUF, PMA_EP0_OUT_ADDR);
-  HAL_PCDEx_PMAConfig(&g_hpcd, 0x80, PCD_SNG_BUF, PMA_EP0_IN_ADDR);
-  HAL_PCDEx_PMAConfig(&g_hpcd, 0x01, PCD_DBL_BUF, PMA_CDC_OUT_ADDR);
-  HAL_PCDEx_PMAConfig(&g_hpcd, 0x82, PCD_SNG_BUF, PMA_CDC_IN_ADDR);
-  HAL_PCDEx_PMAConfig(&g_hpcd, 0x83, PCD_SNG_BUF, PMA_CDC_CMD_ADDR);
-#endif
+  for (uint32_t i = 0; i < (DEV_NUM_EP + 1); i++) {
+    HAL_PCDEx_PMAConfig(&g_hpcd, ep_def[i].ep_adress, ep_def[i].ep_kind, ep_def[i].ep_size);
+  }
 #endif /* USE_USB_HS */
   return USBD_OK;
 }

--- a/cores/arduino/stm32/usb/usbd_ep_conf.c
+++ b/cores/arduino/stm32/usb/usbd_ep_conf.c
@@ -1,0 +1,71 @@
+/**
+  ******************************************************************************
+  * @file    usbd_ep_conf.c
+  * @brief   USB Device endpoints configuration
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under Ultimate Liberty license
+  * SLA0044, the "License"; You may not use this file except in compliance with
+  * the License. You may obtain a copy of the License at:
+  *                      www.st.com/SLA0044
+  *
+  ******************************************************************************
+  */
+#if defined(HAL_PCD_MODULE_ENABLED) && defined(USBCON)
+/* Includes ------------------------------------------------------------------*/
+#include "usbd_ep_conf.h"
+
+#ifdef USBD_USE_CDC
+const ep_desc_t ep_def[] = {
+#ifdef USE_USB_HS
+  {0x00,       CDC_DATA_HS_MAX_PACKET_SIZE},
+  {0x80,       CDC_DATA_HS_MAX_PACKET_SIZE},
+  {CDC_OUT_EP, CDC_DATA_HS_MAX_PACKET_SIZE},
+  {CDC_IN_EP,  CDC_DATA_HS_MAX_PACKET_SIZE},
+  {CDC_CMD_EP, CDC_CMD_PACKET_SIZE}
+#else /* USE_USB_FS */
+#ifdef USB_OTG_FS
+  {0x00,       CDC_DATA_FS_MAX_PACKET_SIZE},
+  {0x80,       CDC_DATA_FS_MAX_PACKET_SIZE},
+  {CDC_OUT_EP, CDC_DATA_FS_MAX_PACKET_SIZE},
+  {CDC_IN_EP,  CDC_DATA_FS_MAX_PACKET_SIZE},
+  {CDC_CMD_EP, CDC_CMD_PACKET_SIZE}
+#else
+  {0x00,       PMA_EP0_OUT_ADDR, PCD_SNG_BUF},
+  {0x80,       PMA_EP0_IN_ADDR,  PCD_SNG_BUF},
+  {CDC_OUT_EP, PMA_CDC_OUT_ADDR, PCD_DBL_BUF},
+  {CDC_IN_EP,  PMA_CDC_IN_ADDR,  PCD_SNG_BUF},
+  {CDC_CMD_EP, PMA_CDC_CMD_ADDR, PCD_SNG_BUF}
+#endif
+#endif
+};
+#endif /* USBD_USE_CDC */
+
+#ifdef USBD_USE_HID_COMPOSITE
+const ep_desc_t ep_def[] = {
+#if !defined (USB)
+#ifdef USE_USB_HS
+  {0x00,                   USB_HS_MAX_PACKET_SIZE},
+  {0x80,                   USB_HS_MAX_PACKET_SIZE},
+#else
+  {0x00,                   USB_FS_MAX_PACKET_SIZE},
+  {0x80,                   USB_FS_MAX_PACKET_SIZE},
+#endif
+  {HID_MOUSE_EPIN_ADDR,    HID_MOUSE_EPIN_SIZE},
+  {HID_KEYBOARD_EPIN_ADDR, HID_KEYBOARD_EPIN_SIZE},
+#else
+  {0x00,                   PMA_EP0_OUT_ADDR,     PCD_SNG_BUF},
+  {0x80,                   PMA_EP0_IN_ADDR,      PCD_SNG_BUF},
+  {HID_MOUSE_EPIN_ADDR,    PMA_MOUSE_IN_ADDR,    PCD_SNG_BUF},
+  {HID_KEYBOARD_EPIN_ADDR, PMA_KEYBOARD_IN_ADDR, PCD_SNG_BUF},
+#endif
+};
+#endif /* USBD_USE_HID_COMPOSITE */
+
+#endif /* HAL_PCD_MODULE_ENABLED && USBCON */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/cores/arduino/stm32/usb/usbd_ep_conf.h
+++ b/cores/arduino/stm32/usb/usbd_ep_conf.h
@@ -1,0 +1,89 @@
+/**
+  ******************************************************************************
+  * @file    usbd_ep_conf.h
+  * @brief   USB Device endpoints configuration
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under Ultimate Liberty license
+  * SLA0044, the "License"; You may not use this file except in compliance with
+  * the License. You may obtain a copy of the License at:
+  *                      www.st.com/SLA0044
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USBD_EP_CONF_H
+#define __USBD_EP_CONF_H
+
+#ifdef USBCON
+
+#include <stdint.h>
+#include "usbd_def.h"
+
+typedef struct {
+  uint32_t ep_adress; /* Endpoint address */
+  uint32_t ep_size;   /* Endpoint size */
+#if defined (USB)
+  uint32_t ep_kind;   /* PCD Endpoint Kind: PCD_SNG_BUF or PCD_DBL_BUF */
+#endif
+} ep_desc_t;
+
+
+/* CDC Endpoints Configurations */
+#ifdef USBD_USE_CDC
+
+#define CDC_OUT_EP                    0x01U  /* EP1 for data OUT */
+#define CDC_IN_EP                     0x82U  /* EP1 for data IN */
+#define CDC_CMD_EP                    0x83U  /* EP2 for CDC commands */
+
+#define DEV_NUM_EP                    0x04U   /* Device Endpoints number including EP0 */
+
+/* CDC Endpoints parameters*/
+#define CDC_DATA_HS_MAX_PACKET_SIZE   USB_HS_MAX_PACKET_SIZE  /* Endpoint IN & OUT Packet size */
+#define CDC_DATA_FS_MAX_PACKET_SIZE   USB_FS_MAX_PACKET_SIZE  /* Endpoint IN & OUT Packet size */
+#define CDC_CMD_PACKET_SIZE                               8U  /* Control Endpoint Packet size */
+#endif /* USBD_USE_CDC */
+
+
+/* HID composite (Mouse + Keyboard) Endpoints Configurations */
+#ifdef USBD_USE_HID_COMPOSITE
+#define HID_MOUSE_EPIN_ADDR           0x81U
+#define HID_KEYBOARD_EPIN_ADDR        0x82U
+
+#define HID_MOUSE_EPIN_SIZE           0x04U
+#define HID_KEYBOARD_EPIN_SIZE        0x08U
+
+#define DEV_NUM_EP                    0x03U   /* Device Endpoints number including EP0 */
+#endif /* USBD_USE_HID_COMPOSITE */
+
+/* Require DEV_NUM_EP to be defined */
+#if defined (USB)
+/* Size in words, byte size divided by 2 */
+#define PMA_EP0_OUT_ADDR    (8 * DEV_NUM_EP)
+#define PMA_EP0_IN_ADDR     (PMA_EP0_OUT_ADDR + USB_MAX_EP0_SIZE)
+
+#ifdef USBD_USE_CDC
+#define PMA_CDC_OUT_BASE    (PMA_EP0_IN_ADDR + USB_MAX_EP0_SIZE)
+#define PMA_CDC_OUT_ADDR    ((PMA_CDC_OUT_BASE + USB_FS_MAX_PACKET_SIZE) | \
+                            (PMA_CDC_OUT_BASE << 16U))
+#define PMA_CDC_IN_ADDR     (PMA_CDC_OUT_BASE + USB_FS_MAX_PACKET_SIZE * 2)
+#define PMA_CDC_CMD_ADDR    (PMA_CDC_IN_ADDR + CDC_CMD_PACKET_SIZE)
+#endif /* USBD_USE_CDC */
+#ifdef USBD_USE_HID_COMPOSITE
+#define PMA_MOUSE_IN_ADDR   (PMA_EP0_IN_ADDR + HID_MOUSE_EPIN_SIZE)
+#define PMA_KEYBOARD_IN_ADDR    (PMA_MOUSE_IN_ADDR + HID_KEYBOARD_EPIN_SIZE)
+#endif /* USBD_USE_HID_COMPOSITE */
+#endif /* USB */
+
+extern const ep_desc_t ep_def[DEV_NUM_EP + 1];
+
+
+#endif /* USBCON */
+#endif /* __USBD_EP_CONF_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
Endpoints (EP) configuration was not properly set
depending of USB class used and USB type (HS/FS/LS).