### PR TITLE
HardwareTimer: set callback before enabling interrupt

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -848,13 +848,13 @@ void HardwareTimer::setInterruptPriority(uint32_t preemptPriority, uint32_t subP
   */
 void HardwareTimer::attachInterrupt(void (*callback)(HardwareTimer *))
 {
+  callbacks[0] = callback;
   if (callback != NULL) {
     // Clear flag before enabling IT
     __HAL_TIM_CLEAR_FLAG(&(_timerObj.handle), TIM_FLAG_UPDATE);
     // Enable update interrupt only if callback is valid
     __HAL_TIM_ENABLE_IT(&(_timerObj.handle), TIM_IT_UPDATE);
   }
-  callbacks[0] = callback;
 }
 
 /**
@@ -885,13 +885,13 @@ void HardwareTimer::attachInterrupt(uint32_t channel, void (*callback)(HardwareT
     Error_Handler();  // only channel 1..4 have an interrupt
   }
 
+  callbacks[channel] = callback;
   if (callback != NULL) {
     // Clear flag before enabling IT
     __HAL_TIM_CLEAR_FLAG(&(_timerObj.handle), interrupt);
     // Enable interrupt corresponding to channel, only if callback is valid
     __HAL_TIM_ENABLE_IT(&(_timerObj.handle), interrupt);
   }
-  callbacks[channel] = callback;
 }
 
 /**


### PR DESCRIPTION
**Summary**
HardwareTimer: set callback before enabling interrupt to avoid race condition.

Takes into account race condition remark from #806
