### PR TITLE
[NUCLEO_L073RZ] Enable USB clock

### DIFF
--- a/variants/NUCLEO_L073RZ/variant.cpp
+++ b/variants/NUCLEO_L073RZ/variant.cpp
@@ -122,14 +122,16 @@ WEAK void SystemClock_Config(void)
 
   RCC_OscInitTypeDef RCC_OscInitStruct;
   RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_PeriphCLKInitTypeDef PeriphClkInit;
 
   /* Configure the main internal regulator output voltage */
   __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
 
   /* Initializes the CPU, AHB and APB busses clocks */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSI48;
   RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-  RCC_OscInitStruct.HSICalibrationValue = 16;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
   RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
   RCC_OscInitStruct.PLL.PLLMUL = RCC_PLLMUL_4;
@@ -147,6 +149,12 @@ WEAK void SystemClock_Config(void)
   RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
 
   if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK) {
+    _Error_Handler(__FILE__, __LINE__);
+  }
+
+  PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USB;
+  PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
+  if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
     _Error_Handler(__FILE__, __LINE__);
   }
 }


### PR DESCRIPTION

**Summary**

This PR fixes/implements the following **bugs**

* [x] USB CDC Serial does not work on NUCLEO_L073RZ

**Describe the bug**
The bug is very similar to #479 for Discovery L072CZ
I've manually applied this patch https://github.com/stm32duino/Arduino_Core_STM32/commit/59673c97667d0eb7212c46b26e5d4089615f162c to NUCLEO_L073RZ and now it works nicely as well.

**To Reproduce**
Enable "USB CDC" in Arduino_STM32 menu settings.
Connect NUCLEO_L073RZ's PA11/PA12 to a USB host.
The host reports that:
_device not accepting address 61, error -32_

This PR is just intended to apply one known good L072CZ fix onto the L073RZ target.
 

