### PR TITLE
Fix stm32yyxx_ll_fmc.c build issue

### DIFF
--- a/libraries/SrcWrapper/src/LL/stm32yyxx_ll_fmc.c
+++ b/libraries/SrcWrapper/src/LL/stm32yyxx_ll_fmc.c
@@ -8,18 +8,10 @@
 #include "stm32f7xx_ll_fmc.c"
 #endif
 #ifdef STM32G4xx
-/*
- * Build issue as not properly guard in current
- * version if stm32g4xx_ll_fmc.h is not include
- */
-/*#include "stm32g4xx_ll_fmc.c"*/
+#include "stm32g4xx_ll_fmc.c"
 #endif
 #ifdef STM32H7xx
-/*
- * Build issue as not properly guard in current
- * version if stm32h7xx_ll_fmc.h is not include
- */
-/*#include "stm32h7xx_ll_fmc.c"*/
+#include "stm32h7xx_ll_fmc.c"
 #endif
 #ifdef STM32L4xx
 #include "stm32l4xx_ll_fmc.c"

--- a/system/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_ll_fmc.c
+++ b/system/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_ll_fmc.c
@@ -63,6 +63,7 @@
   * @brief FMC driver modules
   * @{
   */
+#if defined (HAL_SRAM_MODULE_ENABLED) || defined(HAL_NOR_MODULE_ENABLED) || defined(HAL_NAND_MODULE_ENABLED)
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
@@ -766,6 +767,7 @@ HAL_StatusTypeDef FMC_NAND_GetECC(FMC_NAND_TypeDef *Device, uint32_t *ECCval, ui
 /**
   * @}
   */
+#endif /* HAL_SRAM_MODULE_ENABLED || HAL_NOR_MODULE_ENABLED || HAL_NAND_MODULE_ENABLED */
 
 /**
   * @}

--- a/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_sdram.h
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_sdram.h
@@ -24,6 +24,7 @@
 extern "C" {
 #endif
 
+#if defined(HAL_MDMA_MODULE_ENABLED)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32h7xx_ll_fmc.h"
@@ -216,7 +217,7 @@ HAL_SDRAM_StateTypeDef  HAL_SDRAM_GetState(SDRAM_HandleTypeDef *hsdram);
 /**
   * @}
   */
-
+#endif /* HAL_MDMA_MODULE_ENABLED */
 
 #ifdef __cplusplus
 }

--- a/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_sram.h
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_sram.h
@@ -24,6 +24,7 @@
 extern "C" {
 #endif
 
+#if defined(HAL_MDMA_MODULE_ENABLED)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32h7xx_ll_fmc.h"
@@ -210,7 +211,7 @@ HAL_SRAM_StateTypeDef HAL_SRAM_GetState(SRAM_HandleTypeDef *hsram);
 /**
   * @}
   */
-
+#endif /* HAL_MDMA_MODULE_ENABLED */
 
 #ifdef __cplusplus
 }

--- a/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sdram.c
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sdram.c
@@ -118,7 +118,7 @@
   * @{
   */
 
-#ifdef HAL_SDRAM_MODULE_ENABLED
+#if defined (HAL_SDRAM_MODULE_ENABLED) && defined (HAL_MDMA_MODULE_ENABLED)
 
 /** @defgroup SDRAM SDRAM
   * @brief SDRAM driver modules
@@ -1301,7 +1301,7 @@ static void SDRAM_DMAError(MDMA_HandleTypeDef *hmdma)
   * @}
   */
 
-#endif /* HAL_SDRAM_MODULE_ENABLED */
+#endif /* HAL_SDRAM_MODULE_ENABLED && HAL_MDMA_MODULE_ENABLED */
 
 /**
   * @}

--- a/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sram.c
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sram.c
@@ -119,7 +119,7 @@
   * @{
   */
 
-#ifdef HAL_SRAM_MODULE_ENABLED
+#if defined (HAL_SRAM_MODULE_ENABLED) && defined (HAL_MDMA_MODULE_ENABLED)
 
 /** @defgroup SRAM SRAM
   * @brief SRAM driver modules

--- a/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_fmc.c
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_fmc.c
@@ -64,6 +64,9 @@
   * @brief FMC driver modules
   * @{
   */
+#if (defined (HAL_SRAM_MODULE_ENABLED) || defined(HAL_SDRAM_MODULE_ENABLED)) && defined(HAL_MDMA_MODULE_ENABLED) || \
+  defined(HAL_NOR_MODULE_ENABLED) || defined(HAL_NAND_MODULE_ENABLED)
+
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
@@ -1042,6 +1045,8 @@ uint32_t FMC_SDRAM_GetModeStatus(FMC_SDRAM_TypeDef *Device, uint32_t Bank)
 /**
   * @}
   */
+
+#endif /* (HAL_SRAM_MODULE_ENABLED || HAL_NOR_MODULE_ENABLED) && HAL_MDMA_MODULE_ENABLED || HAL_NAND_MODULE_ENABLED || HAL_SDRAM_MODULE_ENABLED */
 
 /**
   * @}


### PR DESCRIPTION
Some guards missing in the G4 and H7 HAL Cube firmware.
Instead of removing stm32yyxx_ll_fmc.c from the build add a
fix in the HAL Cube firmware.