### PR TITLE
Added experimental support for BlackPill F411CE

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1009,6 +1009,14 @@ GenF4.menu.pnum.BLACKPILL_F401CC.build.board=BLACKPILL_F401CC
 GenF4.menu.pnum.BLACKPILL_F401CC.build.product_line=STM32F401xC
 GenF4.menu.pnum.BLACKPILL_F401CC.build.variant=PILL_F401XX
 
+# BlackPill F411CE - Works using PILL_F401XX variant, needs testing
+GenF4.menu.pnum.BLACKPILL_F411CE=BlackPill F411CE
+GenF4.menu.pnum.BLACKPILL_F411CE.upload.maximum_size=524288
+GenF4.menu.pnum.BLACKPILL_F411CE.upload.maximum_data_size=131072
+GenF4.menu.pnum.BLACKPILL_F411CE.build.board=BLACKPILL_F411CE
+GenF4.menu.pnum.BLACKPILL_F411CE.build.product_line=STM32F411xE
+GenF4.menu.pnum.BLACKPILL_F411CE.build.variant=PILL_F401XX
+
 # Core board F401RCT6
 GenF4.menu.pnum.CoreBoard_F401RC=Core board F401RCT6
 GenF4.menu.pnum.CoreBoard_F401RC.upload.maximum_size=262144


### PR DESCRIPTION
Added a new board to dropdown menu based on existing variant.
This is no breaking change.
Bugs are probably hiding somewhere because we are referencing a slightly different variant with the same layout to support this board.
Tests need to be done to see if everything is compatible.

I own two BlackPills F401CC and F411CE, both on the same PCB.
AliExpress link: https://www.aliexpress.com/item/4000069263843.html
The only difference seems to be 256K Flash + 64K RAM versus 512K Flash + 128K RAM.
Compiles, uploads and works for me over DFU with serial out.
