### PR TITLE
Fix keyword literal for setRx and setTx

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -267,8 +267,8 @@ PIN_WIRE_SCL	LITERAL1
 
 # Serial
 HardwareSerial	KEYWORD2
-setRX	KEYWORD2
-setTX	KEYWORD2
+setRx	KEYWORD2
+setTx	KEYWORD2
 setHalfDuplex	KEYWORD2
 isHalfDuplex	KEYWORD2
 enableHalfDuplexRx	KEYWORD2


### PR DESCRIPTION
This PR fixes a typo where the setRx and setTx methods weren't color highlighted correctly.