### PR TITLE
Servo: enlarge pin number range to [0..255]

### DIFF
--- a/libraries/Servo/src/Servo.h
+++ b/libraries/Servo/src/Servo.h
@@ -90,8 +90,8 @@
 #if !defined(ARDUINO_ARCH_STM32F4)
 
 typedef struct  {
-  uint8_t nbr        : 6 ;            // a pin number from 0 to 63
-  uint8_t isActive   : 1 ;            // true if this channel is enabled, pin not pulsed if false
+  uint8_t nbr;            // a pin number from 0 to 255
+  uint8_t isActive;       // true if this channel is enabled, pin not pulsed if false
 } ServoPin_t   ;
 
 typedef struct {


### PR DESCRIPTION
**Summary**

Servo: enlarge pin number range to [0..255]
On some configurations, pin number is larger than 63:
Example: NUCLEO_F429ZI PA0 = 103


Fixes issue 
https://www.stm32duino.com/viewtopic.php?f=7&t=134
