### PR TITLE
HardwareTimer: rework internal mapping of arduino API to HAL/LL API

### DIFF
--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -29,6 +29,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "timer.h"
+#include "stm32yyxx_ll_tim.h"
 
 #if defined(HAL_TIM_MODULE_ENABLED) && !defined(HAL_TIM_MODULE_ONLY)
 
@@ -83,7 +84,9 @@ class HardwareTimer {
     ~HardwareTimer();  // destructor
 
     void pause(void);  // Pause counter and all output channels
+    void pauseChannel(uint32_t channel); // Timer is still running but channel (output and interrupt) is disabled
     void resume(void); // Resume counter and all output channels
+    void resumeChannel(uint32_t channel); // Resume only one channel
 
     void setPrescaleFactor(uint32_t prescaler); // set prescaler register (which is factor value - 1)
     uint32_t getPrescaleFactor();
@@ -118,8 +121,7 @@ class HardwareTimer {
 
     void timerHandleDeinit();  // Timer deinitialization
 
-    // Refresh() can only be called after a 1st call to resume() to be sure timer is initialised.
-    // It is usefull while timer is running after some registers update
+    // Refresh() is usefull while timer is running after some registers update
     void refresh(void); // Generate update event to force all registers (Autoreload, prescaler, compare) to be taken into account
 
 
@@ -130,14 +132,15 @@ class HardwareTimer {
 
     // The following function(s) are available for more advanced timer options
     TIM_HandleTypeDef *getHandle();  // return the handle address for HAL related configuration
+
   private:
-    TIM_OC_InitTypeDef _channelOC[TIMER_CHANNELS];
-    TIM_IC_InitTypeDef _channelIC[TIMER_CHANNELS];
+    TimerModes_t  _ChannelMode[TIMER_CHANNELS];
     timerObj_t _timerObj;
     void (*callbacks[1 + TIMER_CHANNELS])(HardwareTimer *); //Callbacks: 0 for update, 1-4 for channels. (channel5/channel6, if any, doesn't have interrupt)
-
     int getChannel(uint32_t channel);
-    void resumeChannel(uint32_t channel);
+    int getLLChannel(uint32_t channel);
+    int getIT(uint32_t channel);
+    int getAssociatedChannel(uint32_t channel);
 #if defined(TIM_CCER_CC1NE)
     bool isComplementaryChannel[TIMER_CHANNELS];
 #endif

--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -81,7 +81,9 @@ static void timerTonePinInit(PinName p, uint32_t frequency, uint32_t duration)
 
   if (frequency <= MAX_FREQ) {
     if (frequency == 0) {
-      timerTonePinDeinit();
+      if (TimerTone != NULL) {
+        TimerTone->pause();
+      }
     } else {
       TimerTone_pinInfo.pin = p;
 
@@ -121,12 +123,13 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
 void noTone(uint8_t _pin, bool destruct)
 {
   PinName p = digitalPinToPinName(_pin);
-  if ((p != NC) && (TimerTone_pinInfo.pin == p)) {
-    timerTonePinDeinit();
-
-    if ((destruct) && (TimerTone != NULL)) {
+  if ((p != NC) && (TimerTone_pinInfo.pin == p) && (TimerTone != NULL)) {
+    if (destruct) {
+      timerTonePinDeinit();
       delete (TimerTone);
       TimerTone = NULL;
+    } else {
+      TimerTone->pause();
     }
   }
 }


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->
Rework HardwareTimer internal working. And add new API to pause/resume individual channel.
Main rework:
* `HAL_TIM_Base_Init()` is now called only once at object creation
* `HAL_TIM_xxx_ConfigChannel` is now done in `setMode()`
* `HAL_TIM_xxx_Start` is done in `resumeChannel()`
* use LL when possible
* Configuration are directly made through hardware register access (when possible),
  then remove useless attribute
* Add new API to pause only one channel (fixes #763):
```c
     pauseChannel(uint32_t channel);
     resumeChannel(uint32_t channel);
```
* integration of PR #767 Flexible interrupts handling

- [x] Update wiki when merged


