### PR TITLE
Fix single-pin half-duplex in SoftwareSerial::send

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -227,15 +227,15 @@ inline void SoftwareSerial::send()
       tx_tick_cnt = OVERSAMPLE; // Wait OVERSAMPLE tick to send next bit
     } else { // Transmission finished
       tx_tick_cnt = 1;
-      if (_output_pending || !(_half_duplex && active_listener == this)) {
+      if (_output_pending) {
         active_out = nullptr;
-        rx_bit_cnt = -1; // rx_bit_cnt = -1 :  waiting for start bit
-        rx_tick_cnt = 2; // 2 : next interrupt will be discarded. 2 interrupts required to consider RX pin level
-        active_in = this;
-        // When in half-duplex mode, we wait for HALFDUPLEX_SWITCH_DELAY bit-periods after the byte has
+
+        // When in half-duplex mode, wait for HALFDUPLEX_SWITCH_DELAY bit-periods after the byte has
         // been transmitted before allowing the switch to RX mode
       } else if (tx_bit_cnt > 10 + OVERSAMPLE * HALFDUPLEX_SWITCH_DELAY) {
-        pinMode(_receivePin, _inverse_logic ? INPUT_PULLDOWN : INPUT_PULLUP); // pullup for normal logic!
+        if (_half_duplex && active_listener == this) {
+          setRXTX(true);
+        }
         active_out = nullptr;
       }
     }

--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -348,11 +348,10 @@ void SoftwareSerial::begin(long speed)
   if (!_half_duplex) {
     setTX();
     setRX();
+    listen();
   } else {
     setTX();
   }
-
-  listen();
 }
 
 void SoftwareSerial::end()


### PR DESCRIPTION
**Summary**

When SoftwareSerial was adapted from the LPC1768 version, SoftwareSerial::send was altered in a way that prevents single-pin half-duplex communication from working properly.

This change reverts to the behavior seen in other repositories using variations of this code.

<!-- Summary of the PR -->
This PR fixes/implements the following **bugs/features**

* [ ] Fixes one-wire half-duplex communication
* [ ] No intentional breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

This issue was discovered while testing a [Marlin pull request](https://github.com/MarlinFirmware/Marlin/pull/15655) which is adapting Marlin to work with STM32 5.7. During testing I found that one-pin communication with TMC stepper drivers did not work properly, although it did when using similar SoftwareSerial code from other sources.

The image below shows the same read command being sent to a TMC2208 stepper driver, both before and after the change in this PR. (Doesn't scale well, click to zoom)
![SWSerial_Send_Compare](https://user-images.githubusercontent.com/20053467/68066091-c55b7780-fcef-11e9-9060-900aaed07774.png)

**Validation**

I have validated that I can now communicate properly with TMC stepper drivers using one-wire connections inside Marlin.
