### PR TITLE
Harden Print::printf() method

### DIFF
--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -32,10 +32,6 @@
 #define OCT 8
 #define BIN 2
 
-#ifndef PRINTF_BUFFER
-#define PRINTF_BUFFER 80
-#endif
-
 // uncomment next line to support printing of 64 bit ints.
 #define SUPPORT_LONGLONG
 
@@ -109,8 +105,8 @@ class Print {
     void print(uint64_t, uint8_t = DEC);
 #endif
 
-    void printf(const char *format, ...);
-    void printf(const __FlashStringHelper *format, ...);
+    int printf(const char *format, ...);
+    int printf(const __FlashStringHelper *format, ...);
 };
 
 #endif

--- a/libraries/SrcWrapper/src/syscalls.c
+++ b/libraries/SrcWrapper/src/syscalls.c
@@ -81,16 +81,12 @@ int _read(UNUSED(int file), UNUSED(char *ptr), UNUSED(int len))
   return 0;
 }
 
+/* Moved to Print.cpp to support Print::printf()
 __attribute__((weak))
 int _write(UNUSED(int file), char *ptr, int len)
 {
-#ifdef HAL_UART_MODULE_ENABLED
-  return uart_debug_write((uint8_t *)ptr, (uint32_t)len);
-#else
-  (void)ptr;
-  return len;
-#endif
 }
+*/
 
 __attribute__((weak))
 void _exit(UNUSED(int status))


### PR DESCRIPTION
Based on @PaulStoffregen works for Teensyduino:
https://github.com/PaulStoffregen/cores

* Remove `PRINTF_BUFFER` usage.
* Aligned declaration with `printf()` one by returning the number of characters printed (excluding the null byte used to end output to strings).

### Tested:
 * core debug
 * standard `printf` usage on the `DEBUG_UART`
 * Serial over USB

Harden #780 from @MCUdude.