### PR TITLE
Revert "Added the repeated-start feature in I2C driver"

### DIFF
--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -740,16 +740,8 @@ i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address,
     return i2c_IsDeviceReady(obj, dev_address, 1);
   }
 
-#if defined(I2C_OTHER_FRAME)
-  uint32_t XferOptions = obj->handle.XferOptions; // save XferOptions value, because handle can be modified by HAL, which cause issue in case of NACK from slave
-#endif
-
   do {
-#if defined(I2C_OTHER_FRAME)
-    if (HAL_I2C_Master_Seq_Transmit_IT(&(obj->handle), dev_address, data, size, XferOptions) == HAL_OK) {
-#else
     if (HAL_I2C_Master_Transmit_IT(&(obj->handle), dev_address, data, size) == HAL_OK) {
-#endif
       ret = I2C_OK;
       // wait for transfer completion
       while ((HAL_I2C_GetState(&(obj->handle)) != HAL_I2C_STATE_READY)
@@ -811,16 +803,8 @@ i2c_status_e i2c_master_read(i2c_t *obj, uint8_t dev_address, uint8_t *data, uin
   uint32_t tickstart = HAL_GetTick();
   uint32_t delta = 0;
 
-#if defined(I2C_OTHER_FRAME)
-  uint32_t XferOptions = obj->handle.XferOptions; // save XferOptions value, because handle can be modified by HAL, which cause issue in case of NACK from slave
-#endif
-
   do {
-#if defined(I2C_OTHER_FRAME)
-    if (HAL_I2C_Master_Seq_Receive_IT(&(obj->handle), dev_address, data, size, XferOptions) == HAL_OK) {
-#else
     if (HAL_I2C_Master_Receive_IT(&(obj->handle), dev_address, data, size) == HAL_OK) {
-#endif
       ret = I2C_OK;
       // wait for transfer completion
       while ((HAL_I2C_GetState(&(obj->handle)) != HAL_I2C_STATE_READY)

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -116,10 +116,7 @@ void TwoWire::setClock(uint32_t frequency)
 
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddress, uint8_t isize, uint8_t sendStop)
 {
-#if !defined(I2C_OTHER_FRAME)
   UNUSED(sendStop);
-#endif
-
   if (_i2c.isMaster == 1) {
     allocateRxBuffer(quantity);
     // error if no memory block available to allocate the buffer
@@ -149,15 +146,6 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 
     // perform blocking read into buffer
     uint8_t read = 0;
-
-#if defined(I2C_OTHER_FRAME)
-    if (sendStop == 0) {
-      _i2c.handle.XferOptions = I2C_OTHER_FRAME ;
-    } else {
-      _i2c.handle.XferOptions = I2C_OTHER_AND_LAST_FRAME;
-    }
-#endif
-
     if (I2C_OK == i2c_master_read(&_i2c, address << 1, rxBuffer, quantity)) {
       read = quantity;
     }
@@ -223,18 +211,8 @@ void TwoWire::beginTransmission(int address)
 //
 uint8_t TwoWire::endTransmission(uint8_t sendStop)
 {
-#if !defined(I2C_OTHER_FRAME)
   UNUSED(sendStop);
-#endif
   int8_t ret = 4;
-  // check transfer options and store it in the I2C handle
-#if defined(I2C_OTHER_FRAME)
-  if (sendStop == 0) {
-    _i2c.handle.XferOptions = I2C_OTHER_FRAME ;
-  } else {
-    _i2c.handle.XferOptions = I2C_OTHER_AND_LAST_FRAME;
-  }
-#endif
 
   if (_i2c.isMaster == 1) {
     // transmit buffer (blocking)


### PR DESCRIPTION
During Non regression tests for 1.7.0 found an issue on STM32 F2 and F4 series due to #590 introduction. Using I2C EEPROM failed.
So, reverts stm32duino/Arduino_Core_STM32#590