### PR TITLE
Add printf to print class

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -196,12 +196,22 @@ size_t Print::println(const Printable &x)
   return n;
 }
 
-void Print::printf(const char format[], ...)
+void Print::printf(const char *format, ...)
 {
-  char buf[PRINTF_BUF];
+  char buf[PRINTF_BUFFER];
   va_list ap;
   va_start(ap, format);
   vsnprintf(buf, sizeof(buf), format, ap);
+  write(buf);
+  va_end(ap);
+}
+
+void Print::printf(const __FlashStringHelper *format, ...)
+{
+  char buf[PRINTF_BUFFER];
+  va_list ap;
+  va_start(ap, format);
+  vsnprintf(buf, sizeof(buf), (const char *)format, ap);
   write(buf);
   va_end(ap);
 }

--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -196,6 +196,16 @@ size_t Print::println(const Printable &x)
   return n;
 }
 
+void Print::printf(const char format[], ...)
+{
+  char buf[PRINTF_BUF];
+  va_list ap;
+  va_start(ap, format);
+  vsnprintf(buf, sizeof(buf), format, ap);
+  write(buf);
+  va_end(ap);
+}
+
 // Private Methods /////////////////////////////////////////////////////////////
 
 size_t Print::printNumber(unsigned long n, uint8_t base)

--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -211,7 +211,7 @@ void Print::printf(const __FlashStringHelper *format, ...)
   char buf[PRINTF_BUFFER];
   va_list ap;
   va_start(ap, format);
-  vsnprintf(buf, sizeof(buf), (const char *)format, ap);
+  vsnprintf_P(buf, sizeof(buf), (const char *)format, ap);
   write(buf);
   va_end(ap);
 }

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -32,7 +32,6 @@
 #define OCT 8
 #define BIN 2
 
-class __FlashStringHelper;
 
 #ifndef PRINTF_BUFFER
 #define PRINTF_BUFFER 80

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -23,7 +23,6 @@
 #include <inttypes.h>
 #include <stdio.h> // for size_t
 #include <stdarg.h> // for printf
-#define PRINTF_BUF 80
 
 #include "WString.h"
 #include "Printable.h"
@@ -32,6 +31,12 @@
 #define HEX 16
 #define OCT 8
 #define BIN 2
+
+class __FlashStringHelper;
+
+#ifndef PRINTF_BUFFER
+#define PRINTF_BUFFER 80
+#endif
 
 // uncomment next line to support printing of 64 bit ints.
 #define SUPPORT_LONGLONG
@@ -106,7 +111,8 @@ class Print {
     void print(uint64_t, uint8_t = DEC);
 #endif
 
-    void printf(const char[], ...);
+    void printf(const char *format, ...);
+    void printf(const __FlashStringHelper *format, ...);
 };
 
 #endif

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -22,6 +22,8 @@
 
 #include <inttypes.h>
 #include <stdio.h> // for size_t
+#include <stdarg.h> // for printf
+#define PRINTF_BUF 80
 
 #include "WString.h"
 #include "Printable.h"
@@ -103,6 +105,8 @@ class Print {
     void println(uint64_t, uint8_t = DEC);
     void print(uint64_t, uint8_t = DEC);
 #endif
+
+    void printf(const char[], ...);
 };
 
 #endif

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -32,7 +32,6 @@
 #define OCT 8
 #define BIN 2
 
-
 #ifndef PRINTF_BUFFER
 #define PRINTF_BUFFER 80
 #endif


### PR DESCRIPTION
This PR uses [Adafruits printf implementation](https://github.com/adafruit/ArduinoCore-samd/blob/361481d34d0e6a9d5b2cd074ee0a990d78df3396/cores/arduino/Print.cpp#L189-L197). 
For those who didn't know, printf is super useful when you want to format your output. When printf is a part of the Print class, all libraries that inherits the print class (such as Serial, LiquidCrystal, SoftwareSerial + other LCD libraries).

This PR makes this possible:
```cpp
Serial.printf("Milliseconds since start: %d\n", millis());
```