### PR TITLE
[CI] Specify core version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,10 @@ matrix:
       - ./arduino --save-prefs --pref "boardsmanager.additional.urls=https://github.com/stm32duino/BoardManagerFiles/raw/dev/STM32/package_stm_index.json"
         # Install the latest core version
       - ./arduino --install-boards STM32:stm32
-      - rm -fr $HOME/.arduino15/packages/STM32/hardware/stm32/*
-        # Replace default core with the one being built
-      - sudo ln -s $TRAVIS_BUILD_DIR $HOME/.arduino15/packages/STM32/hardware/stm32/*
+    # Replace default core with the one being built
+      - export CORE_VERSION=`ls $HOME/.arduino15/packages/STM32/hardware/stm32`;
+        rm -fr $HOME/.arduino15/packages/STM32/hardware/stm32/*;
+        sudo ln -s $TRAVIS_BUILD_DIR $HOME/.arduino15/packages/STM32/hardware/stm32/$CORE_VERSION
     before_script:
       - cd $TRAVIS_BUILD_DIR/CI/build/
       - cp ./conf/path_config_travis.json ./path_config.json


### PR DESCRIPTION
Arduino 1.8.10 required a core version to be able to build.