### PR TITLE
HardwareTimer: Fix STM32F1 specific gpio configuration in case of input

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -651,8 +651,17 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin)
 
   if (pin != NC) {
     if ((int)get_pwm_channel(pin) == timChannel) {
-      /* Configure PWM GPIO pins */
-      pinmap_pinout(pin, PinMap_PWM);
+#if defined(STM32F1xx)
+      if ((mode == TIMER_INPUT_CAPTURE_RISING) || (mode == TIMER_INPUT_CAPTURE_FALLING) \
+          || (mode == TIMER_INPUT_CAPTURE_BOTHEDGE) || (mode == TIMER_INPUT_FREQ_DUTY_MEASUREMENT)) {
+        // on F1 family, input alternate function must configure GPIO in input mode
+        pinMode(pin, INPUT);
+      } else
+#endif
+      {
+        /* Configure PWM GPIO pins */
+        pinmap_pinout(pin, PinMap_PWM);
+      }
     } else {
       // Pin doesn't match with timer output channels
       Error_Handler();


### PR DESCRIPTION
**Summary**
<!-- Summary of the PR -->
On F1 family, input alternate function must configure GPIO in input mode
(not in alternate function like other STM32 families).

**Closing issues**

Fixes #812
