### PR TITLE
SPI: Fix prescaler at low baudrates

### DIFF
--- a/cores/arduino/stm32/spi_com.c
+++ b/cores/arduino/stm32/spi_com.c
@@ -215,8 +215,8 @@ void spi_init(spi_t *obj, uint32_t speed, spi_mode_e mode, uint8_t msb)
     handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128;
   } else if (speed >= (spi_freq / SPI_SPEED_CLOCK_DIV256_MHZ)) {
     handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256;
-  } else {
-    handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;
+  } else { //speed is lower than (spi_freq / SPI_SPEED_CLOCK_DIV256_MHZ). we can't go below this.
+    handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256; // Set prescaler at max value so we have the lowest frequency possible
   }
 
   handle->Init.Direction         = SPI_DIRECTION_2LINES;

--- a/cores/arduino/stm32/spi_com.c
+++ b/cores/arduino/stm32/spi_com.c
@@ -213,10 +213,12 @@ void spi_init(spi_t *obj, uint32_t speed, spi_mode_e mode, uint8_t msb)
     handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64;
   } else if (speed >= (spi_freq / SPI_SPEED_CLOCK_DIV128_MHZ)) {
     handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128;
-  } else if (speed >= (spi_freq / SPI_SPEED_CLOCK_DIV256_MHZ)) {
+  } else {
+    /*
+     * As it is not possible to go below (spi_freq / SPI_SPEED_CLOCK_DIV256_MHZ).
+     * Set prescaler at max value so get the lowest frequency possible.
+     */
     handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256;
-  } else { //speed is lower than (spi_freq / SPI_SPEED_CLOCK_DIV256_MHZ). we can't go below this.
-    handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256; // Set prescaler at max value so we have the lowest frequency possible
   }
 
   handle->Init.Direction         = SPI_DIRECTION_2LINES;


### PR DESCRIPTION
**Summary**
The current prescaler, if the user requests a slow clock, is set to a value which makes no sense.
We should give a frequency closer to what the user asks.

This PR fixes/implements the following **bugs/features**

* [x] BUG: Clock is too high when the user requests a slow clock.

**motivation** for making this change:
If a SPI device can't handle high speed clock and the user requests a slow one we should give him the slowest clock we can. The code, before the PR, had unexpected behavior which makes difficult to track down where the problem is.

**Validation**
Should work.