### PR TITLE
Add mechanism to set SoftwareSerial interrupt priority

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -66,6 +66,8 @@ class SoftwareSerial : public Stream {
     // static data
     static bool initialised;
     static HardwareTimer timer;
+    static const IRQn_Type timer_interrupt_number;
+    static uint32_t timer_interrupt_priority;
     static SoftwareSerial *active_listener;
     static SoftwareSerial *volatile active_out;
     static SoftwareSerial *volatile active_in;
@@ -117,6 +119,8 @@ class SoftwareSerial : public Stream {
     {
       return true;
     }
+
+    static void setInterruptPriority(uint32_t preemptPriority, uint32_t subPriority);
 
     using Print::write;
 };


### PR DESCRIPTION
**Summary**

Add a mechanism to set timer interrupt priority for the timer used By SoftwareSerial.

This PR fixes/implements the following **bugs/features**
* [ ] #751 Allow override for SoftwareSerial timer ISR priority


**Validation**

I have reworked an in-development version of Marlin to use this to configure the SoftwareSerial interrupt priority during HAL initialization. Using digital outputs added to the interrupt handlers, I was able to confirm the nesting of multiple preempted timer interrupts, as desired.

In the image below it can be seen that the serial interrupt is the highest of the three priorities, allowing it to preempt both of the other timer interrupts.

![Triple_Preemption](https://user-images.githubusercontent.com/20053467/68107574-24f58680-fe9a-11e9-874a-58c216b76e5c.PNG)


Fixes #751
