### PR TITLE
Add methods to check if there's an IRQ handler

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -715,8 +715,11 @@ bool HardwareTimer::hasInterrupt()
   * @param  channel: Arduino channel [1..4]
   * @retval returns true if a channel compare match interrupt has already been set
   */
-bool HardwareTimer::hasInterrupt(uint32_t channel);
+bool HardwareTimer::hasInterrupt(uint32_t channel)
 {
+  if ((channel == 0) || (channel > (TIMER_CHANNELS + 1))) {
+    Error_Handler();  // only channel 1..4 have an interrupt
+  }
   return callbacks[channel] != NULL;
 }
 

--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -702,6 +702,25 @@ void HardwareTimer::detachInterrupt(uint32_t channel)
 }
 
 /**
+  * @brief  Checks if there's an interrupt callback attached on Rollover event
+  * @retval returns true if a timer rollover interrupt has already been set
+  */
+bool HardwareTimer::hasInterrupt()
+{
+  return callbacks[0] != NULL;
+}
+
+/**
+  * @brief  Checks if there's an interrupt callback attached on Capture/Compare event
+  * @param  channel: Arduino channel [1..4]
+  * @retval returns true if a channel compare match interrupt has already been set
+  */
+bool HardwareTimer::hasInterrupt(uint32_t channel);
+{
+  return callbacks[channel] != NULL;
+}
+
+/**
   * @brief  Generate an update event to force all registers (Autoreload, prescaler, compare) to be taken into account
   * @note   Refresh() can only be called after a 1st call to resume() to be sure timer is initialised.
   *         It is usefull while timer is running after some registers update

--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -110,9 +110,11 @@ class HardwareTimer {
     //Add interrupt to period update
     void attachInterrupt(void (*handler)(HardwareTimer *)); // Attach interrupt callback which will be called upon update event (timer rollover)
     void detachInterrupt();  // remove interrupt callback which was attached to update event
+    bool hasInterrupt();  //returns true if a timer rollover interrupt has already been set
     //Add interrupt to capture/compare channel
     void attachInterrupt(uint32_t channel, void (*handler)(HardwareTimer *)); // Attach interrupt callback which will be called upon compare match event of specified channel
     void detachInterrupt(uint32_t channel);  // remove interrupt callback which was attached to compare match event of specified channel
+    bool hasInterrupt(uint32_t channel);  //returns true if an interrupt has already been set on the channel compare match
 
     void timerHandleDeinit();  // Timer deinitialization
 


### PR DESCRIPTION
**Summary**

Added methods to check if there's an user-IRQ-handler currently attached.

This PR implements the following **feature**

* [ ] It's easier to understand if you need to attach or detach an IRQ
* [ ] Lower memory usage in complex scenarios

**Why**
..well...first of all...why not?
The HardwareTimer, internally, knows **if** there's a callback. Exposing this to the user makes no harm.
It's a good C++ programming practice to give a way for an object to expose its status. 

Now let's talk about why should it be there.
Imagine a situation in which you want to disable the callback (for example on a channel) leaving the timer running and receiving other interrupts on other channels.

When you have multiple timers and each of them has multiple channels it's difficult to keep track of them all, moreover if they aren't enabled and disabled from the "main" schetch but by some other interrupt handler.

In a situation where you have "multiple sources" of detach/attach this can be cumbersome.
Providing a "zero-cost" (each HardwareTimer knows it already) property which will expose the status of the interrupt handler (present/absent) will make code easier to write and with less bugs.


**Validation**

Should be good.

**Code formatting**

Should be good.

**Closing issues**

Doesn't close any issue but helps programmers to **not** create new ones.