### PR TITLE
[CDC]: Do not claim AT-protocol in CDC interface descriptor

### DIFF
--- a/cores/arduino/stm32/usb/cdc/usbd_cdc.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc.c
@@ -190,7 +190,7 @@ __ALIGN_BEGIN uint8_t USBD_CDC_CfgHSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END = 
   0x01,   /* bNumEndpoints: One endpoints used */
   0x02,   /* bInterfaceClass: Communication Interface Class */
   0x02,   /* bInterfaceSubClass: Abstract Control Model */
-  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* bInterfaceProtocol: No specific protocol */
   0x00,   /* iInterface: */
 
   /*Header Functional Descriptor*/
@@ -285,7 +285,7 @@ __ALIGN_BEGIN uint8_t USBD_CDC_CfgFSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END = 
   0x01,   /* bNumEndpoints: One endpoints used */
   0x02,   /* bInterfaceClass: Communication Interface Class */
   0x02,   /* bInterfaceSubClass: Abstract Control Model */
-  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* bInterfaceProtocol: No specific protocol */
   0x00,   /* iInterface: */
 
   /*Header Functional Descriptor*/
@@ -375,7 +375,7 @@ __ALIGN_BEGIN uint8_t USBD_CDC_OtherSpeedCfgDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIG
   0x01,   /* bNumEndpoints: One endpoints used */
   0x02,   /* bInterfaceClass: Communication Interface Class */
   0x02,   /* bInterfaceSubClass: Abstract Control Model */
-  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* bInterfaceProtocol: No specific protocol */
   0x00,   /* iInterface: */
 
   /*Header Functional Descriptor*/


### PR DESCRIPTION
The CDC code presents itself as a virtual serial port. However, it also
sets the "bFunctionProtocol" value to 1, which means it supports
AT-commands, which is not actually the case. This might cause problems
with some software, such as ModemManager.

Originally, ModemManager would be very liberal with probing serial
devices, using a blacklist to prevent probing non-modems such as
Arduinos.

Since version 1.7.990, it has supported a "strict" mode where it tries to be
more restrained in what devices it probes. For CDC ACM devices, this
means it will only probe devices that claim to support AT-commands.
However, it also stopped applying the blacklist (intending to eventually
remove the blacklist), meaning it would end up probing these serial ports.

This new strict policy is not the upstream default, but is enabled in
Debian (since Buster) and Ubuntu (since bionic 18.04.2). Later versions
of ModemManager make an exception for single-port Serial devices making this
less of a problem, but best to also fix the descriptor.

For the equivalent change in the Arduino AVR core, see:
https://github.com/arduino/ArduinoCore-avr/pull/92
