### PR TITLE
Flexible interrupts handling

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -632,7 +632,7 @@ void HardwareTimer::setInterruptPriority(uint32_t preemptPriority, uint32_t subP
   */
 void HardwareTimer::attachInterrupt(void (*callback)(HardwareTimer *))
 {
-  if (callbacks[0] == null) { //if there's no callback the ISR here is not enabled
+  if (callbacks[0] == NULL) { //if there's no callback the ISR here is not enabled
     __HAL_TIM_ENABLE_IT(&(_timerObj.handle), TIM_IT_UPDATE);
   }
 
@@ -665,7 +665,7 @@ void HardwareTimer::attachInterrupt(uint32_t channel, void (*callback)(HardwareT
     Error_Handler();  // only channel 1..4 have an interrupt
   }
 
-  bool mustActivateISR = callbacks[channel] == null; //no user callback means ISR is disabled
+  bool mustActivateISR = (callbacks[channel] == NULL); //no user callback means ISR is disabled
 
   callbacks[channel] = callback;
 

--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -672,25 +672,17 @@ void HardwareTimer::attachInterrupt(uint32_t channel, void (*callback)(HardwareT
   if (mustActivateISR) {
     switch (channel) {
       case 1:
-      {
         __HAL_TIM_ENABLE_IT(&(_timerObj.handle), TIM_IT_CC1); // Enable the TIM Capture/Compare 1 interrupt
         break;
-      }
       case 2:
-      {
         __HAL_TIM_ENABLE_IT(&(_timerObj.handle), TIM_IT_CC2); // Enable the TIM Capture/Compare 2 interrupt
         break;
-      }
       case 3:
-      {
         __HAL_TIM_ENABLE_IT(&(_timerObj.handle), TIM_IT_CC3); // Enable the TIM Capture/Compare 3 interrupt
         break;
-      }
       case 4:
-      {
         __HAL_TIM_ENABLE_IT(&(_timerObj.handle), TIM_IT_CC4); // Enable the TIM Capture/Compare 4 interrupt
         break;
-      }
     }
   }
 }
@@ -704,25 +696,17 @@ void HardwareTimer::detachInterrupt(uint32_t channel)
 {
   switch (channel) {
     case 1:
-    {
       __HAL_TIM_DISABLE_IT(&(_timerObj.handle), TIM_IT_CC1); // Disable the TIM Capture/Compare 1 interrupt
       break;
-    }
     case 2:
-    {
       __HAL_TIM_DISABLE_IT(&(_timerObj.handle), TIM_IT_CC2); // Disable the TIM Capture/Compare 2 interrupt
       break;
-    }
     case 3:
-    {
       __HAL_TIM_DISABLE_IT(&(_timerObj.handle), TIM_IT_CC3); // Disable the TIM Capture/Compare 3 interrupt
       break;
-    }
     case 4:
-    {
       __HAL_TIM_DISABLE_IT(&(_timerObj.handle), TIM_IT_CC4); // Disable the TIM Capture/Compare 4 interrupt
       break;
-    }
     default:
       Error_Handler();  // only channel 1..4 have an interrupt
   }

--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -635,7 +635,7 @@ void HardwareTimer::attachInterrupt(void (*callback)(HardwareTimer *))
   if (callbacks[0] == null) { //if there's no callback the ISR here is not enabled
     __HAL_TIM_ENABLE_IT(&(_timerObj.handle), TIM_IT_UPDATE);
   }
-  
+
   callbacks[0] = callback; //set or replace user callback
 }
 

--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -632,9 +632,10 @@ void HardwareTimer::setInterruptPriority(uint32_t preemptPriority, uint32_t subP
   */
 void HardwareTimer::attachInterrupt(void (*callback)(HardwareTimer *))
 {
-  if (callbacks[0] == null) //if there's no callback the ISR here is not enabled
+  if (callbacks[0] == null) { //if there's no callback the ISR here is not enabled
     __HAL_TIM_ENABLE_IT(&(_timerObj.handle), TIM_IT_UPDATE);
-
+  }
+  
   callbacks[0] = callback; //set or replace user callback
 }
 
@@ -660,7 +661,7 @@ void HardwareTimer::detachInterrupt()
   */
 void HardwareTimer::attachInterrupt(uint32_t channel, void (*callback)(HardwareTimer *))
 {
-    if ((channel == 0) || (channel > (TIMER_CHANNELS + 1))) {
+  if ((channel == 0) || (channel > (TIMER_CHANNELS + 1))) {
     Error_Handler();  // only channel 1..4 have an interrupt
   }
 
@@ -668,9 +669,8 @@ void HardwareTimer::attachInterrupt(uint32_t channel, void (*callback)(HardwareT
 
   callbacks[channel] = callback;
 
-  if (mustActivateISR)
-    switch (channel)
-    {
+  if (mustActivateISR) {
+    switch (channel) {
       case 1:
       {
         __HAL_TIM_ENABLE_IT(&(_timerObj.handle), TIM_IT_CC1); // Enable the TIM Capture/Compare 1 interrupt
@@ -692,6 +692,7 @@ void HardwareTimer::attachInterrupt(uint32_t channel, void (*callback)(HardwareT
         break;
       }
     }
+  }
 }
 
 /**
@@ -701,8 +702,7 @@ void HardwareTimer::attachInterrupt(uint32_t channel, void (*callback)(HardwareT
   */
 void HardwareTimer::detachInterrupt(uint32_t channel)
 {
-  switch (channel)
-  {
+  switch (channel) {
     case 1:
     {
       __HAL_TIM_DISABLE_IT(&(_timerObj.handle), TIM_IT_CC1); // Disable the TIM Capture/Compare 1 interrupt


### PR DESCRIPTION
**Summary**

This PR modifies (internally) how timers are started so that it will be possible to attach an interrupt to an already running timer.

This PR fixes/implements the following **bugs/features**

* [x] Bug: If the timer is initially started without a user-interrupt (it's rather a callback from an interrupt) it's impossible to assign one without stopping and restarting the timer. If the interrupt is assigned before starting the timer, instead the user can attach and detach them freely and have the callback still invoked. This was undocumented before today (I altered the wiki adding this warning but then I realized that a patch which handled it was better than a warning)
* [x] Bug: The user calls `detachInterrupt` and he expects to not have something besides systick that can interrupt his code. His code is still interrupted by HardwareTimer IRQ handler (and this is bad for time critical code, for example when the user, using the callback, wants to give a clock to something) 
* [x] Feature: you can now attachInterrupt and detachInterrupt anytime

**Motivation**
Improvement in usage and predictable behavior if the user didn't read the "warning" in the documentation.

**Validation**
Sorry it's untested at the moment. But, in theory, it should work fine.

**Code formatting**
I changed everything that travis complained about.

**Closing issues**
Closes the issues I mentioned in "bugs".
I didn't open them because I preferred to see if I could use the same time to find a solution instead of creating a problem :)