### PR TITLE
Moved from arm-none-eabi-gcc 8.2.1-1.7 to 9.2.1-1.1

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -17,7 +17,7 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
-compiler.path={runtime.tools.arm-none-eabi-gcc-8.2.1-1.7.path}/bin/
+compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-8.3.1-1.4.path}/bin/
 
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.c.cmd=arm-none-eabi-gcc

--- a/platform.txt
+++ b/platform.txt
@@ -17,7 +17,7 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
-compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-8.3.1-1.4.path}/bin/
+compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-9.2.1-1.1.path}/bin/
 
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.c.cmd=arm-none-eabi-gcc


### PR DESCRIPTION
Thanks to @ilg-ul,  arm-none-eabi-gcc packages are now available from:
https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack
Release [v9.2.1-1.1](https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/tag/v9.2.1-1.1)

Linked:
https://github.com/stm32duino/arm-none-eabi-gcc/issues/2