### PR TITLE
USB-related improvements

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -15,7 +15,6 @@ menu.upload_method=Upload method
 
 Nucleo_144.name=Nucleo-144
 
-Nucleo_144.build.vid=0x0483
 Nucleo_144.build.core=arduino
 Nucleo_144.build.board=Nucleo_144
 Nucleo_144.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
@@ -162,7 +161,6 @@ Nucleo_144.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 
 Nucleo_64.name=Nucleo-64
 
-Nucleo_64.build.vid=0x0483
 Nucleo_64.build.core=arduino
 Nucleo_64.build.board=Nucleo_64
 Nucleo_64.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
@@ -423,7 +421,6 @@ Nucleo_64.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 
 Nucleo_32.name=Nucleo-32
 
-Nucleo_32.build.vid=0x0483
 Nucleo_32.build.core=arduino
 Nucleo_32.build.board=Nucleo_32
 Nucleo_32.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
@@ -517,7 +514,6 @@ Nucleo_32.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 
 Disco.name=Discovery
 
-Disco.build.vid=0x0483
 Disco.build.core=arduino
 Disco.build.board=Disco
 Disco.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
@@ -635,7 +631,6 @@ Disco.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 
 Eval.name=Eval
 
-Eval.build.vid=0x0483
 Eval.build.core=arduino
 Eval.build.board=Eval
 Eval.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
@@ -668,7 +663,6 @@ Eval.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 
 STM32MP1.name=STM32MP1 series coprocessor
 
-STM32MP1.build.vid=0x0483
 STM32MP1.build.core=arduino
 STM32MP1.build.board=STM32MP1
 STM32MP1.build.mcu=cortex-m4
@@ -756,7 +750,6 @@ GenF0.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 # Generic F1
 GenF1.name=Generic STM32F1 series
 
-GenF1.build.vid=0x0483
 GenF1.build.core=arduino
 GenF1.build.board=GenF1
 GenF1.build.mcu=cortex-m3
@@ -894,7 +887,6 @@ GenF1.menu.upload_method.dfuoMethod.build.bootloader_flags=-DBL_LEGACY_LEAF -DVE
 
 GenF3.name=Generic STM32F3 series
 
-GenF3.build.vid=0x0483
 GenF3.build.core=arduino
 GenF3.build.board=GenF3
 GenF3.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
@@ -936,7 +928,6 @@ GenF3.menu.upload_method.bmpMethod.upload.tool=bmp_upload
 
 GenF4.name=Generic STM32F4 series
 
-GenF4.build.vid=0x0483
 GenF4.build.core=arduino
 GenF4.build.board=GenF4
 GenF4.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
@@ -1123,7 +1114,6 @@ GenF4.menu.upload_method.hidMethod.build.bootloader_flags=-DBL_HID -DVECT_TAB_OF
 # Generic L0
 GenL0.name=Generic STM32L0 series
 
-GenL0.build.vid=0x0483
 GenL0.build.core=arduino
 GenL0.build.board=GenL0
 GenL0.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -D__CORTEX_SC=0
@@ -1172,7 +1162,6 @@ GenL0.menu.upload_method.bmpMethod.upload.tool=bmp_upload
 
 ESC_board.name=Electronic speed controllers
 
-ESC_board.build.vid=0x0483
 ESC_board.build.core=arduino
 ESC_board.build.board=FCE_board
 ESC_board.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
@@ -1209,7 +1198,6 @@ ESC_board.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 
 LoRa.name=LoRa boards
 
-LoRa.build.vid=0x0483
 LoRa.build.core=arduino
 LoRa.build.board=LoRa
 LoRa.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
@@ -1280,7 +1268,6 @@ LoRa.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 
 3dprinter.name=3D printer boards
 
-3dprinter.build.vid=0x0483
 3dprinter.build.core=arduino
 3dprinter.build.board=3dprinter
 3dprinter.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
@@ -1296,8 +1283,6 @@ LoRa.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.pnum.ARMED_V1.build.product_line=STM32F407xx
 3dprinter.menu.pnum.ARMED_V1.build.variant=ARMED_V1
 3dprinter.menu.pnum.ARMED_V1.build.cmsis_lib_gcc=arm_cortexM4lf_math
-3dprinter.menu.pnum.ARMED_V1.build.vid=0x0483
-3dprinter.menu.pnum.ARMED_V1.build.pid=0x5740
 
 # REMRAM_V1 board
 3dprinter.menu.pnum.REMRAM_V1=RemRam v1
@@ -1446,7 +1431,6 @@ LoRa.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 
 Genericflight.name=Generic flight controllers
 
-Genericflight.build.vid=0x0483
 Genericflight.build.core=arduino
 Genericflight.build.board=Genericflight
 Genericflight.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
@@ -1531,7 +1515,6 @@ Genericflight.menu.upload_method.dfuoMethod.build.bootloader_flags=-DBL_LEGACY_L
 
 Midatronics.name=Midatronics boards
 
-Midatronics.build.vid=0x0483
 Midatronics.build.core=arduino
 Midatronics.build.board=Midatronics
 Midatronics.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}

--- a/cores/arduino/stm32/usb/usbd_desc.c
+++ b/cores/arduino/stm32/usb/usbd_desc.c
@@ -135,8 +135,8 @@ __ALIGN_BEGIN uint8_t USBD_Class_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   HIBYTE(USBD_VID),           /* idVendor */
   LOBYTE(USBD_PID),           /* idProduct */
   HIBYTE(USBD_PID),           /* idProduct */
-  0x00,                       /* bcdDevice rel. 2.00 */
-  0x02,
+  0x00,                       /* bcdDevice rel. 0.00 */
+  0x00,
   USBD_IDX_MFC_STR,           /* Index of manufacturer string */
   USBD_IDX_PRODUCT_STR,       /* Index of product string */
   USBD_IDX_SERIAL_STR,        /* Index of serial number string */
@@ -159,8 +159,8 @@ __ALIGN_BEGIN uint8_t USBD_Class_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   HIBYTE(USBD_VID),           /* idVendor */
   LOBYTE(USBD_PID),           /* idProduct */
   HIBYTE(USBD_PID),           /* idProduct */
-  0x00,                       /* bcdDevice rel. 2.00 */
-  0x02,
+  0x00,                       /* bcdDevice rel. 0.00 */
+  0x00,
   USBD_IDX_MFC_STR,           /* Index of manufacturer string */
   USBD_IDX_PRODUCT_STR,       /* Index of product string */
   USBD_IDX_SERIAL_STR,        /* Index of serial number string */

--- a/cores/arduino/stm32/usb/usbd_desc.c
+++ b/cores/arduino/stm32/usb/usbd_desc.c
@@ -21,41 +21,75 @@
 #include "usbd_core.h"
 #include "usbd_desc.h"
 #include "utils.h"
+#include <variant.h>
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-#if USBD_VID == 0x2341
+
+/* USB VID and PID: Either both or neither must be specified. If not
+ * specified, default to the ST VID, with a PID assigned to HID or a PID
+ * assigned to CDC devices. */
+#if !USBD_PID && !USBD_VID
+// Undef the default zero values
+#undef USBD_PID
+#undef USBD_VID
+// Define default values, based on the USB class used
+#define USBD_VID 0x0483
+#if defined(USBD_USE_HID_COMPOSITE)
+#define USBD_PID                      0x5711
+#elif defined(USBD_USE_CDC)
+#define USBD_PID                      0x5740
+#endif
+#endif /* !USBD_PID && !USBD_VID */
+
+#if !USBD_VID || !USBD_PID
+#error "USB VID or PID not specified"
+#endif
+
+/* Manufacturer string: Use the specified string if specified, guess
+   based on VID otherwise */
+#if defined(USB_MANUFACTURER_STRING)
+#define USBD_MANUFACTURER_STRING USB_MANUFACTURER_STRING
+#elif USBD_VID == 0x2341
 #define USBD_MANUFACTURER_STRING "Arduino LLC"
 #elif USBD_VID == 0x2A03
 #define USBD_MANUFACTURER_STRING "Arduino srl"
 #elif USBD_VID == 0x0483
 #define USBD_MANUFACTURER_STRING "STMicroelectronics"
-#elif !defined(USB_MANUFACTURER)
-// Fall through to unknown if no manufacturer name was provided in a macro
-#define USBD_MANUFACTURER_STRING "Unknown"
 #else
-#define USBD_MANUFACTURER_STRING USB_MANUFACTURER
+#define USBD_MANUFACTURER_STRING "Unknown"
 #endif
+
 #define USBD_LANGID_STRING            0x409   /* 1033 US.S English */
 
+/* Product string: Use the specified string if specified, construct
+   based on BOARD_NAME and class otherwise. */
+#if defined(USB_PRODUCT_STRING)
+#define USBD_CLASS_PRODUCT_HS_STRING        USB_PRODUCT_STRING
+#define USBD_CLASS_PRODUCT_FS_STRING        USB_PRODUCT_STRING
+#elif defined(USBD_USE_HID_COMPOSITE)
+#define USBD_CLASS_PRODUCT_HS_STRING        CONCATS(BOARD_NAME, "HID in HS Mode")
+#define USBD_CLASS_PRODUCT_FS_STRING        CONCATS(BOARD_NAME, "HID in FS Mode")
+#elif defined(USBD_USE_CDC)
+#define USBD_CLASS_PRODUCT_HS_STRING        CONCATS(BOARD_NAME, "CDC in HS Mode")
+#define USBD_CLASS_PRODUCT_FS_STRING        CONCATS(BOARD_NAME, "CDC in FS Mode")
+#else
+#define USBD_CLASS_PRODUCT_HS_STRING        CONCATS(BOARD_NAME, "in HS Mode")
+#define USBD_CLASS_PRODUCT_FS_STRING        CONCATS(BOARD_NAME, "in FS Mode")
+#endif
+
 #ifdef USBD_USE_HID_COMPOSITE
-#define USBD_CLASS_PID                      0x5711
-#define USBD_CLASS_PRODUCT_HS_STRING        CONCATS(USB_PRODUCT, "HID in HS Mode")
-#define USBD_CLASS_PRODUCT_FS_STRING        CONCATS(USB_PRODUCT, "HID in FS Mode")
-#define USBD_CLASS_CONFIGURATION_HS_STRING  CONCATS(USB_PRODUCT, "HID Config")
-#define USBD_CLASS_INTERFACE_HS_STRING      CONCATS(USB_PRODUCT, "HID Interface")
-#define USBD_CLASS_CONFIGURATION_FS_STRING  CONCATS(USB_PRODUCT, "HID Config")
-#define USBD_CLASS_INTERFACE_FS_STRING      CONCATS(USB_PRODUCT, "HID Interface")
+#define USBD_CLASS_CONFIGURATION_HS_STRING  CONCATS(BOARD_NAME, "HID Config")
+#define USBD_CLASS_INTERFACE_HS_STRING      CONCATS(BOARD_NAME, "HID Interface")
+#define USBD_CLASS_CONFIGURATION_FS_STRING  CONCATS(BOARD_NAME, "HID Config")
+#define USBD_CLASS_INTERFACE_FS_STRING      CONCATS(BOARD_NAME, "HID Interface")
 #endif /* USBD_USE_HID_COMPOSITE */
 
 #ifdef USBD_USE_CDC
-#define USBD_CLASS_PID                      0x5740
-#define USBD_CLASS_PRODUCT_HS_STRING        CONCATS(USB_PRODUCT, "CDC in HS Mode")
-#define USBD_CLASS_PRODUCT_FS_STRING        CONCATS(USB_PRODUCT, "CDC in FS Mode")
-#define USBD_CLASS_CONFIGURATION_HS_STRING  CONCATS(USB_PRODUCT, "CDC Config")
-#define USBD_CLASS_INTERFACE_HS_STRING      CONCATS(USB_PRODUCT, "CDC Interface")
-#define USBD_CLASS_CONFIGURATION_FS_STRING  CONCATS(USB_PRODUCT, "CDC Config")
-#define USBD_CLASS_INTERFACE_FS_STRING      CONCATS(USB_PRODUCT, "CDC Interface")
+#define USBD_CLASS_CONFIGURATION_HS_STRING  CONCATS(BOARD_NAME, "CDC Config")
+#define USBD_CLASS_INTERFACE_HS_STRING      CONCATS(BOARD_NAME, "CDC Interface")
+#define USBD_CLASS_CONFIGURATION_FS_STRING  CONCATS(BOARD_NAME, "CDC Config")
+#define USBD_CLASS_INTERFACE_FS_STRING      CONCATS(BOARD_NAME, "CDC Interface")
 #endif /* USBD_USE_CDC */
 
 /* Private macro -------------------------------------------------------------*/
@@ -99,8 +133,8 @@ __ALIGN_BEGIN uint8_t USBD_Class_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   USB_MAX_EP0_SIZE,           /* bMaxPacketSize */
   LOBYTE(USBD_VID),           /* idVendor */
   HIBYTE(USBD_VID),           /* idVendor */
-  LOBYTE(USBD_CLASS_PID),           /* idVendor */
-  HIBYTE(USBD_CLASS_PID),           /* idVendor */
+  LOBYTE(USBD_PID),           /* idProduct */
+  HIBYTE(USBD_PID),           /* idProduct */
   0x00,                       /* bcdDevice rel. 2.00 */
   0x02,
   USBD_IDX_MFC_STR,           /* Index of manufacturer string */
@@ -123,8 +157,8 @@ __ALIGN_BEGIN uint8_t USBD_Class_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   USB_MAX_EP0_SIZE,           /* bMaxPacketSize */
   LOBYTE(USBD_VID),           /* idVendor */
   HIBYTE(USBD_VID),           /* idVendor */
-  LOBYTE(USBD_CLASS_PID),           /* idVendor */
-  HIBYTE(USBD_CLASS_PID),           /* idVendor */
+  LOBYTE(USBD_PID),           /* idProduct */
+  HIBYTE(USBD_PID),           /* idProduct */
   0x00,                       /* bcdDevice rel. 2.00 */
   0x02,
   USBD_IDX_MFC_STR,           /* Index of manufacturer string */

--- a/platform.txt
+++ b/platform.txt
@@ -69,11 +69,20 @@ compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.5.1.path}/CMSIS/DSP/Lib/GCC
 
 # USB Flags
 # ---------
-build.usb_flags=-DUSBCON {build.usb_speed} -DUSBD_VID={build.vid} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT="{build.board}"' -DHAL_PCD_MODULE_ENABLED 
+build.usb_flags=-DUSBCON {build.usb_speed} -DUSBD_VID={build.vid} -DUSBD_PID={build.pid} -DHAL_PCD_MODULE_ENABLED
 
-# Default usb manufacturer will be replaced at compile time using
-# numeric vendor ID if available or by board's specific value.
-build.usb_manufacturer="Unknown"
+# Specify defaults for vid/pid, since an empty value is impossible to
+# detect in the preprocessor, but a 0 can be checked for.
+# Boards should specify either both, or neither of these.
+build.vid=0
+build.pid=0
+
+# To customize the USB manufacturer or product string, must add defines
+# for them, e.g.:
+#    some_board.build.extra_flags='-DUSB_MANUFACTURER_STRING="My Company"' '-DUSB_PRODUCT_STRING="My Product"'
+# This cannot be done using build variables and specifying the -D
+# options here, since then the default would be a defined, but empty macro
+# that the preprocessor cannot detect.
 
 # Build information's
 build.info.flags=-D{build.series} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DBOARD_NAME="{build.board}"


### PR DESCRIPTION
The main goal of this PR is to make configuration of USB details (VID, PID, manufacturer and product strings) more flexible, allowing (third-party) board.txt files more control over how a board identifies on the USB side.

A related minor change is to set the device version number to 0, since this is a value that should really be configured by the sketch (and until then, should not have a meaningful value).

See the commit messages for details.