### PR TITLE
Fix TIM1_IRQn definition when TIM10 is not defined

### DIFF
--- a/cores/arduino/stm32/timer.h
+++ b/cores/arduino/stm32/timer.h
@@ -51,8 +51,13 @@ extern "C" {
 #define TIM1_IRQn TIM1_UP_TIM16_IRQn
 #define TIM1_IRQHandler TIM1_UP_TIM16_IRQHandler
 #elif defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32F7xx)
+#if !defined (TIM10_BASE)
+#define TIM1_IRQn TIM1_UP_IRQn
+#define TIM1_IRQHandler TIM1_UP_IRQHandler
+#else
 #define TIM1_IRQn TIM1_UP_TIM10_IRQn
 #define TIM1_IRQHandler TIM1_UP_TIM10_IRQHandler
+#endif
 #elif defined(STM32H7xx) || defined(STM32MP1xx)
 #define TIM1_IRQn TIM1_UP_IRQn
 #define TIM1_IRQHandler TIM1_UP_IRQHandler


### PR DESCRIPTION
Fixes #878

