### PR TITLE
[Timer] Add getHandle function

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -713,6 +713,18 @@ void HardwareTimer::refresh()
 }
 
 /**
+  * @brief  Return the timer object handle object for more advanced setup
+  * @note   Using this function and editing the Timer handle is at own risk! No support will
+  *         be provided whatsoever if the HardwareTimer does not work as expected when editing
+  *         the handle using the HAL functionality or other custom coding.
+  * @retval TIM_HandleTypeDef address
+  */
+TIM_HandleTypeDef *HardwareTimer::getHandle()
+{
+  return &_timerObj.handle;
+}
+
+/**
   * @brief  Generic Update (rollover) callback which will call user callback
   * @param  htim: HAL timer handle
   * @retval None

--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -126,6 +126,8 @@ class HardwareTimer {
     static void captureCompareCallback(TIM_HandleTypeDef *htim); // Generic Caputre and Compare callback which will call user callback
     static void updateCallback(TIM_HandleTypeDef *htim);  // Generic Update (rollover) callback which will call user callback
 
+    // The following function(s) are available for more advanced timer options
+    TIM_HandleTypeDef *getHandle();  // return the handle address for HAL related configuration
   private:
     TIM_OC_InitTypeDef _channelOC[TIMER_CHANNELS];
     TIM_IC_InitTypeDef _channelIC[TIMER_CHANNELS];


### PR DESCRIPTION
This enables users to config timers using the HAL layers for more advanced timer
settings when needed. This is especially useful when multiple timer channels
require separate configurations under the same timer instance.

This feature is related to issue #763 