### PR TITLE
Analog pins definition clean up

### DIFF
--- a/cores/arduino/pins_arduino.c
+++ b/cores/arduino/pins_arduino.c
@@ -67,6 +67,42 @@ PinName analogInputToPinName(uint32_t pin)
   return pn;
 }
 
+bool pinIsAnalogInput(uint32_t pin)
+{
+  bool ret = false;
+#if NUM_ANALOG_INPUTS > 0
+#ifndef NUM_ANALOG_LAST
+  ret = (pin >= A0) && (pin < (A0 + NUM_ANALOG_INPUTS));
+#else
+  for (uint32_t i = 0; i < NUM_ANALOG_INPUTS; i++) {
+    if (analogInPin[i] == pin) {
+      ret = true;
+      break;
+    }
+  }
+#endif /* NUM_ANALOG_LAST */
+#endif /* NUM_ANALOG_INPUTS > 0 */
+  return ret;
+}
+
+uint32_t digitalPinToAnalogInput(uint32_t pin)
+{
+  uint32_t ret = NUM_ANALOG_INPUTS;
+#if NUM_ANALOG_INPUTS > 0
+#ifndef NUM_ANALOG_LAST
+  ret = pin - A0;
+#else
+  for (uint32_t i = 0; i < NUM_ANALOG_INPUTS; i++) {
+    if (analogInPin[i] == pin) {
+      ret = i;
+      break;
+    }
+  }
+#endif /* NUM_ANALOG_LAST */
+#endif /* NUM_ANALOG_INPUTS > 0 */
+  return ret;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -51,17 +51,30 @@ enum {
 };
 
 // Arduino analog pins
+
 #ifndef NUM_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS 0
 #endif
+
+// If NUM_ANALOG_FIRST is not defined:
+// - Ax are not contiguous in the digitalPin array
+// - analogInPin array is available
 #ifndef NUM_ANALOG_FIRST
-#define NUM_ANALOG_FIRST NUM_DIGITAL_PINS
+#define NUM_ANALOG_FIRST          (NUM_DIGITAL_PINS + 1)
+#define NUM_ANALOG_LAST           (NUM_DIGITAL_PINS + NUM_ANALOG_INPUTS)
+#define NUM_ANALOG_INTERNAL_FIRST (NUM_ANALOG_LAST + 1)
+#else
+#define NUM_ANALOG_INTERNAL_FIRST (NUM_DIGITAL_PINS + 1)
 #endif
 
+// If NUM_ANALOG_INPUTS is not defined there is no analog pins defined.
+// Anyway ADC internal channels are always avaialable.
+#if NUM_ANALOG_INPUTS > 0
 // Analog pins must be contiguous to be able to loop on each value
 #define MAX_ANALOG_INPUTS 24
 _Static_assert(NUM_ANALOG_INPUTS <= MAX_ANALOG_INPUTS,
                "Core NUM_ANALOG_INPUTS limited to MAX_ANALOG_INPUTS");
+
 _Static_assert(NUM_ANALOG_FIRST >= NUM_ANALOG_INPUTS,
                "First analog pin value (A0) must be greater than or equal to NUM_ANALOG_INPUTS");
 
@@ -161,6 +174,7 @@ static const uint8_t A22 = PIN_A22;
 #define PIN_A23      (PIN_A22 + 1)
 static const uint8_t A23 = PIN_A23;
 #endif
+#endif /* NUM_ANALOG_INPUTS > 0 */
 
 // Default for Arduino connector compatibility
 // SPI Definitions
@@ -208,38 +222,56 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 // ADC internal channels (not a pins)
 // Only used for analogRead()
 #if defined(ADC_CHANNEL_TEMPSENSOR) || defined(ADC_CHANNEL_TEMPSENSOR_ADC1)
-#define ATEMP        (NUM_DIGITAL_PINS + 1)
+#define ATEMP        (NUM_ANALOG_INTERNAL_FIRST)
 #endif
 #ifdef ADC_CHANNEL_VREFINT
-#define AVREF        (NUM_DIGITAL_PINS + 2)
+#define AVREF        (NUM_ANALOG_INTERNAL_FIRST + 2)
 #endif
 #ifdef ADC_CHANNEL_VBAT
-#define AVBAT        (NUM_DIGITAL_PINS + 3)
+#define AVBAT        (NUM_ANALOG_INTERNAL_FIRST + 3)
 #endif
 #if defined(ADC5) && defined(ADC_CHANNEL_TEMPSENSOR_ADC5)
-#define ATEMP_ADC5   (NUM_DIGITAL_PINS + 4)
+#define ATEMP_ADC5   (NUM_ANALOG_INTERNAL_FIRST + 4)
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 extern const PinName digitalPin[];
+extern const uint32_t analogInPin[];
 
 #define NOT_AN_INTERRUPT            NC // -1
 
 // Convert a digital pin number Dxx to a PinName PX_n
 // Note: Analog pin is also a digital pin.
+#ifndef NUM_ANALOG_LAST
 #define digitalPinToPinName(p)      (((uint32_t)p < NUM_DIGITAL_PINS) ? digitalPin[p] : NC)
+#else
+#define digitalPinToPinName(p)      (((uint32_t)p < NUM_DIGITAL_PINS) ? digitalPin[p] : \
+            ((uint32_t)p >= NUM_ANALOG_FIRST) && ((uint32_t)p <= NUM_ANALOG_LAST) ? \
+                                                digitalPin[analogInPin[p-NUM_ANALOG_FIRST]] : NC)
+#endif
 // Convert a PinName PX_n to a digital pin number
 uint32_t pinNametoDigitalPin(PinName p);
 
 // Convert an analog pin number to a digital pin number
-#if defined(NUM_ANALOG_INPUTS) && (NUM_ANALOG_INPUTS>0)
+#if NUM_ANALOG_INPUTS > 0
 // Used by analogRead api to have A0 == 0
+// For contiguous analog pins definition in digitalPin array
+#ifndef NUM_ANALOG_LAST
 #define analogInputToDigitalPin(p)  (((uint32_t)p < NUM_ANALOG_INPUTS) ? (p+A0) : p)
 #else
+// For non contiguous analog pins definition in digitalPin array
+#define analogInputToDigitalPin(p)  ( \
+            ((uint32_t)p < NUM_ANALOG_INPUTS) ? analogInPin[p] : \
+            ((uint32_t)p >= NUM_ANALOG_FIRST) && ((uint32_t)p <= NUM_ANALOG_LAST) ? \
+                                                analogInPin[p-NUM_ANALOG_FIRST] : p)
+#endif // !NUM_ANALOG_LAST
+#else
+// No analog pin defined
 #define analogInputToDigitalPin(p)  (NUM_DIGITAL_PINS)
-#endif
+#endif // NUM_ANALOG_INPUTS > 0
+
 // Convert an analog pin number Axx to a PinName PX_n
 PinName analogInputToPinName(uint32_t pin);
 

--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -65,9 +65,6 @@ _Static_assert(NUM_ANALOG_INPUTS <= MAX_ANALOG_INPUTS,
 _Static_assert(NUM_ANALOG_FIRST >= NUM_ANALOG_INPUTS,
                "First analog pin value (A0) must be greater than or equal to NUM_ANALOG_INPUTS");
 
-// Defined for backward compatibility with Firmata which unfortunately use it
-#define AEND (NUM_ANALOG_FIRST+NUM_ANALOG_INPUTS)
-
 #if NUM_ANALOG_INPUTS > 0
 #define PIN_A0       NUM_ANALOG_FIRST
 static const uint8_t A0 = PIN_A0;

--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -17,6 +17,7 @@
 */
 #ifndef _PINS_ARDUINO_H_
 #define _PINS_ARDUINO_H_
+#include <stdbool.h>
 #include <stdlib.h> /* Required for static_assert */
 // Include board variant
 #include "variant.h"
@@ -323,12 +324,15 @@ PinName analogInputToPinName(uint32_t pin);
 // return first occurence of linked PinName (PYx)
 #define digitalPinFirstOccurence(p) (pinNametoDigitalPin(digitalPinToPinName(p)))
 
-// Specific for Firmata. As some pins could be duplicated,
-// ensure 'p' is not one of the serial pins
+// Specific for Firmata.
+// Some pins could be duplicated, ensure 'p' is not one of the serial pins
 #if defined(PIN_SERIAL_RX) && defined(PIN_SERIAL_TX)
 #define pinIsSerial(p)              ((digitalPinFirstOccurence(p) == PIN_SERIAL_RX) ||\
                                      (digitalPinFirstOccurence(p) == PIN_SERIAL_TX))
 #endif
+// Convenient macro to handle Analog
+bool pinIsAnalogInput(uint32_t pin);
+uint32_t digitalPinToAnalogInput(uint32_t pin);
 
 #ifdef __cplusplus
 }

--- a/variants/BLUE_F407VE_Mini/variant.cpp
+++ b/variants/BLUE_F407VE_Mini/variant.cpp
@@ -128,25 +128,28 @@ const PinName digitalPin[] = {
   PB_3,
   PB_5,
   PB_7,
-  PB_9,   //D79 - LED
+  PB_9    //D79 - LED
   //GND
   //3V3
   //GND
-  // Analog pins
-  PA_0,   //D80
-  PA_1,
-  PA_2,
-  PA_3,
-  PA_4,
-  PA_5,
-  PB_0,
-  PB_1,
-  PC_0,
-  PC_1,
-  PC_2,   //D90
-  PC_3,
-  PC_4,
-  PC_5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  7,  //A0
+  8,  //A1
+  49, //A2
+  50, //A3
+  9,  //A4
+  51, //A5
+  12, //A6
+  54, //A7
+  5,  //A8
+  47, //A9
+  6,  //A10
+  48, //A11
+  11, //A12
+  53  //A13
 };
 
 #ifdef __cplusplus

--- a/variants/BLUE_F407VE_Mini/variant.h
+++ b/variants/BLUE_F407VE_Mini/variant.h
@@ -47,14 +47,14 @@ extern "C" {
 #define PE4  2
 #define PE6  3
 #define PC14 4  // OSC32_IN
-#define PC0  5  // A8
-#define PC2  6  // A10
-#define PA0  7  // A0
-#define PA1  8  // A1
-#define PA4  9  // A4
+#define PC0  A8
+#define PC2  A10
+#define PA0  A0
+#define PA1  A1
+#define PA4  A4
 #define PA6  10
-#define PC4  11 // A12
-#define PB0  12 // A6
+#define PC4  A12
+#define PB0  A6
 #define PB2  13
 #define PE8  14
 #define PE9  15
@@ -96,14 +96,14 @@ extern "C" {
 #define PE5  44
 #define PC13 45
 #define PC15 46 // OSC32_OUT
-#define PC1  47 // A9
-#define PC3  48 // A11
-#define PA2  49 // A2
-#define PA3  50 // A3
-#define PA5  51 // A5
+#define PC1  A9
+#define PC3  A11
+#define PA2  A2
+#define PA3  A3
+#define PA5  A5
 #define PA7  52
-#define PC5  53 // A13
-#define PB1  54 // A7
+#define PC5  A13
+#define PB1  A7
 #define PE7  55
 #define PE10 56
 #define PE12 57
@@ -135,10 +135,9 @@ extern "C" {
 // GND
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        94
+#define NUM_DIGITAL_PINS        80
 // This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       14
-#define NUM_ANALOG_FIRST        80
 
 // On-board LED pin number
 #define LED_BUILTIN             PB9

--- a/variants/DEMO_F030F4/variant.cpp
+++ b/variants/DEMO_F030F4/variant.cpp
@@ -57,17 +57,19 @@ const PinName digitalPin[] = {
   // These two are only available on boards without a crystal:
   PF_0,
   PF_1,
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  // A0 have to be greater than NUM_ANALOG_INPUTS
-  PA_0,  //D15/A0 ~ D0
-  PA_1,  //D16/A1 ~ D1
-  PA_2,  //D17/A2 ~ D2
-  PA_3,  //D18/A3 ~ D3
-  PA_4,  //D19/A4 ~ D4
-  PA_5,  //D20/A5 ~ D5
-  PA_6,  //D21/A6 ~ D6
-  PA_7,  //D22/A7 ~ D7
-  PB_1   //D23/A8 ~ D8
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  0, //A0
+  1, //A1
+  2, //A2
+  3, //A3
+  4, //A4
+  5, //A5
+  6, //A6
+  7, //A7
+  8  //A8
 };
 
 #ifdef __cplusplus

--- a/variants/DEMO_F030F4/variant.h
+++ b/variants/DEMO_F030F4/variant.h
@@ -40,16 +40,16 @@ extern "C" {
 
 // USB connector on the top, MCU side
 // Left Side
-#define PA0  0  //D0/A0
-#define PA1  1  //D1/A1
-#define PA2  2  //D2/A2 - TX
-#define PA3  3  //D3/A3 - RX
-#define PA4  4  //D4/A4 - LED
+#define PA0  A0 //D0/A0
+#define PA1  A1 //D1/A1
+#define PA2  A2 //D2/A2 - TX
+#define PA3  A3 //D3/A3 - RX
+#define PA4  A4 //D4/A4 - LED
 // Right side
-#define PA5  5  //D5/A5 - SCK
-#define PA6  6  //D6/A6 - MISO
-#define PA7  7  //D7/A7 - MOSI
-#define PB1  8  //D8/A8 - SS
+#define PA5  A5 //D5/A5 - SCK
+#define PA6  A6 //D6/A6 - MISO
+#define PA7  A7 //D7/A7 - MOSI
+#define PB1  A8 //D8/A8 - SS
 #define PA9  9  //D9    - SCL (TX UART header)
 #define PA10 10 //D10   - SDA (RX UART header)
 #define PA13 11 //D11   - SWDIO
@@ -59,10 +59,9 @@ extern "C" {
 #define PF1  14
 
 // This must be a literal with the same value as PEND
-#define NUM_DIGITAL_PINS        24
+#define NUM_DIGITAL_PINS        15
 // This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       9
-#define NUM_ANALOG_FIRST        15
 
 // On-board LED pin number
 #define LED_BUILTIN             PA4

--- a/variants/DISCO_F030R8/variant.cpp
+++ b/variants/DISCO_F030R8/variant.cpp
@@ -34,7 +34,7 @@
 extern "C" {
 #endif
 
-// Pin number
+// Digital PinName array
 const PinName digitalPin[] = {
   //P1 connector Right side (bottom view)
   PC_13, //D0
@@ -92,24 +92,27 @@ const PinName digitalPin[] = {
   PC_6,  //D51
   PB_15, //D52
   PB_14, //D53
-  PB_13, //D54
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PC_0,  //D55/A0 = D5
-  PC_1,  //D56/A1 = D6
-  PC_2,  //D57/A2 = D7
-  PC_3,  //D58/A3 = D8
-  PA_0,  //D59/A4 = D9
-  PA_1,  //D60/A5 = D10
-  PA_2,  //D61/A6 = D11
-  PA_3,  //D62/A7 = D12
-  PA_4,  //D63/A8 = D15
-  PA_5,  //D64/A9 = D16
-  PA_6,  //D65/A10= D17
-  PA_7,  //D66/A11= D18
-  PC_4,  //D67/A12 = D19
-  PC_5,  //D68/A13 = D20
-  PB_0,  //D69/A14 = D21
-  PB_1   //D70/A15 = D22
+  PB_13  //D54
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  5,  //A0  = D5
+  6,  //A1  = D6
+  7,  //A2  = D7
+  8,  //A3  = D8
+  9,  //A4  = D9
+  10, //A5  = D10
+  11, //A6  = D11
+  12, //A7  = D12
+  15, //A8  = D15
+  16, //A9  = D16
+  17, //A10 = D17
+  18, //A11 = D18
+  19, //A12 = D19
+  20, //A13 = D20
+  21, //A14 = D21
+  22  //A15 = D22
 };
 
 #ifdef __cplusplus

--- a/variants/DISCO_F030R8/variant.h
+++ b/variants/DISCO_F030R8/variant.h
@@ -45,24 +45,24 @@ extern "C" {
 #define PC15 2
 #define PF0  3
 #define PF1  4
-#define PC0  5  // A0
-#define PC1  6  // A1
-#define PC2  7  // A2
-#define PC3  8  // A3
-#define PA0  9  // A4/USER_BTN
-#define PA1  10 // A5
-#define PA2  11 // A6
-#define PA3  12 // A7
+#define PC0  A0
+#define PC1  A1
+#define PC2  A2
+#define PC3  A3
+#define PA0  A4 // USER_BTN
+#define PA1  A5
+#define PA2  A6
+#define PA3  A7
 #define PF4  13
 #define PF5  14
-#define PA4  15 // A8
-#define PA5  16 // A9
-#define PA6  17 // A10
-#define PA7  18 // A11
-#define PC4  19 // A12
-#define PC5  20 // A13
-#define PB0  21 // A14
-#define PB1  22 // A15
+#define PA4  A8
+#define PA5  A9
+#define PA6  A10
+#define PA7  A11
+#define PC4  A12
+#define PC5  A13
+#define PB0  A14
+#define PB1  A15
 #define PB2  23
 #define PB10 24
 #define PB11 25
@@ -101,7 +101,6 @@ extern "C" {
 #define NUM_DIGITAL_PINS        71
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       16
-#define NUM_ANALOG_FIRST        55
 
 //On-board LED pin number
 #define LED_BUILTIN             PC9 // LD3

--- a/variants/DISCO_F100RB/variant.cpp
+++ b/variants/DISCO_F100RB/variant.cpp
@@ -73,24 +73,27 @@ const PinName digitalPin[] = {
   PB_12, //D43 - SPI SS
   PB_13, //D44 - SPI SCLK
   PB_14, //D45 - SPI MISO
-  PB_15, //D46 - SPI MOSI
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PC_0,  //D47/A0 = D0
-  PC_1,  //D48/A1 = D1
-  PC_2,  //D49/A2 = D2
-  PC_3,  //D50/A3 = D3
-  PA_0,  //D51/A4 = D4
-  PA_1,  //D52/A5 = D5
-  PA_2,  //D53/A6 = D6
-  PA_3,  //D54/A7 = D7
-  PA_4,  //D55/A8 = D8
-  PA_5,  //D56/A9 = D9
-  PA_6,  //D57/A10 = D10
-  PA_7,  //D58/A11 = D11
-  PC_4,  //D59/A12 = D12
-  PC_5,  //D60/A13 = D13
-  PB_0,  //D61/A14 = D14
-  PB_1   //D62/A15 = D15
+  PB_15  //D46 - SPI MOSI
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  1,  //A0
+  2,  //A1
+  3,  //A2
+  4,  //A3
+  5,  //A4
+  6,  //A5
+  7,  //A6
+  8,  //A7
+  9,  //A8
+  10, //A9
+  11, //A10
+  12, //A11
+  13, //A12
+  14, //A13
+  15, //A14
+  16  //A15
 };
 
 #ifdef __cplusplus

--- a/variants/DISCO_F100RB/variant.h
+++ b/variants/DISCO_F100RB/variant.h
@@ -29,22 +29,22 @@ extern "C" {
 
 // P1 connector
 #define PC13 0
-#define PC0  1  // A0
-#define PC1  2  // A1
-#define PC2  3  // A2
-#define PC3  4  // A3
-#define PA0  5  // A4/User button
-#define PA1  6  // A5
-#define PA2  7  // A6
-#define PA3  8  // A7
-#define PA4  9  // A8
-#define PA5  10 // A9
-#define PA6  11 // A10
-#define PA7  12 // A11
-#define PC4  13 // A12
-#define PC5  14 // A13
-#define PB0  15 // A14
-#define PB1  16 // A15
+#define PC0  A0
+#define PC1  A1
+#define PC2  A2
+#define PC3  A3
+#define PA0  A4 // User button
+#define PA1  A5
+#define PA2  A6
+#define PA3  A7
+#define PA4  A8
+#define PA5  A9
+#define PA6  A10
+#define PA7  A11
+#define PC4  A12
+#define PC5  A13
+#define PB0  A14
+#define PB1  A15
 #define PB2  17
 // P2 connector
 #define PC6  18
@@ -79,10 +79,9 @@ extern "C" {
 #define PB15 46 // SPI MOSI
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        63
+#define NUM_DIGITAL_PINS        47
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       16
-#define NUM_ANALOG_FIRST        47
 
 // On-board LED pin number
 #define LED_BUILTIN             PC9

--- a/variants/DISCO_F407VG/variant.cpp
+++ b/variants/DISCO_F407VG/variant.cpp
@@ -106,17 +106,19 @@ const PinName digitalPin[] = {
   PA_13, //D75
   PA_9,  //D76
   PC_9,  //D77
-  PC_7,  //D78
-  //Duplicated to have A0-A5 as F407 do not have Uno like connector
-  // and to be aligned with PinMap_ADC
-  PC_2,  //D79/A0 = D1
-  PC_4,  //D80/A1 = D6
-  PB_0,  //D81/A2 = D7
-  PC_1,  //D82/A3 = D39
-  PC_3,  //D83/A4 = D40
-  PA_1,  //D84/A5 = D41
-  PC_5,  //D85/A6 = D45
-  PB_1   //D86/A7 = D46
+  PC_7   //D78
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  1,  //A0
+  6,  //A1
+  7,  //A2
+  39, //A3
+  40, //A4
+  41, //A5
+  45, //A6
+  46  //A7
 };
 
 #ifdef __cplusplus

--- a/variants/DISCO_F407VG/variant.h
+++ b/variants/DISCO_F407VG/variant.h
@@ -29,13 +29,13 @@ extern "C" {
 
 //P1 connector Right side
 #define PC0  0
-#define PC2  1  // A0
+#define PC2  A0
 #define PA0  2
 #define PA2  3
 #define PA4  4
 #define PA6  5
-#define PC4  6  // A1
-#define PB0  7  // A2
+#define PC4  A1
+#define PB0  A2
 #define PB2  8
 #define PE8  9
 #define PE10 10
@@ -69,14 +69,14 @@ extern "C" {
 #define PC8  37
 #define PC6  38
 //P1 Connector Left Side
-#define PC1  39 // A3
-#define PC3  40 // A4
-#define PA1  41 // A5
+#define PC1  A3
+#define PC3  A4
+#define PA1  A5
 #define PA3  42
 #define PA5  43
 #define PA7  44
-#define PC5  45 // A6
-#define PB1  46 // A7
+#define PC5  A6
+#define PB1  A7
 #define PE7  47
 #define PE9  48
 #define PE11 49
@@ -112,10 +112,9 @@ extern "C" {
 #define PC7  78
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        87
+#define NUM_DIGITAL_PINS        79
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       8
-#define NUM_ANALOG_FIRST        79
 
 // On-board LED pin number
 #define LED_BUILTIN             PD12

--- a/variants/DISCO_L475VG_IOT/variant.cpp
+++ b/variants/DISCO_L475VG_IOT/variant.cpp
@@ -106,18 +106,27 @@ const PinName digitalPin[] = {
   PC_3,  //D71/A2
   PC_2,  //D72/A3
   PC_1,  //D73/A4
-  PC_0,  //D74/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_1,  //D75/A6
-  PA_0,  //D76/A7
-  PB_0,  //D77/A8
-  PA_3,  //D78/A9
-  PB_1,  //D79/A10
-  PA_4,  //D80/A11
-  PA_2,  //D81/A12
-  PA_7,  //D82/A13
-  PA_6,  //D83/A14
-  PA_5   //D84/A15
+  PC_0   //D74/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  69, //A0
+  70, //A1
+  71, //A2
+  72, //A3
+  73, //A4
+  74, //A5
+  0,  //A6
+  1,  //A7
+  3,  //A8
+  4,  //A9
+  6,  //A10
+  7,  //A11
+  10, //A12
+  11, //A13
+  12, //A14
+  13, //A15
 };
 
 #ifdef __cplusplus

--- a/variants/DISCO_L475VG_IOT/variant.h
+++ b/variants/DISCO_L475VG_IOT/variant.h
@@ -28,21 +28,21 @@ extern "C" {
  *----------------------------------------------------------------------------*/
 
 // CN3 connector
-#define PA1  0  // A6/UART4_RX
-#define PA0  1  // A7/UART4_TX
+#define PA1  A6 //UART4_RX
+#define PA0  A7 //UART4_TX
 #define PD14 2
-#define PB0  3  // A8/PWM
-#define PA3  4  // A9
+#define PB0  A8 //PWM
+#define PA3  A9
 #define PB4  5  // PWM
-#define PB1  6  // A10/PWM
-#define PA4  7  // A11
+#define PB1  A10//PWM
+#define PA4  A11
 // CN1 connector
 #define PB2  8
 #define PA15 9  // PWM
-#define PA2  10 // A12/SPI_SSN/PWM
-#define PA7  11 // A13/SPI1_MOSI/PWM
-#define PA6  12 // A14/SPI1_MISO
-#define PA5  13 // A15/SPI1_SCK/LED1
+#define PA2  A12//SPI_SSN/PWM
+#define PA7  A13//SPI1_MOSI/PWM
+#define PA6  A14//SPI1_MISO
+#define PA5  A15//SPI1_SCK/LED1
 #define PB9  14 // I2C1_SDA
 #define PB8  15 // I2C1_SCL
 // Not on connector
@@ -104,18 +104,17 @@ extern "C" {
 #define PE14 67 // QUADSPI_BK1_IO2
 #define PE15 68 // QUADSPI_BK1_IO3
 // CN4 connector
-#define PC5  69 // A0
-#define PC4  70 // A1
-#define PC3  71 // A2
-#define PC2  72 // A3
-#define PC1  73 // A4
-#define PC0  74 // A5
+#define PC5  A0
+#define PC4  A1
+#define PC3  A2
+#define PC2  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        85
+#define NUM_DIGITAL_PINS        75
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       16
-#define NUM_ANALOG_FIRST        69
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/DIYMORE_F407VGT/variant.cpp
+++ b/variants/DIYMORE_F407VGT/variant.cpp
@@ -133,24 +133,27 @@ const PinName digitalPin[] = {
   PB_6,  // 74 Header left, pin 25
   PB_5,  // 75 Header left, pin 26
   PE_0,  // 76 Header left, pin 27 and LED_BUILTIN
-  PB_7,  // 77 Header left, pin 28
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_0,  // 78/A0
-  PA_1,  // 79/A1
-  PA_2,  // 80/A2
-  PA_3,  // 81/A3
-  PA_4,  // 82/A4
-  PA_5,  // 83/A5
-  PA_6,  // 84/A6
-  PA_7,  // 85/A7
-  PB_0,  // 86/A8
-  PB_1,  // 87/A9
-  PC_0,  // 88/A10
-  PC_1,  // 89/A11
-  PC_2,  // 90/A12
-  PC_3,  // 91/A13
-  PC_4,  // 92/A14
-  PC_5   // 93/A15
+  PB_7   // 77 Header left, pin 28
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  8,  //A0
+  11, //A1
+  10, //A2
+  12, //A3
+  15, //A4
+  14, //A5
+  17, //A6
+  16, //A7
+  21, //A8
+  20, //A9
+  7,  //A10
+  6,  //A11
+  9,  //A12
+  13, //A13
+  19, //A14
+  18  //A15
 };
 
 #ifdef __cplusplus

--- a/variants/DIYMORE_F407VGT/variant.h
+++ b/variants/DIYMORE_F407VGT/variant.h
@@ -57,22 +57,22 @@ extern "C" {
 #define PE6  5  // Header right, pin 6
 // Header right, pin 7 = GND
 // Header right, pin 8 = 3.3V
-#define PC1  6  // Header right, pin 9
-#define PC0  7  // Header right, pin 10
-#define PA0  8  // Header right, pin 11
-#define PC2  9  // Header right, pin 12
-#define PA2  10 // Header right, pin 13
-#define PA1  11 // Header right, pin 14
-#define PA3  12 // Header right, pin 15
-#define PC3  13 // Header right, pin 16
-#define PA5  14 // Header right, pin 17
-#define PA4  15 // Header right, pin 18
-#define PA7  16 // Header right, pin 19
-#define PA6  17 // Header right, pin 20
-#define PC5  18 // Header right, pin 21
-#define PC4  19 // Header right, pin 22
-#define PB1  20 // Header right, pin 23
-#define PB0  21 // Header right, pin 24
+#define PC1  A11  // Header right, pin 9
+#define PC0  A10  // Header right, pin 10
+#define PA0  A0 // Header right, pin 11
+#define PC2  A12 // Header right, pin 12
+#define PA2  A2 // Header right, pin 13
+#define PA1  A1 // Header right, pin 14
+#define PA3  A3 // Header right, pin 15
+#define PC3  A13 // Header right, pin 16
+#define PA5  A5  // Header right, pin 17
+#define PA4  A4 // Header right, pin 18
+#define PA7  A7 // Header right, pin 19
+#define PA6  A6 // Header right, pin 20
+#define PC5  A15 // Header right, pin 21
+#define PC4  A14 // Header right, pin 22
+#define PB1  A9 // Header right, pin 23
+#define PB0  A8 // Header right, pin 24
 #define PB9  22 // Header right, pin 25
 #define PB8  23 // Header right, pin 26
 #define PE7  24 // Header right, pin 27
@@ -139,11 +139,10 @@ extern "C" {
 #define PB7  77 // Header left, pin 28
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        94  // Number of definitions above
+#define NUM_DIGITAL_PINS        78  // Number of definitions above
 
 // This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       16
-#define NUM_ANALOG_FIRST        78
 
 // On-board LED pin number
 #define LED_BUILTIN             PE0

--- a/variants/FK407M1/variant.cpp
+++ b/variants/FK407M1/variant.cpp
@@ -80,24 +80,27 @@ const PinName digitalPin[] = {
   PD_6,   PD_7,
   PC_7,   PC_8,
   PD_15,  PC_6,
-  PC_13,  PA_15, // LED and Button pins - not broken out on the board
-  // Analog pins
-  PA_0,
-  PA_1,
-  PA_2,
-  PA_3,
-  PA_4,
-  PA_5,
-  PA_6,
-  PA_7,
-  PB_0,
-  PB_1,
-  PC_0,
-  PC_1,
-  PC_2,
-  PC_3,
-  PC_4,
-  PC_5
+  PC_13,  PA_15 // LED and Button pins - not broken out on the board
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  30, //A0
+  32, //A1
+  31, //A2
+  27, //A3
+  28, //A4
+  26, //A5
+  25, //A6
+  23, //A7
+  22, //A8
+  19, //A9
+  35, //A10
+  36, //A11
+  37, //A12
+  29, //A13
+  24, //A14
+  21  //A15
 };
 
 #ifdef __cplusplus

--- a/variants/FK407M1/variant.h
+++ b/variants/FK407M1/variant.h
@@ -58,25 +58,25 @@ extern "C" {
 #define PE11 16
 #define PE10 17
 #define PE9  18
-#define PB1  19
+#define PB1  A9
 #define PB2  20
-#define PC5  21
-#define PB0  22
-#define PA7  23
-#define PC4  24
-#define PA6  25
-#define PA5  26
-#define PA3  27
-#define PA4  28
-#define PC3  29
-#define PA0  30
-#define PA2  31
-#define PA1  32
+#define PC5  A15
+#define PB0  A8
+#define PA7  A7
+#define PC4  A14
+#define PA6  A6
+#define PA5  A5
+#define PA3  A3
+#define PA4  A4
+#define PC3  A13
+#define PA0  A0
+#define PA2  A2
+#define PA1  A1
 #define PD13 33
 #define PD14 34
-#define PC0  35
-#define PC1  36
-#define PC2  37
+#define PC0  A10
+#define PC1  A11
+#define PC2  A12
 // Right Side
 #define PA12 38
 #define PA11 39
@@ -118,10 +118,9 @@ extern "C" {
 #define PA15 75
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        92
+#define NUM_DIGITAL_PINS        76
 // This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       16
-#define NUM_ANALOG_FIRST        76
 
 // On-board LED pin number
 #define LED_D1                  PC13

--- a/variants/HY_TinySTM103T/variant.cpp
+++ b/variants/HY_TinySTM103T/variant.cpp
@@ -65,19 +65,22 @@ const PinName digitalPin[] = {
   PA_9,
   PA_10,
   PA_11,
-  PA_12,
+  PA_12
   //GND
-  //defines so that analog pins align to arduino mappings
-  PA_0, //A0
-  PA_1,
-  PA_2,
-  PA_3,
-  PA_4,
-  PA_5,
-  PA_6,
-  PA_7,
-  PB_0,
-  PB_1, //A9
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  2,  //A0
+  1,  //A1
+  0,  //A2
+  11, //A3
+  12, //A4
+  13, //A5
+  14, //A6
+  15, //A7
+  16, //A8
+  17  //A9
 };
 
 #ifdef __cplusplus

--- a/variants/HY_TinySTM103T/variant.h
+++ b/variants/HY_TinySTM103T/variant.h
@@ -40,9 +40,9 @@ extern "C" {
 
 // Right side
 
-#define PA2  0
-#define PA1  1 // LED
-#define PA0  2
+#define PA2  A2
+#define PA1  A1 // LED
+#define PA0  A0
 #define PA14 3
 #define PA13 4
 #define PB7  5
@@ -52,14 +52,14 @@ extern "C" {
 #define PB3  9
 #define PA15 10
 // Left side
-#define PA3  11
-#define PA4  12
-#define PA5  13
-#define PA6  14
-#define PA7  15
-#define PB0  16
-#define PB1  17
-#define PB2  18//BOOT1
+#define PA3  A3
+#define PA4  A4
+#define PA5  A5
+#define PA6  A6
+#define PA7  A7
+#define PB0  A8
+#define PB1  A9
+#define PB2  18 //BOOT1
 #define PA8  19
 #define PA9  20
 #define PA10 21
@@ -67,10 +67,9 @@ extern "C" {
 #define PA12 23
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        34
+#define NUM_DIGITAL_PINS        24
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       10
-#define NUM_ANALOG_FIRST        24
 
 // On-board LED pin number
 #define LED_BUILTIN             PA1

--- a/variants/MAPLEMINI_F103CB/variant.cpp
+++ b/variants/MAPLEMINI_F103CB/variant.cpp
@@ -72,18 +72,20 @@ const PinName digitalPin[] = {
   // Other
   PB_8,  //D32 - BOOT0 - User buttons
   PB_1,  //D33 - LED
-  PB_9,  //D34 - USB DISC
-  // Duplicated pins to avoid issue with analogRead
-  // A0 have to be greater than NUM_ANALOG_INPUTS
-  PB_0,  //D35/A0 = D3
-  PA_7,  //D36/A1 = D4
-  PA_6,  //D37/A2 = D5
-  PA_5,  //D38/A3 = D6
-  PA_4,  //D39/A4 = D7
-  PA_3,  //D40/A5 = D8
-  PA_2,  //D41/A6 = D9
-  PA_1,  //D42/A7 = D10
-  PA_0   //D43/A8 = D11
+  PB_9   //D34 - USB DISC
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  3,  //A0
+  4,  //A1
+  5,  //A2
+  6,  //A3
+  7,  //A4
+  8,  //A5
+  9,  //A6
+  10, //A7
+  11  //A8
 };
 
 #ifdef __cplusplus

--- a/variants/MAPLEMINI_F103CB/variant.h
+++ b/variants/MAPLEMINI_F103CB/variant.h
@@ -42,15 +42,15 @@ extern "C" {
 #define PB11 0
 #define PB10 1
 #define PB2  2
-#define PB0  3  // A0
-#define PA7  4  // A1
-#define PA6  5  // A2
-#define PA5  6  // A3
-#define PA4  7  // A4
-#define PA3  8  // A5
-#define PA2  9  // A6
-#define PA1  10 // A7
-#define PA0  11 // A8
+#define PB0  A0
+#define PA7  A1
+#define PA6  A2
+#define PA5  A3
+#define PA4  A4
+#define PA3  A5
+#define PA2  A6
+#define PA1  A7
+#define PA0  A8
 #define PC15 12
 #define PC14 13
 #define PC13 14
@@ -78,10 +78,9 @@ extern "C" {
 #define PB9  34 // USB DISC
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        44
+#define NUM_DIGITAL_PINS        35
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       9
-#define NUM_ANALOG_FIRST        35
 
 // On-board LED pin number
 #define LED_BUILTIN             PB1

--- a/variants/NUCLEO_F030R8/variant.cpp
+++ b/variants/NUCLEO_F030R8/variant.cpp
@@ -83,14 +83,23 @@ const PinName digitalPin[] = {
   PA_4,  //D51/A2
   PB_0,  //D52/A3
   PC_1,  //D53/A4
-  PC_0,  //D54/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D55/A6  = D11
-  PA_6,  //D56/A7  = D12
-  PC_2,  //D57/A8  = D29
-  PC_3,  //D58/A9  = D30
-  PC_5,  //D59/A10 = D36
-  PC_4   //D60/A11 = D46
+  PC_0   //D54/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  49, //A0
+  50, //A1
+  51, //A2
+  52, //A3
+  53, //A4
+  54, //A5
+  11, //A6
+  12, //A7
+  29, //A8
+  30, //A9
+  36, //A10
+  46  //A11
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F030R8/variant.h
+++ b/variants/NUCLEO_F030R8/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13
 #define PB9  14
 #define PB8  15
@@ -58,8 +58,8 @@ extern "C" {
 #define PC15 26
 #define PF0  27
 #define PF1  28
-#define PC2  29 // A8
-#define PC3  30 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 31
 #define PD2  32
@@ -68,7 +68,7 @@ extern "C" {
 // CN10 Right side
 #define PC8  34
 #define PC6  35
-#define PC5  36 // A10
+#define PC5  A10
 #define PA12 37
 #define PA11 38
 #define PB12 39
@@ -78,21 +78,20 @@ extern "C" {
 #define PB15 43
 #define PB14 44
 #define PB13 45
-#define PC4  46 // A11
+#define PC4  A11
 #define PF5  47
 #define PF4  48
-#define PA0  49 // A0
-#define PA1  50 // A1
-#define PA4  51 // A2
-#define PB0  52 // A3
-#define PC1  53 // A4
-#define PC0  54 // A5
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        61
+#define NUM_DIGITAL_PINS        55
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12
-#define NUM_ANALOG_FIRST        49
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_F091RC/variant.cpp
+++ b/variants/NUCLEO_F091RC/variant.cpp
@@ -80,14 +80,23 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6  = D11
-  PA_6,  //D53/A7  = D12
-  PC_2,  //D54/A8  = D28
-  PC_3,  //D55/A9  = D29
-  PC_5,  //D56/A10 = D35
-  PC_4   //D57/A11 = D45
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  28, //A8
+  29, //A9
+  35, //A10
+  45  //A11
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F091RC/variant.h
+++ b/variants/NUCLEO_F091RC/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13
 #define PB9  14
 #define PB8  15
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15 25
 #define PF0  26
 #define PF1  27
-#define PC2  28 // A8
-#define PC3  29 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -67,7 +67,7 @@ extern "C" {
 // CN10 Right side
 #define PC8  33
 #define PC6  34
-#define PC5  35 // A10
+#define PC5  A10
 #define PA12 36
 #define PA11 37
 #define PB12 38
@@ -77,19 +77,18 @@ extern "C" {
 #define PB15 42
 #define PB14 43
 #define PB13 44
-#define PC4  45 // A11
-#define PA0  46 // A0
-#define PA1  47 // A1
-#define PA4  48 // A2
-#define PB0  49 // A3
-#define PC1  50 // A4
-#define PC0  51 // A5
+#define PC4  A11
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        58
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_F103RB/variant.cpp
+++ b/variants/NUCLEO_F103RB/variant.cpp
@@ -80,16 +80,25 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6 = D11
-  PA_6,  //D53/A7 = D12
-  PA_5,  //D54/A8 = D13
-  PC_2,  //D55/A9 = D28
-  PC_3,  //D56/A10 = D29
-  PB_1,  //D57/A11 = D41
-  PC_4,  //D58/A12 = D45
-  PC_5   //D59/A13 = D35
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  13, //A8
+  28, //A9
+  29, //A10
+  41, //A11
+  45, //A12
+  35  //A13
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F103RB/variant.h
+++ b/variants/NUCLEO_F103RB/variant.h
@@ -38,9 +38,9 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
-#define PA5  13 // A8 - LED
+#define PA7  A6
+#define PA6  A7
+#define PA5  A8 // LED
 #define PB9  14
 #define PB8  15
 // ST Morpho
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15 25
 #define PD0  26
 #define PD1  27
-#define PC2  28 // A9
-#define PC3  29 // A10
+#define PC2  A9
+#define PC3  A10
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -67,29 +67,28 @@ extern "C" {
 // CN10 Right side
 #define PC8  33
 #define PC6  34
-#define PC5  35 // A13
+#define PC5  A13
 #define PA12 36
 #define PA11 37
 #define PB12 38
 #define PB11 39
 #define PB2  40
-#define PB1  41 // A11
+#define PB1  A11
 #define PB15 42
 #define PB14 43
 #define PB13 44
-#define PC4  45 // A12
-#define PA0  46 // A0
-#define PA1  47 // A1
-#define PA4  48 // A2
-#define PB0  49 // A3
-#define PC1  50 // A4
-#define PC0  51 // A5
+#define PC4  A12
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        60
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       14
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_F207ZG/variant.cpp
+++ b/variants/NUCLEO_F207ZG/variant.cpp
@@ -132,16 +132,29 @@ const PinName digitalPin[] = {
   PB_1,  //D84/A6
   PC_2,  //D85/A7
   PF_4,  //D86/A8
-  PF_6,  //D87/A9
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D88/A10 = D11/D71
-  PA_6,  //D89/A11 = D12
-  PA_5,  //D90/A12 = D13
-  PA_4,  //D91/A13 = D24
-  PA_0,  //D92/A14 = D32
-  PF_8,  //D93/A15 = D61
-  PF_7,  //D94/A16 = D62
-  PF_9   //D95/A17 = D63
+  PF_6   //D87/A9
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  78, //A0
+  79, //A1
+  80, //A2
+  81, //A3
+  82, //A4
+  83, //A5
+  84, //A6
+  85, //A7
+  86, //A8
+  87, //A9
+  11, //A10
+  12, //A11
+  13, //A12
+  24, //A13
+  32, //A14
+  61, //A15
+  62, //A16
+  63  //A17
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F207ZG/variant.h
+++ b/variants/NUCLEO_F207ZG/variant.h
@@ -50,9 +50,9 @@ extern "C" {
 #define PF12 8
 #define PD15 9
 #define PD14 10
-#define PA7  11 // A10
-#define PA6  12 // A11
-#define PA5  13 // A12
+#define PA7  A10
+#define PA6  A11
+#define PA5  A12
 #define PB9  14
 #define PB8  15
 #define PC6  16
@@ -63,7 +63,7 @@ extern "C" {
 #define PC7  21
 #define PB5  22
 #define PB3  23
-#define PA4  24 // A13
+#define PA4  A13
 #define PB4  25
 #define PB6  26
 #define PB2  27
@@ -71,7 +71,7 @@ extern "C" {
 #define PD12 29
 #define PD11 30
 #define PE2  31
-#define PA0  32 // A14
+#define PA0  A14
 #define PB0  33 // LED1
 #define PE0  34
 #define PB11 35
@@ -100,9 +100,9 @@ extern "C" {
 #define PE5  58
 #define PE6  59
 #define PE3  60
-#define PF8  61 // A15
-#define PF7  62 // A16
-#define PF9  63 // A17
+#define PF8  A15
+#define PF7  A16
+#define PF9  A17
 #define PG1  64
 #define PG0  65
 #define PD1  66
@@ -117,22 +117,21 @@ extern "C" {
 #define PC13 75 // USER_BTN
 #define PD9  76 // Serial Rx
 #define PD8  77 // Serial Tx
-#define PA3  78 // A0
-#define PC0  79 // A1
-#define PC3  80 // A2
-#define PF3  81 // A3
-#define PF5  82 // A4
-#define PF10 83 // A5
-#define PB1  84 // A6
-#define PC2  85 // A7
-#define PF4  86 // A8
-#define PF6  87 // A9
+#define PA3  A0
+#define PC0  A1
+#define PC3  A2
+#define PF3  A3
+#define PF5  A4
+#define PF10 A5
+#define PB1  A6
+#define PC2  A7
+#define PF4  A8
+#define PF6  A9
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        96
+#define NUM_DIGITAL_PINS        88
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       18
-#define NUM_ANALOG_FIRST        78
 
 // On-board LED pin number
 #define LED_BUILTIN             PB0

--- a/variants/NUCLEO_F302R8/variant.cpp
+++ b/variants/NUCLEO_F302R8/variant.cpp
@@ -80,14 +80,23 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PC_2,  //D52/A6  = D28
-  PC_3,  //D53/A7  = D29
-  PB_11, //D54/A8  = D39
-  PB_1,  //D55/A9  = D41
-  PA_7,  //D56/A10 = D42
-  PA_6,  //D57/A11 = D43
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  28, //A6
+  29, //A7
+  39, //A8
+  41, //A9
+  42, //A10
+  43  //A11
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F302R8/variant.h
+++ b/variants/NUCLEO_F302R8/variant.h
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15 25
 #define PF0  26
 #define PF1  27
-#define PC2  28 // A6
-#define PC3  29 // A7
+#define PC2  A6
+#define PC3  A7
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -71,11 +71,11 @@ extern "C" {
 #define PA12 36
 #define PA11 37
 #define PB12 38
-#define PB11 39 // A8
+#define PB11 A8
 #define PB2  40
-#define PB1  41 // A9
-#define PA7  42 // A10
-#define PA6  43 // A11
+#define PB1  A9
+#define PA7  A10
+#define PA6  A11
 #define PA5  44
 #define PC4  45
 #define PA0  46 // A0
@@ -86,10 +86,9 @@ extern "C" {
 #define PC0  51 // A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        58
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_F303RE/variant.cpp
+++ b/variants/NUCLEO_F303RE/variant.cpp
@@ -80,16 +80,25 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6  = D11
-  PA_6,  //D53/A7  = D12
-  PC_2,  //D54/A8  = D28
-  PC_3,  //D55/A9  = D29
-  PC_5,  //D56/A10 = D35
-  PB_11, //D57/A11 = D39
-  PB_2,  //D58/A12 = D40
-  PC_4   //D59/A13 = D45
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  28, //A8
+  29, //A9
+  35, //A10
+  39, //A11
+  40, //A12
+  45  //A13
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F303RE/variant.h
+++ b/variants/NUCLEO_F303RE/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13
 #define PB9  14
 #define PB8  15
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15 25
 #define PF0  26
 #define PF1  27
-#define PC2  28 // A8
-#define PC3  29 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -67,29 +67,28 @@ extern "C" {
 // CN10 Right side
 #define PC8  33
 #define PC6  34
-#define PC5  35 // A10
+#define PC5  A10
 #define PA12 36
 #define PA11 37
 #define PB12 38
-#define PB11 39 // A11
-#define PB2  40 // A12
+#define PB11 A11
+#define PB2  A12
 #define PB1  41
 #define PB15 42
 #define PB14 43
 #define PB13 44
-#define PC4  45 // A13
-#define PA0  46 // A0
-#define PA1  47 // A1
-#define PA4  48 // A2
-#define PB0  49 // A3
-#define PC1  50 // A4
-#define PC0  51 // A5
+#define PC4  A13
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        60
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       14
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_F401RE/variant.cpp
+++ b/variants/NUCLEO_F401RE/variant.cpp
@@ -80,15 +80,24 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6  = D11
-  PA_6,  //D53/A7  = D12
-  PC_2,  //D54/A8  = D28
-  PC_3,  //D55/A9  = D29
-  PC_5,  //D56/A10 = D35
-  PB_1,  //D57/A11 = D41
-  PC_4   //D58/A12 = D45
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  28, //A8
+  29, //A9
+  35, //A10
+  41, //A11
+  45  //A12
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F401RE/variant.h
+++ b/variants/NUCLEO_F401RE/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13
 #define PB9  14
 #define PB8  15
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15 25
 #define PH0  26
 #define PH1  27
-#define PC2  28 // A8
-#define PC3  29 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -67,29 +67,28 @@ extern "C" {
 // CN10 Right side
 #define PC8  33
 #define PC6  34
-#define PC5  35 // A10
+#define PC5  A10
 #define PA12 36
 #define PA11 37
 #define PB12 38
 #define PB11 39
 #define PB2  40
-#define PB1  41 // A11
+#define PB1  A11
 #define PB15 42
 #define PB14 43
 #define PB13 44
-#define PC4  45 // A12
-#define PA0  46 // A0
-#define PA1  47 // A1
-#define PA4  48 // A2
-#define PB0  49 // A3
-#define PC1  50 // A4
-#define PC0  51 // A5
+#define PC4  A12
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        59
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       13
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_F411RE/variant.cpp
+++ b/variants/NUCLEO_F411RE/variant.cpp
@@ -80,15 +80,24 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6  = D11
-  PA_6,  //D53/A7  = D12
-  PC_2,  //D54/A8  = D28
-  PC_3,  //D55/A9  = D29
-  PC_5,  //D56/A10 = D35
-  PB_1,  //D57/A11 = D41
-  PC_4   //D58/A12 = D45
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  28, //A8
+  29, //A9
+  35, //A10
+  41, //A11
+  45  //A12
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F411RE/variant.h
+++ b/variants/NUCLEO_F411RE/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13
 #define PB9  14
 #define PB8  15
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15 25
 #define PH0  26
 #define PH1  27
-#define PC2  28 // A8
-#define PC3  29 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -67,29 +67,28 @@ extern "C" {
 // CN10 Right side
 #define PC8  33
 #define PC6  34
-#define PC5  35 // A10
+#define PC5  A10
 #define PA12 36
 #define PA11 37
 #define PB12 38
 #define PB11 39
 #define PB2  40
-#define PB1  41 // A11
+#define PB1  A11
 #define PB15 42
 #define PB14 43
 #define PB13 44
-#define PC4  45 // A12
-#define PA0  46 // A0
-#define PA1  47 // A1
-#define PA4  48 // A2
-#define PB0  49 // A3
-#define PC1  50 // A4
-#define PC0  51 // A5
+#define PC4  A12
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        59
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       13
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_F429ZI/variant.cpp
+++ b/variants/NUCLEO_F429ZI/variant.cpp
@@ -37,9 +37,9 @@ const PinName digitalPin[] = {
   PF_12, //D8
   PD_15, //D9
   PD_14, //D10
-  PA_7,  //D11
-  PA_6,  //D12
-  PA_5,  //D13
+  PA_7,  //D11/A10
+  PA_6,  //D12/A11
+  PA_5,  //D13/A12
   PB_9,  //D14
   PB_8,  //D15
   PC_6,  //D16
@@ -50,7 +50,7 @@ const PinName digitalPin[] = {
   PC_7,  //D21
   PB_5,  //D22
   PB_3,  //D23
-  PA_4,  //D24
+  PA_4,  //D24/A13
   PB_4,  //D25
   PB_6,  //D26
   PB_2,  //D27
@@ -58,7 +58,7 @@ const PinName digitalPin[] = {
   PD_12, //D29
   PD_11, //D30
   PE_2,  //D31
-  PA_0,  //D32
+  PA_0,  //D32/A14
   PB_0,  //D33 - LED_GREEN
   PE_0,  //D34
   PB_11, //D35
@@ -87,9 +87,9 @@ const PinName digitalPin[] = {
   PE_5,  //D58
   PE_6,  //D59
   PE_3,  //D60
-  PF_8,  //D61
-  PF_7,  //D62
-  PF_9,  //D63
+  PF_8,  //D61/A15
+  PF_7,  //D62/A16
+  PF_9,  //D63/A17
   PG_1,  //D64
   PG_0,  //D65
   PD_1,  //D66
@@ -113,16 +113,29 @@ const PinName digitalPin[] = {
   PB_1,  //D84/A6
   PC_2,  //D85/A7
   PF_4,  //D86/A8
-  PF_6,  //D87/A9
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D88/A10 = D11
-  PA_6,  //D89/A11 = D12
-  PA_5,  //D90/A12 = D13
-  PA_4,  //D91/A13 = D24
-  PA_0,  //D92/A14 = D32
-  PF_8,  //D93/A15 = D61
-  PF_7,  //D94/A16 = D62
-  PF_9   //D95/A17 = D63
+  PF_6   //D87/A9
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  78, //A0
+  79, //A1
+  80, //A2
+  81, //A3
+  82, //A4
+  83, //A5
+  84, //A6
+  85, //A7
+  86, //A8
+  87, //A9
+  11, //A10
+  12, //A11
+  13, //A12
+  24, //A13
+  32, //A14
+  61, //A15
+  62, //A16
+  63  //A17
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F429ZI/variant.h
+++ b/variants/NUCLEO_F429ZI/variant.h
@@ -38,9 +38,9 @@ extern "C" {
 #define PF12 8
 #define PD15 9
 #define PD14 10
-#define PA7  11 // A10
-#define PA6  12 // A11
-#define PA5  13 // A12
+#define PA7  A10
+#define PA6  A11
+#define PA5  A12
 #define PB9  14
 #define PB8  15
 #define PC6  16
@@ -51,7 +51,7 @@ extern "C" {
 #define PC7  21
 #define PB5  22
 #define PB3  23
-#define PA4  24 // A13
+#define PA4  A13
 #define PB4  25
 #define PB6  26
 #define PB2  27
@@ -59,7 +59,7 @@ extern "C" {
 #define PD12 29
 #define PD11 30
 #define PE2  31
-#define PA0  32 // A14
+#define PA0  A14
 #define PB0  33 // LED_GREEN
 #define PE0  34
 #define PB11 35
@@ -88,9 +88,9 @@ extern "C" {
 #define PE5  58
 #define PE6  59
 #define PE3  60
-#define PF8  61 // A15
-#define PF7  62 // A16
-#define PF9  63 // A17
+#define PF8  A15
+#define PF7  A16
+#define PF9  A17
 #define PG1  64
 #define PG0  65
 #define PD1  66
@@ -105,22 +105,21 @@ extern "C" {
 #define PC13 75 // USER_BTN
 #define PD9  76 // Serial Rx
 #define PD8  77 // Serial Tx
-#define PA3  78 // A0
-#define PC0  79 // A1
-#define PC3  80 // A2
-#define PF3  81 // A3
-#define PF5  82 // A4
-#define PF10 83 // A5
-#define PB1  84 // A6
-#define PC2  85 // A7
-#define PF4  86 // A8
-#define PF6  87 // A9
+#define PA3  A0
+#define PC0  A1
+#define PC3  A2
+#define PF3  A3
+#define PF5  A4
+#define PF10 A5
+#define PB1  A6
+#define PC2  A7
+#define PF4  A8
+#define PF6  A9
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        96
+#define NUM_DIGITAL_PINS        88
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       18
-#define NUM_ANALOG_FIRST        78
 
 // On-board LED pin number
 #define LED_BUILTIN             PB0

--- a/variants/NUCLEO_F446RE/variant.cpp
+++ b/variants/NUCLEO_F446RE/variant.cpp
@@ -80,16 +80,25 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6  = D11
-  PA_6,  //D53/A7  = D12
-  PA_5,  //D54/A8  = D13
-  PC_2,  //D55/A9  = D28
-  PC_3,  //D56/A10 = D29
-  PC_5,  //D57/A11 = D35
-  PB_1,  //D58/A12 = D41
-  PC_4,  //D59/A13 = D45
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  13, //A8
+  28, //A9
+  29, //A10
+  35, //A11
+  41, //A12
+  45  //A13
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F446RE/variant.h
+++ b/variants/NUCLEO_F446RE/variant.h
@@ -38,9 +38,9 @@ extern "C" {
 #define PA9   8
 #define PC7   9
 #define PB6   10
-#define PA7   11 // A6
-#define PA6   12 // A7
-#define PA5   13 // A8 - LD2
+#define PA7   A6
+#define PA6   A7
+#define PA5   A8 // LD2
 #define PB9   14
 #define PB8   15
 // ST Morpho
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15  25 // NC by default SB48 opened
 #define PH0   26 // NC by default SB55 opened
 #define PH1   27
-#define PC2   28 // A9
-#define PC3   29 // A10
+#define PC2   A9
+#define PC3   A10
 // CN7 Right Side
 #define PC11  30
 #define PD2   31
@@ -67,29 +67,28 @@ extern "C" {
 // CN10 Right side
 #define PC8   33
 #define PC6   34
-#define PC5   35 // A11
+#define PC5   A11
 #define PA12  36
 #define PA11  37
 #define PB12  38
 // 39 is NC
 #define PB2   40
-#define PB1   41 // A12
+#define PB1   A12
 #define PB15  42
 #define PB14  43
 #define PB13  44
-#define PC4   45 // A13
-#define PA0   46 // A0
-#define PA1   47 // A1
-#define PA4   48 // A2
-#define PB0   49 // A3
-#define PC1   50 // A4
-#define PC0   51 // A5
+#define PC4   A13
+#define PA0   A0
+#define PA1   A1
+#define PA4   A2
+#define PB0   A3
+#define PC1   A4
+#define PC0   A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        60
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       14
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_F767ZI/variant.cpp
+++ b/variants/NUCLEO_F767ZI/variant.cpp
@@ -111,16 +111,29 @@ const PinName digitalPin[] = {
   PB_1,  //D84/A6
   PC_2,  //D85/A7
   PF_4,  //D86/A8
-  PF_6,  //D87/A9
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D88/A10 = D11
-  PA_6,  //D89/A11 = D12
-  PA_5,  //D90/A12 = D13
-  PA_4,  //D91/A13 = D24
-  PA_0,  //D92/A14 = D32
-  PF_8,  //D93/A15 = D61
-  PF_7,  //D94/A16 = D62
-  PF_9   //D95/A17 = D63
+  PF_6   //D87/A9
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  78, //A0
+  79, //A1
+  80, //A2
+  81, //A3
+  82, //A4
+  83, //A5
+  84, //A6
+  85, //A7
+  86, //A8
+  87, //A9
+  11, //A10
+  12, //A11
+  13, //A12
+  24, //A13
+  32, //A14
+  61, //A15
+  62, //A16
+  63  //A17
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_F767ZI/variant.h
+++ b/variants/NUCLEO_F767ZI/variant.h
@@ -37,9 +37,9 @@ extern "C" {
 #define PF13 7
 #define PF12 8
 #define PD15 9
-#define PD14 10 // A10
-#define PA7  11 // A11
-#define PA6  12 // A12
+#define PD14 A10
+#define PA7  A11
+#define PA6  A12
 #define PA5  13
 #define PB9  14
 #define PB8  15
@@ -51,7 +51,7 @@ extern "C" {
 #define PC7  21
 #define PB5  22
 #define PB3  23
-#define PA4  24 // A13
+#define PA4  A13
 #define PB4  25
 #define PB6  26
 #define PB2  27
@@ -59,7 +59,7 @@ extern "C" {
 #define PD12 29
 #define PD11 30
 #define PE2  31
-#define PA0  32 // A14
+#define PA0  A14
 #define PB0  33 // LED_GREEN
 #define PE0  34
 #define PB11 35
@@ -88,9 +88,9 @@ extern "C" {
 #define PE5  58
 #define PE6  59
 #define PE3  60
-#define PF8  61 // A15
-#define PF7  62 // A16
-#define PF9  63 // A17
+#define PF8  A15
+#define PF7  A16
+#define PF9  A17
 #define PG1  64
 #define PG0  65
 #define PD1  66
@@ -105,22 +105,21 @@ extern "C" {
 #define PC13 75 // USER_BTN
 #define PD9  76 // Serial Rx
 #define PD8  77 // Serial Tx
-#define PA3  78 // A0
-#define PC0  79 // A1
-#define PC3  80 // A2
-#define PF3  81 // A3
-#define PF5  82 // A4
-#define PF10 83 // A5
-#define PB1  84 // A6
-#define PC2  85 // A7
-#define PF4  86 // A8
-#define PF6  87 // A9
+#define PA3  A0
+#define PC0  A1
+#define PC3  A2
+#define PF3  A3
+#define PF5  A4
+#define PF10 A5
+#define PB1  A6
+#define PC2  A7
+#define PF4  A8
+#define PF6  A9
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        96
+#define NUM_DIGITAL_PINS        88
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       18
-#define NUM_ANALOG_FIRST        78
 
 // On-board LED pin number
 #define LED_BUILTIN             PB0

--- a/variants/NUCLEO_G071RB/variant.cpp
+++ b/variants/NUCLEO_G071RB/variant.cpp
@@ -87,12 +87,21 @@ const PinName digitalPin[] = {
   PA_4,  //D55/A2
   PB_1,  //D56/A3
   PB_11, //D57/A4
-  PB_12, //D58/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D59/A6 = D11
-  PA_6,  //D60/A7 = D12
-  PB_2,  //D61/A8 = D45
-  PB_10  //D62/A9 = D48
+  PB_12  //D58/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  53, //A0
+  54, //A1
+  55, //A2
+  56, //A3
+  57, //A4
+  58, //A5
+  11, //A6
+  12, //A7
+  45, //A8
+  48  //A9
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_G071RB/variant.h
+++ b/variants/NUCLEO_G071RB/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB0  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13 // LED
 #define PB9  14
 #define PB8  15
@@ -77,26 +77,25 @@ extern "C" {
 #define PA12 42
 #define PC1  43
 #define PC0  44
-#define PB2  45 // A8
+#define PB2  A8
 #define PB6  46
 #define PB15 47
-#define PB10 48 // A9
+#define PB10 A9
 #define PB13 49
 #define PA2  50
 #define PD8  51
 #define PD9  52
-#define PA0  53 // A0
-#define PA1  54 // A1
-#define PA4  55 // A2
-#define PB1  56 // A3
-#define PB11 57 // A4
-#define PB12 58 // A5
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB1  A3
+#define PB11 A4
+#define PB12 A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        63
+#define NUM_DIGITAL_PINS        59
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       10
-#define NUM_ANALOG_FIRST        53
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_L053R8/variant.cpp
+++ b/variants/NUCLEO_L053R8/variant.cpp
@@ -80,14 +80,23 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6  = D11
-  PA_6,  //D53/A7  = D12
-  PC_2,  //D54/A8  = D28
-  PC_3,  //D55/A9  = D29
-  PC_5,  //D56/A10 = D35
-  PC_4   //D57/A11 = D45
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  28, //A8
+  29, //A9
+  35, //A10
+  45  //A11
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_L053R8/variant.h
+++ b/variants/NUCLEO_L053R8/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13
 #define PB9  14
 #define PB8  15
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15 25
 #define PH0  26
 #define PH1  27
-#define PC2  28 // A8
-#define PC3  29 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -67,7 +67,7 @@ extern "C" {
 // CN10 Right side
 #define PC8  33
 #define PC6  34
-#define PC5  35 // A10
+#define PC5  A10
 #define PA12 36
 #define PA11 37
 #define PB12 38
@@ -77,19 +77,18 @@ extern "C" {
 #define PB15 42
 #define PB14 43
 #define PB13 44
-#define PC4  45 // A11
-#define PA0  46 // A0
-#define PA1  47 // A1
-#define PA4  48 // A2
-#define PB0  49 // A3
-#define PC1  50 // A4
-#define PC0  51 // A5
+#define PC4  A11
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        58
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_L073RZ/variant.cpp
+++ b/variants/NUCLEO_L073RZ/variant.cpp
@@ -92,14 +92,23 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4 - SB56 ON SB51 ON on the board
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6  = D11
-  PA_6,  //D53/A7  = D12
-  PC_2,  //D54/A8  = D28
-  PC_3,  //D55/A9  = D29
-  PC_5,  //D56/A10 = D35
-  PC_4   //D57/A11 = D45
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  28, //A8
+  29, //A9
+  35, //A10
+  45  //A11
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_L073RZ/variant.h
+++ b/variants/NUCLEO_L073RZ/variant.h
@@ -50,8 +50,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10 // PWM is not supported by D10 as no timer on PB6
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13
 #define PB9  14
 #define PB8  15
@@ -69,8 +69,8 @@ extern "C" {
 #define PC15 25
 #define PH0  26
 #define PH1  27
-#define PC2  28 // A8
-#define PC3  29 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -79,7 +79,7 @@ extern "C" {
 // CN10 Right side
 #define PC8  33
 #define PC6  34
-#define PC5  35 // A10
+#define PC5  A10
 #define PA12 36
 #define PA11 37
 #define PB12 38
@@ -89,20 +89,19 @@ extern "C" {
 #define PB15 42
 #define PB14 43
 #define PB13 44
-#define PC4  45 // A11
-#define PA0  46 // A0
-#define PA1  47 // A1
-#define PA4  48 // A2
-#define PB0  49 // A3
-#define PC1  50 // A4 - SB56 ON SB51 ON on the board!
-#define PC0  51 // A5
+#define PC4  A11
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4 // SB56 ON SB51 ON on the board!
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        58
+#define NUM_DIGITAL_PINS        52
 
 // This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_L152RE/variant.cpp
+++ b/variants/NUCLEO_L152RE/variant.cpp
@@ -80,19 +80,28 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6  = D11
-  PA_6,  //D53/A7  = D12
-  PC_2,  //D54/A8  = D28
-  PC_3,  //D55/A9  = D29
-  PC_5,  //D56/A10 = D35
-  PB_12, //D57/A11 = D38
-  PB_1,  //D58/A12 = D41
-  PB_15, //D59/A13 = D42
-  PB_14, //D60/A14 = D43
-  PB_13, //D61/A15 = D44
-  PC_4   //D62/A16 = D45
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  28, //A8
+  29, //A9
+  35, //A10
+  38, //A11
+  41, //A12
+  42, //A13
+  43, //A14
+  44, //A15
+  45  //A16
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_L152RE/variant.h
+++ b/variants/NUCLEO_L152RE/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13
 #define PB9  14
 #define PB8  15
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15 25
 #define PH0  26
 #define PH1  27
-#define PC2  28 // A8
-#define PC3  29 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -67,29 +67,28 @@ extern "C" {
 // CN10 Right side
 #define PC8  33
 #define PC6  34
-#define PC5  35 // A10
+#define PC5  A10
 #define PA12 36
 #define PA11 37
-#define PB12 38 // A11
+#define PB12 A11
 #define PB11 39
 #define PB2  40
-#define PB1  41 // A12
-#define PB15 42 // A13
-#define PB14 43 // A14
-#define PB13 44 // A15
-#define PC4  45 // A16
-#define PA0  46 // A0
-#define PA1  47 // A1
-#define PA4  48 // A2
-#define PB0  49 // A3
-#define PC1  50 // A4
-#define PC0  51 // A5
+#define PB1  A12
+#define PB15 A13
+#define PB14 A14
+#define PB13 A15
+#define PC4  A16
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        63
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       17
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_L452RE/variant.cpp
+++ b/variants/NUCLEO_L452RE/variant.cpp
@@ -80,13 +80,7 @@ const PinName digitalPin[] = {
   PA_4,  //D47/A2
   PB_0,  //D48/A3
   PC_1,  //D49/A4
-  PC_0,  //D50/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D51/A6  = D11
-  PA_6,  //D52/A7  = D12
-  PC_2,  //D53/A8  = D27
-  PC_3,  //D54/A9  = D28
-  PC_4   //D55/A10 = D44
+  PC_0   //D50/A5
 #else
   PA_10, //D0
   PA_9,  //D1
@@ -143,15 +137,32 @@ const PinName digitalPin[] = {
   PC_3,  //D47 // A2
   PC_2,  //D48 // A3
   PC_1,  //D49 // A4
-  PC_0,  //D50 // A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_4,  //D51 // A6  = D41
-  PA_5,  //D52 // A7  = D40
-  PA_6,  //D53 // A8  = D39
-  PA_7,  //D54 // A9  = D38
-  PB_0,  //D55 // A10 = D34
-  PB_1,  //D56 // A11 = D37
-  PC_4   //D57 // A12 = D42
+  PC_0   //D50 // A5
+#endif
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  45, //A0
+  46, //A1
+  47, //A2
+  48, //A3
+  49, //A4
+  50, //A5
+#ifdef ARDUINO_NUCLEO_L452RE
+  11, //A6
+  12, //A7
+  27, //A8
+  28, //A9
+  44  //A10
+#else
+  41, //A6
+  40, //A7
+  39, //A8
+  38, //A9
+  34, //A10
+  37, //A11
+  42  //A12
 #endif
 };
 

--- a/variants/NUCLEO_L452RE/variant.h
+++ b/variants/NUCLEO_L452RE/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13 // LED
 #define PB9  14
 #define PB8  15
@@ -56,8 +56,8 @@ extern "C" {
 #define PC15 24
 #define PH0  25
 #define PH1  26
-#define PC2  27 // A8
-#define PC3  28 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 29
 #define PD2  30
@@ -66,23 +66,23 @@ extern "C" {
 // CN10 Right side
 #define PC8  32
 #define PC6  33
-#define PC5  34 // A12
+#define PC5  34
 #define PA12 35
 #define PA11 36
 #define PB12 37
 #define PB11 38
 #define PB2  39
-#define PB1  40 // A11
+#define PB1  40
 #define PB15 41
 #define PB14 42
 #define PB13 43
-#define PC4  44 // A10
-#define PA0  45 // A0
-#define PA1  46 // A1
-#define PA4  47 // A2
-#define PB0  48 // A3
-#define PC1  49 // A4
-#define PC0  50 // A5
+#define PC4  A10
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 #else
 #define PA10 0
 #define PA9  1
@@ -123,39 +123,34 @@ extern "C" {
 #define PC8  31
 #define PC6  32
 #define PC5  33
-#define PB0  34 // A10
+#define PB0  A10
 #define PB11 35
 #define PB2  36
-#define PB1  37 // A11
-#define PA7  38 // A9
-#define PA6  39 // A8
-#define PA5  40 // A7
-#define PA4  41 // A6
-#define PC4  42 // A12
+#define PB1  A11
+#define PA7  A9
+#define PA6  A8
+#define PA5  A7
+#define PA4  A6
+#define PC4  A12
 #define PA3  43
 #define PA2  44
-#define PA0  45 // A0
-#define PA1  46 // A1
-#define PC3  47 // A2
-#define PC2  48 // A3
-#define PC1  49 // A4
-#define PC0  50 // A5
+#define PA0  A0
+#define PA1  A1
+#define PC3  A2
+#define PC2  A3
+#define PC1  A4
+#define PC0  A5
 #endif
 
 // This must be a literal
+#define NUM_DIGITAL_PINS        51
 #ifdef ARDUINO_NUCLEO_L452RE
-// This must be a literal
-#define NUM_DIGITAL_PINS        56
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       11
 #else
-// This must be a literal
-#define NUM_DIGITAL_PINS        58
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       13
 #endif
-
-#define NUM_ANALOG_FIRST        45
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_L476RG/variant.cpp
+++ b/variants/NUCLEO_L476RG/variant.cpp
@@ -80,14 +80,23 @@ const PinName digitalPin[] = {
   PA_4,  //D48/A2
   PB_0,  //D49/A3
   PC_1,  //D50/A4
-  PC_0,  //D51/A5
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_7,  //D52/A6  = D11
-  PA_6,  //D53/A7  = D12
-  PC_2,  //D54/A8  = D28
-  PC_3,  //D55/A9  = D29
-  PC_5,  //D56/A10 = D35
-  PC_4   //D57/A11 = D45
+  PC_0   //D51/A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  46, //A0
+  47, //A1
+  48, //A2
+  49, //A3
+  50, //A4
+  51, //A5
+  11, //A6
+  12, //A7
+  28, //A8
+  29, //A9
+  35, //A10
+  45  //A11
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_L476RG/variant.h
+++ b/variants/NUCLEO_L476RG/variant.h
@@ -38,8 +38,8 @@ extern "C" {
 #define PA9  8
 #define PC7  9
 #define PB6  10
-#define PA7  11 // A6
-#define PA6  12 // A7
+#define PA7  A6
+#define PA6  A7
 #define PA5  13 // LED
 #define PB9  14
 #define PB8  15
@@ -57,8 +57,8 @@ extern "C" {
 #define PC15 25
 #define PH0  26
 #define PH1  27
-#define PC2  28 // A8
-#define PC3  29 // A9
+#define PC2  A8
+#define PC3  A9
 // CN7 Right Side
 #define PC11 30
 #define PD2  31
@@ -67,7 +67,7 @@ extern "C" {
 // CN10 Right side
 #define PC8  33
 #define PC6  34
-#define PC5  35 // A10
+#define PC5  A10
 #define PA12 36
 #define PA11 37
 #define PB12 38
@@ -77,19 +77,18 @@ extern "C" {
 #define PB15 42
 #define PB14 43
 #define PB13 44
-#define PC4  45 // A11
-#define PA0  46 // A0
-#define PA1  47 // A1
-#define PA4  48 // A2
-#define PB0  49 // A3
-#define PC1  50 // A4
-#define PC0  51 // A5
+#define PC4  A11
+#define PA0  A0
+#define PA1  A1
+#define PA4  A2
+#define PB0  A3
+#define PC1  A4
+#define PC0  A5
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        58
+#define NUM_DIGITAL_PINS        52
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       12
-#define NUM_ANALOG_FIRST        46
 
 // On-board LED pin number
 #define LED_BUILTIN             13

--- a/variants/NUCLEO_L496ZG/variant.cpp
+++ b/variants/NUCLEO_L496ZG/variant.cpp
@@ -162,23 +162,37 @@ const PinName digitalPin[] = {
   PA_1,  //D115/A8
   PF_4,  //D116/A9
   PF_6,  //D117/A10
-  // Duplicated pins in order to be aligned with PinMapADC
-  PA_7, //D118/A11 = D11
-  PA_6, //D119/A12 = D12
-  PA_5, //D120/A13 = D13
-  PA_4, //D121/A14 = D20
-  PA_2, //D122/A15 = D26
-  PB_0, //D123/A16 = D29
-  PA_0, //D124/A17 = D32
-  PF_3, //D125/A18 = D49
-  PF_5, //D126/A19 = D50
-  PF_8, //D127/A20 = D61
-  PF_7, //D128/A21 = D62
-  PF_9, //D129/A22 = D63
-  PF_10,//D130/A23 = D91
 #ifdef ARDUINO_NUCLEO_L496ZG
-  PG_15 //D131
+  PG_15  //D118
 #endif
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  107, //A0
+  108, //A1
+  109, //A2
+  110, //A3
+  111, //A4
+  112, //A5
+  113, //A6
+  114, //A7
+  115, //A8
+  116, //A9
+  117, //A10
+  11,  //A11
+  12,  //A12
+  13,  //A13
+  20,  //A14
+  26,  //A15
+  29,  //A16
+  32,  //A17
+  49,  //A18
+  50,  //A19
+  61,  //A20
+  62,  //A21
+  63,  //A22
+  90   //A23
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_L496ZG/variant.h
+++ b/variants/NUCLEO_L496ZG/variant.h
@@ -52,28 +52,28 @@ extern "C" {
 #define PF12 8
 #define PD15 9
 #define PD14 10
-#define PA7  11 // A11
-#define PA6  12 // A12
-#define PA5  13 // A13
+#define PA7  A11
+#define PA6  A12
+#define PA5  A13
 #define PB9  14
 #define PB8  15
 #define PC6  16
 #define PB15 17
 #define PB13 18
 #define PB12 19
-#define PA4  20 // A14
+#define PA4  A14
 #define PB4  21
 #define PB5  22
 #define PB3  23
 // 24 is PA4 (20)
 // 25 is PB4 (21)
-#define PA2  26 // A15
+#define PA2  A15
 #define PB10 27
 #define PE15 28
-#define PB0  29 // A16
+#define PB0  A16
 #define PE12 30
 #define PE14 31
-#define PA0  32 // A17
+#define PA0  A17
 // 32 is PB0 (29)
 #define PE0  34
 #ifdef ARDUINO_NUCLEO_L496ZG
@@ -93,8 +93,8 @@ extern "C" {
 #define PC11 46
 #define PC12 47
 #define PD2  48
-#define PF3  49 // A18
-#define PF5  50 // A19
+#define PF3  A18
+#define PF5  A19
 #define PD7  51
 #define PD6  52
 #define PD5  53
@@ -105,9 +105,9 @@ extern "C" {
 #define PE5  58
 #define PE6  59
 #define PE3  60
-#define PF8  61 // A20
-#define PF7  62 // A21
-#define PF9  63 // A22
+#define PF8  A20
+#define PF7  A21
+#define PF9  A22
 #define PG1  64
 #define PG0  65
 #define PD1  66
@@ -135,7 +135,7 @@ extern "C" {
 #define PD12 87
 #define PD13 88
 #define PE1  89
-#define PF10 90 // A23
+#define PF10 A23
 #define PF11 91
 #define PG2  92
 #define PG3  93
@@ -153,20 +153,19 @@ extern "C" {
 #define PH0  105
 #define PH1  106
 // Analog pins
-#define PA3  107 // A0
-#define PC0  108 // A1
-#define PC3  109 // A2
-#define PC1  110 // A3
-#define PC4  111 // A4
-#define PC5  112 // A5
-#define PB1  113 // A6
-#define PC2  114 // A7
-#define PA1  115 // A8
-#define PF4  116 // A9
-#define PF6  117 // A10
-// 118 to 130 reserved fot A11 to A23
+#define PA3  A0
+#define PC0  A1
+#define PC3  A2
+#define PC1  A3
+#define PC4  A4
+#define PC5  A5
+#define PB1  A6
+#define PC2  A7
+#define PA1  A8
+#define PF4  A9
+#define PF6  A10
 #ifdef ARDUINO_NUCLEO_L496ZG
-#define PG15 131
+#define PG15 118
 #endif
 // PA13 and PA14 are shared with SWD signals connected to ST-LINK/V2-1.
 // If ST-LINK part is not cut, it is not recommended to use them as I/O pins.
@@ -175,13 +174,12 @@ extern "C" {
 
 // This must be a literal with the same value as PEND
 #ifdef ARDUINO_NUCLEO_L496ZG
-#define NUM_DIGITAL_PINS        132
+#define NUM_DIGITAL_PINS        119
 #else
-#define NUM_DIGITAL_PINS        131
+#define NUM_DIGITAL_PINS        118
 #endif
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       24
-#define NUM_ANALOG_FIRST        107
 
 // On-board LED pin number
 #define LED_BUILTIN             PC7

--- a/variants/NUCLEO_L4R5ZI/variant.cpp
+++ b/variants/NUCLEO_L4R5ZI/variant.cpp
@@ -159,18 +159,30 @@ const PinName digitalPin[] = {
   PC_5,  //D112/A5
   PB_1,  //D113/A6
   PC_2,  //D114/A7
-  PA_1,  //D115/A8
-  // Duplicated pins in order to be aligned with PinMapADC
-  PA_7,  //D116/A9 = D11
-  PA_6,  //D117/A10 = D12
-  PA_5,  //D118/A11 = D13
-  PA_4,  //D119/A12 = D20
-  PA_2,  //D120/A13 = D26
-  PB_0,  //D121/A14 = D29
-  PA_0,  //D122/A15 = D32
+  PA_1   //D115/A8
 #ifdef ARDUINO_NUCLEO_L4R5ZI
-  PG_15  //D123
+  , PG_15 //D116
 #endif
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  107, //A0
+  108, //A1
+  109, //A2
+  110, //A3
+  111, //A4
+  112, //A5
+  113, //A6
+  114, //A7
+  115, //A8
+  11, //A9
+  12, //A10
+  13, //A11
+  20, //A12
+  26, //A13
+  29, //A14
+  32  //A15
 };
 
 #ifdef __cplusplus

--- a/variants/NUCLEO_L4R5ZI/variant.h
+++ b/variants/NUCLEO_L4R5ZI/variant.h
@@ -52,28 +52,28 @@ extern "C" {
 #define PF12 8
 #define PD15 9
 #define PD14 10
-#define PA7  11 // A9
-#define PA6  12 // A10
-#define PA5  13 // A11
+#define PA7  A9
+#define PA6  A10
+#define PA5  A11
 #define PB9  14
 #define PB8  15
 #define PC6  16
 #define PB15 17
 #define PB13 18
 #define PB12 19
-#define PA4  20 // A12
+#define PA4  A12
 #define PB4  21
 #define PB5  22
 #define PB3  23
 // 24 is PA4 (20)
 // 25 is PB4 (21)
-#define PA2  26 // A13
+#define PA2  A13
 #define PB10 27
 #define PE15 28
-#define PB0  29 // A14
+#define PB0  A14
 #define PE12 30
 #define PE14 31
-#define PA0  32 // A15
+#define PA0  A15
 // 32 is PB0 (29)
 #define PE0  34
 #ifdef ARDUINO_NUCLEO_L4R5ZI
@@ -153,18 +153,18 @@ extern "C" {
 #define PH0  105
 #define PH1  106
 // Analog pins
-#define PA3  107 // A0
-#define PC0  108 // A1
-#define PC3  109 // A2
-#define PC1  110 // A3
-#define PC4  111 // A4
-#define PC5  112 // A5
-#define PB1  113 // A6
-#define PC2  114 // A7
-#define PA1  115 // A8
+#define PA3  A0
+#define PC0  A1
+#define PC3  A2
+#define PC1  A3
+#define PC4  A4
+#define PC5  A5
+#define PB1  A6
+#define PC2  A7
+#define PA1  A8
 // 116 to 122 reserved fot A9 to A15
 #ifdef ARDUINO_NUCLEO_L4R5ZI
-#define PG15 123
+#define PG15 116
 #endif
 // PA13 and PA14 are shared with SWD signals connected to ST-LINK/V2-1.
 // If ST-LINK part is not cut, it is not recommended to use them as I/O pins.
@@ -173,13 +173,12 @@ extern "C" {
 
 // This must be a literal
 #ifdef ARDUINO_NUCLEO_L4R5ZI
-#define NUM_DIGITAL_PINS        124
+#define NUM_DIGITAL_PINS        117
 #else
-#define NUM_DIGITAL_PINS        123
+#define NUM_DIGITAL_PINS        116
 #endif
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       16
-#define NUM_ANALOG_FIRST        107
 
 // On-board LED pin number
 #define LED_BUILTIN             PC7

--- a/variants/RUMBA32_F446VE/variant.cpp
+++ b/variants/RUMBA32_F446VE/variant.cpp
@@ -103,16 +103,18 @@ const PinName digitalPin[] = {
   PE_12, //D76
   PE_13, //D77
   PE_14, //D78
-  PE_15, //D79
+  PE_15  //D79
+};
 
-  //Duplicated ADC Pins
-  PA_3,  //D80/A0
-  PA_4,  //D81/A1
-  PC_0,  //D82/A2
-  PC_1,  //D83/A3
-  PC_2,  //D84/A4
-  PC_3,  //D85/A5
-  PC_4   //D86/A6
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  3,  //A0
+  4,  //A1
+  32, //A2
+  33, //A3
+  34, //A4
+  35, //A5
+  36  //A6
 };
 
 #ifdef __cplusplus

--- a/variants/RUMBA32_F446VE/variant.h
+++ b/variants/RUMBA32_F446VE/variant.h
@@ -30,8 +30,8 @@ extern "C" {
 #define PA0   0  //D0
 #define PA1   1  //D1
 #define PA2   2  //D2
-#define PA3   3  //D3
-#define PA4   4  //D4
+#define PA3   A0 //D3
+#define PA4   A1 //D4
 #define PA5   5  //D5
 #define PA6   6  //D6
 #define PA7   7  //D7
@@ -59,11 +59,11 @@ extern "C" {
 #define PB13  29 //D29
 #define PB14  30 //D30
 #define PB15  31 //D31
-#define PC0   32 //D32
-#define PC1   33 //D33
-#define PC2   34 //D34
-#define PC3   35 //D35
-#define PC4   36 //D36
+#define PC0   A2 //D32
+#define PC1   A3 //D33
+#define PC2   A4 //D34
+#define PC3   A5 //D35
+#define PC4   A6 //D36
 #define PC5   37 //D37
 #define PC6   38 //D38
 #define PC7   39 //D39
@@ -108,11 +108,10 @@ extern "C" {
 #define PE14  78 //D78
 #define PE15  79 //D79
 
-// This must be a literal with the same value as PEND
-#define NUM_DIGITAL_PINS        87
+// This must be a literal
+#define NUM_DIGITAL_PINS        80
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       7
-#define NUM_ANALOG_FIRST        80
 
 // PWM resolution
 #define PWM_FREQUENCY           20000 // >= 20 Khz => inaudible noise for fans

--- a/variants/VAKE_F446VE/variant.cpp
+++ b/variants/VAKE_F446VE/variant.cpp
@@ -107,14 +107,17 @@ const PinName digitalPin[] = {
   PA_4,
   PB_0,
   PC_1,
-  PC_0,
-  // Duplicated pins in order to be aligned with PinMap_ADC
-  PA_3,
-  PA_2,
-  PC_1,
-  PC_0,
-  PC_2,
-  PC_3,
+  PC_0
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInPin[] = {
+  0,  //A0
+  1,  //A1
+  82, //A2
+  83, //A3
+  28, //A4
+  29  //A5
 };
 
 #ifdef __cplusplus

--- a/variants/VAKE_F446VE/variant.h
+++ b/variants/VAKE_F446VE/variant.h
@@ -27,8 +27,8 @@ extern "C" {
  *        Pins
  *----------------------------------------------------------------------------*/
 
-#define PA3   0 // Z_PROBE_A    ADC
-#define PA2   1 // PWRMON ADC   ADC
+#define PA3   A0 // Z_PROBE_A    ADC
+#define PA2   A1 // PWRMON ADC   ADC
 #define PA10  2 // USART1_RX
 #define PB3   3 // E1_DIAG
 #define PB5   4 // N.C.
@@ -55,8 +55,8 @@ extern "C" {
 #define PC15  25 // E2_CS
 #define PH0   26 // OSC_IN
 #define PH1   27 // OSC_OUT
-#define PC2   28 // THERM2_ADC  ADC
-#define PC3   29 // THERM3_ADC  ADC
+#define PC2   A4 // THERM2_ADC  ADC
+#define PC3   A5 // THERM3_ADC  ADC
 #define PC11  30 // LCD_RS
 #define PD2   31 // LCD_D6
 #define PC9   32 // BEEPER
@@ -109,14 +109,13 @@ extern "C" {
 #define PA1   79 // F2_PWM  or serial
 #define PA4   80 // Z_PROBE_D
 #define PB0   81 // E1_CS
-#define PC1   82 // THERM1_ADC  ADC
-#define PC0   83 // THERM0_ADC  ADC
+#define PC1   A2 // THERM1_ADC  ADC
+#define PC0   A3 // THERM0_ADC  ADC
 
 // This must be a literal
-#define NUM_DIGITAL_PINS        98
+#define NUM_DIGITAL_PINS        84
 // This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS       6
-#define NUM_ANALOG_FIRST        84
 
 // On-board LED pin number
 #define LED_BUILTIN             PB14

--- a/variants/board_template/variant.cpp
+++ b/variants/board_template/variant.cpp
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-// Pin number
+// Digital PinName array
 // This array allows to wrap Arduino pin number(Dx or x)
 // to STM32 PinName (PX_n)
 const PinName digitalPin[] = {
@@ -38,88 +38,30 @@ const PinName digitalPin[] = {
   P, //D13
   P, //D14
   P, //D15
-  P, //D16
-  P, //D17
-  P, //D18
-  P, //D19
-  P, //D20
-  P, //D21
-  P, //D22
-  P, //D23
-  P, //D24
-  P, //D25
-  P, //D26
-  P, //D27
-  P, //D28
-  P, //D29
-  P, //D30
-  P, //D31
-  P, //D32
-  P, //D33
-  P, //D34
-  P, //D35
-  P, //D36
-  P, //D37
-  P, //D38
-  P, //D39
-  P, //D40
-  P, //D41
-  P, //D42
-  P, //D43
-  P, //D44
-  P, //D45
-  P, //D46
-  P, //D47
-  P, //D48
-  P, //D49
-  P, //D50
-  P, //D51
-  P, //D52
-  P, //D53
-  P, //D54
-  P, //D55
-  P, //D56
-  P, //D57
-  P, //D58
-  P, //D59
-  P, //D60
-  P, //D61
-  P, //D62
-  P, //D63
-  P, //D64
-  P, //D65
-  P, //D66
-  P, //D67
-  P, //D68
-  P, //D69
-  P, //D70
-  P, //D71
-  P, //D72
-  P, //D73
-  P, //D74
-  P, //D75
-  P, //D76
-  P, //D77
-  P, //D78/A0
-  P, //D79/A1
-  P, //D80/A2
-  P, //D81/A3
-  P, //D82/A4
-  P, //D83/A5
-  P, //D84/A6
-  P, //D85/A7
-  P, //D86/A8
-  P, //D87/A9
+  P, //D16/A0
+  P, //D17/A1
+  P, //D18/A2
+  P, //D19/A3
+  P, //D20/A4
+  P, //D21/A5
+  // Required only if Ax pins are automaticaly defined using `NUM_ANALOG_FIRST`
+  // and have to be contiguous in this array
   // Duplicated pins in order to be aligned with PinMap_ADC
-  P, //D88/A10 = D
-  P, //D89/A11 = D
-  P, //D90/A12 = D
-  P, //D91/A13 = D
-  P, //D92/A14 = D
-  P, //D93/A15 = D
-  P, //D94/A16 = D
-  P  //D95/A17 = D
+  P, //D22/A6 = D
+  P, //D23/A7 = D
+  P  //D24/A8 = D
 };
+
+// If analog pins are not contiguous in the digitalPin array:
+// Add the analogInPin array without defining NUM_ANALOG_FIRST
+// Analog (Ax) pin number array
+// where x is the index to retrieve the digital pin number
+const uint32_t analogInPin[] = {
+  //PXn, //Ax = Dx
+  2, //A0 = Dx
+  8, //A1 = Dy
+  3  //A2 = Dz
+}
 
 #ifdef __cplusplus
 }
@@ -143,7 +85,7 @@ WEAK void SystemClock_Config(void)
   // available in src/main.c
   // or
   // copied from a STM32CubeYY project examples
-  // where 'YY' could be F0, F1, F2, F3, F4, F7, G0, G4, H7, L0, L1, L4, WB
+  // where 'YY' could be F0, F1, F2, F3, F4, F7, G0, G4, H7, L0, L1, L4, MP1, WB
 }
 
 #ifdef __cplusplus

--- a/variants/board_template/variant.h
+++ b/variants/board_template/variant.h
@@ -35,13 +35,17 @@ extern "C" {
 // !!! // x is PXn (y)
 // !!! Ex:
 // !!! ...
-// !!! #define PA4  20 // A14
+// !!! #define PA4  20 // A14 <-- if NUM_ANALOG_FIRST not defined
+// !!! or
+// !!! #define PA4  A14 // 20 <-- if NUM_ANALOG_FIRST defined
 // !!! #define PB4  21
 // !!! #define PB5  22
 // !!! #define PB3  23
 // !!! // 24 is PA4 (20)
 // !!! // 25 is PB4 (21)
-// !!! #define PA2  26 // A15
+// !!! #define PA2  26 // A15 <-- if NUM_ANALOG_FIRST not defined
+// !!! or
+// !!! #define PA2  A15 // 26 <-- if NUM_ANALOG_FIRST defined
 // !!! ...
 //#define PXn x
 
@@ -51,12 +55,10 @@ extern "C" {
 #define NUM_DIGITAL_PINS        0
 
 // Allow to define Arduino style alias for analog input pin number --> Ax
-// If no analog pin required then NUM_ANALOG_INPUTS and NUM_ANALOG_FIRST
-// could not be defined or set to respectively `0` and `NUM_DIGITAL_PINS`
-// All pins are digital, analog inputs are a subset of digital pins
-// and must be contiguous to be able to loop on each value
-// This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS
-// defined in pin_arduino.h
+// If no analog pin required then NUM_ANALOG_INPUTS could not be defined
+// or set to `0`
+// All pins are digital, analog inputs are a subset of digital pins.
+// This must be a literal
 // It is used with preprocessor tests (e.g. #if NUM_ANALOG_INPUTS > 3)
 // so an enum will not work.
 // !!!
@@ -64,9 +66,24 @@ extern "C" {
 // !!! defined in digitalPin[] array in variant.cpp
 // !!!
 #define NUM_ANALOG_INPUTS       0
-// Define digital pin number of the first analog input  (i.e. which digital pin is A0)
-// First analog pin value (A0) must be greater than or equal to NUM_ANALOG_INPUTS
+
+// They are 2 possibles way to define analog pins:
+//-------------------------------------------------------------------------------------------
+//   - If they are contiguous in the digitalPin array:
+//     Simply defined `NUM_ANALOG_FIRST` and all pins Ax will be automatically defined.
+//     It define the digital pin number of the first analog input  (i.e. which digital pin is A0)
+//     First analog pin value (A0) must be greater than or equal to NUM_ANALOG_INPUTS
+//     This must be a literal with a value less than or equal to MAX_ANALOG_INPUTS
+//     defined in pin_arduino.h
 #define NUM_ANALOG_FIRST        0
+//------------------------------------OR------------------------------------------------------
+//   - If they are not contiguous in the digitalPin array:
+//     Add an analogInPin array in the variant.cpp without defining NUM_ANALOG_FIRST
+//     In that case the defined PYn for analog pin have to define the Ax definition instead of
+//     index in digitalPin[] array:
+//     #define PA4  A14
+//-------------------------------------------------------------------------------------------
+
 
 // Below ADC and PWM definitions already done in the core
 // Could be redefined here if needed


### PR DESCRIPTION
This PR allows to define non contiguous analog pins.

Based on @MCUdude works.

~After several investigations, it is not possible to provide a generic way to define non contiguous analog pins.
This PR simply clean the analog pins definition~

Finally, found a way to fit all requirements.
