### PR TITLE
Fix SPI pin matching check

### DIFF
--- a/libraries/SPI/src/utility/spi_com.c
+++ b/libraries/SPI/src/utility/spi_com.c
@@ -181,7 +181,7 @@ void spi_init(spi_t *obj, uint32_t speed, spi_mode_e mode, uint8_t msb)
   obj->spi = pinmap_merge_peripheral(spi_data, spi_cntl);
 
   // Are all pins connected to the same SPI instance?
-  if (obj->spi == NP) {
+  if (spi_data == NP || spi_cntl == NP || obj->spi == NP) {
     core_debug("ERROR: SPI pins mismatch\n");
     return;
   }


### PR DESCRIPTION
This looks up the SPI module corresponding to each of pins passed and
then uses `pinmap_merge_peripheral()` to merge this in a single pin. If
not all pins map to the same SPI module, this should abort.

The `pinmap_merge_peripheral` function returns NP to indicate a mismatch
between the passed peripherals. However, when one of the arguments is
already NP, this is not propagated into the function result, instead the
other argument is simplly returned.

In this case, the merging happens in two levels: First MISO and MOSI are
merged, then SCK and SS are merged and finally the merged results are
again merged. That means that if MISO and MISO mismatch, but SCK and SS
match (or the other way around), the NP returned due to the mismatch is
ignored and the final result is not NP, so no error is raised.

This changes the code to also check the intermediate merge results for
NP, to properly detect mismatches.


Note that the actual error message produced using `core_debug()` is disabled by default (which might need some additional work to somehow elegantly enable that), but this will at least make sure that the check in the code is correct.