### PR TITLE
I2C: allow static redefinition of I2C buffer size

### DIFF
--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -61,7 +61,11 @@ extern "C" {
 #endif
 
 /* I2C Tx/Rx buffer size */
+#if !defined(I2C_TXRX_BUFFER_SIZE)
 #define I2C_TXRX_BUFFER_SIZE    32
+#elif (I2C_TXRX_BUFFER_SIZE >= 256)
+#error I2C buffer size cannot exceed 255
+#endif
 
 /* Redefinition of IRQ for F0/G0/L0 families */
 #if defined(STM32F0xx) || defined(STM32G0xx) || defined(STM32L0xx)


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->
I2C: allow static redefinition of I2C buffer size.
Default buffer size is still 32, but it is now possible to redefine compilation switch: I2C_TXRX_BUFFER_SIZE
It's maximum value is 255

Now it is possible to transfer up to 255 bytes for all following cases:
* Master read
* Master write
* Slave read
* Slave write

Warning: a bug in STM32 cube HAL currently prevents, in Master mode, to send/receive exactly 255 bytes.
Issue is tracked internally, and fix should come in later release.

Nevertheless, if required, it is possible to patch the STM32 cube HAL:
for example, when working on NUCLEO_L476RG in file stm32l4xx_hal_i2c.c (adapt file name to the STM32 familly you are working on), replace all occurrences of 
`if (hi2c->XferCount < MAX_NBYTE_SIZE)`
by
`if (hi2c->XferCount <= MAX_NBYTE_SIZE)`
