### PR TITLE
[I2C] Fix error reporting on I2C timeout

### DIFF
--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -813,7 +813,7 @@ i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address,
       }
 
       err = HAL_I2C_GetError(&(obj->handle));
-      if ((delta > I2C_TIMEOUT_TICK)
+      if ((delta >= I2C_TIMEOUT_TICK)
           || ((err & HAL_I2C_ERROR_TIMEOUT) == HAL_I2C_ERROR_TIMEOUT)) {
         ret = I2C_TIMEOUT;
       } else {
@@ -887,7 +887,7 @@ i2c_status_e i2c_master_read(i2c_t *obj, uint8_t dev_address, uint8_t *data, uin
     }
 
     err = HAL_I2C_GetError(&(obj->handle));
-    if ((delta > I2C_TIMEOUT_TICK)
+    if ((delta >= I2C_TIMEOUT_TICK)
         || ((err & HAL_I2C_ERROR_TIMEOUT) == HAL_I2C_ERROR_TIMEOUT)) {
       ret = I2C_TIMEOUT;
     } else {


### PR DESCRIPTION
This is related to: https://github.com/stm32duino/Arduino_Core_STM32/pull/748#pullrequestreview-343999545

When this timeout is triggered, I2C_OK was returned. This happens because in the
loop above, it checks for `(delta < I2C_TIMEOUT_TICK)`, so it breaks out of the
loop as soon as `delta == I2C_TIMEOUT_TICK`. Then, the if below checks for
`(delta > I2C_TIMEOUT_TICK)`, which is not yet false. Since the hardware reports
no errors either, I2C_OK was returned.

By using `>=` in the if rather than `>`, this is fixed and I2C_TIMEOUT is now
returned instead.

