### PR TITLE
HardwareTimer: Allow setting preload enable bits

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -678,6 +678,28 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin)
 }
 
 /**
+  * @brief  Enable or disable preloading for overflow value
+  *         When disabled, changes to the overflow value take effect
+  *         immediately. When enabled, the value takes effect only at
+  *         the next update event (typically the next overflow).
+  *
+  *         Note that the capture/compare register has its own preload
+  *         enable bit, which is independent and enabled in PWM modes
+  *         and disabled otherwise. If you need more control of that
+  *         bit, you can use the HAL functions directly.
+  * @param  value: true to enable preloading, false to disable
+  * @retval None
+  */
+void HardwareTimer::setPreloadEnable(bool value)
+{
+  if (value) {
+    LL_TIM_EnableARRPreload(_timerObj.handle.Instance);
+  } else {
+    LL_TIM_DisableARRPreload(_timerObj.handle.Instance);
+  }
+}
+
+/**
   * @brief  Set channel Capture/Compare register
   * @param  channel: Arduino channel [1..4]
   * @param  compare: compare value depending on format

--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -93,7 +93,7 @@ HardwareTimer::HardwareTimer(TIM_TypeDef *instance)
 #if defined(TIM_RCR_REP)
   _timerObj.handle.Init.RepetitionCounter = 0;
 #endif
-  _timerObj.handle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+  _timerObj.handle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
   HAL_TIM_Base_Init(&(_timerObj.handle));
 }
 
@@ -442,6 +442,11 @@ uint32_t HardwareTimer::getOverflow(TimerFormat_t format)
 
 /**
   * @brief  Set overflow (rollover)
+  *
+  *         Note that by default, the new value will not be applied
+  *         immediately, but become effective at the next update event
+  *         (usually the next timer overflow). See setPreloadEnable()
+  *         for controlling this behaviour.
   * @param  overflow: depend on format parameter
   * @param  format of overflow parameter. If ommited default format is Tick
   *           TICK_FORMAT:     overflow is the number of tick for overflow
@@ -680,8 +685,9 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin)
 /**
   * @brief  Enable or disable preloading for overflow value
   *         When disabled, changes to the overflow value take effect
-  *         immediately. When enabled, the value takes effect only at
-  *         the next update event (typically the next overflow).
+  *         immediately. When enabled (the default), the value takes
+  *         effect only at the next update event (typically the next
+  *         overflow).
   *
   *         Note that the capture/compare register has its own preload
   *         enable bit, which is independent and enabled in PWM modes

--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -112,7 +112,6 @@ class HardwareTimer {
     void setPWM(uint32_t channel, PinName pin, uint32_t frequency, uint32_t dutycycle, void (*PeriodCallback)(HardwareTimer *) = NULL, void (*CompareCallback)(HardwareTimer *) = NULL); // Set all in one command freq in HZ, Duty in percentage. Including both interrup.
     void setPWM(uint32_t channel, uint32_t pin, uint32_t frequency, uint32_t dutycycle, void (*PeriodCallback)(HardwareTimer *) = NULL, void (*CompareCallback)(HardwareTimer *) = NULL);
 
-
     void setCount(uint32_t val, TimerFormat_t format = TICK_FORMAT); // set timer counter to value 'val' depending on format provided
     uint32_t getCount(TimerFormat_t format = TICK_FORMAT);  // return current counter value of timer depending on format provided
 
@@ -120,7 +119,6 @@ class HardwareTimer {
     void setMode(uint32_t channel, TimerModes_t mode, uint32_t pin);
 
     uint32_t getCaptureCompare(uint32_t channel, TimerCompareFormat_t format = TICK_COMPARE_FORMAT); // return Capture/Compare register value of specified channel depending on format provided
-
     void setCaptureCompare(uint32_t channel, uint32_t compare, TimerCompareFormat_t format = TICK_COMPARE_FORMAT);  // set Compare register value of specified channel depending on format provided
 
     void setInterruptPriority(uint32_t preemptPriority, uint32_t subPriority); // set interrupt priority
@@ -138,7 +136,6 @@ class HardwareTimer {
 
     // Refresh() is usefull while timer is running after some registers update
     void refresh(void); // Generate update event to force all registers (Autoreload, prescaler, compare) to be taken into account
-
 
     uint32_t getTimerClkFreq();  // return timer clock frequency in Hz.
 

--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -118,6 +118,8 @@ class HardwareTimer {
     void setMode(uint32_t channel, TimerModes_t mode, PinName pin = NC); // Configure timer channel with specified mode on specified pin if available
     void setMode(uint32_t channel, TimerModes_t mode, uint32_t pin);
 
+    void setPreloadEnable(bool value); // Configure overflow preload enable setting
+
     uint32_t getCaptureCompare(uint32_t channel, TimerCompareFormat_t format = TICK_COMPARE_FORMAT); // return Capture/Compare register value of specified channel depending on format provided
     void setCaptureCompare(uint32_t channel, uint32_t compare, TimerCompareFormat_t format = TICK_COMPARE_FORMAT);  // set Compare register value of specified channel depending on format provided
 

--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -146,11 +146,6 @@ class HardwareTimer {
 
     // The following function(s) are available for more advanced timer options
     TIM_HandleTypeDef *getHandle();  // return the handle address for HAL related configuration
-
-  private:
-    TimerModes_t  _ChannelMode[TIMER_CHANNELS];
-    timerObj_t _timerObj;
-    void (*callbacks[1 + TIMER_CHANNELS])(HardwareTimer *); //Callbacks: 0 for update, 1-4 for channels. (channel5/channel6, if any, doesn't have interrupt)
     int getChannel(uint32_t channel);
     int getLLChannel(uint32_t channel);
     int getIT(uint32_t channel);
@@ -158,6 +153,10 @@ class HardwareTimer {
 #if defined(TIM_CCER_CC1NE)
     bool isComplementaryChannel[TIMER_CHANNELS];
 #endif
+  private:
+    TimerModes_t  _ChannelMode[TIMER_CHANNELS];
+    timerObj_t _timerObj;
+    void (*callbacks[1 + TIMER_CHANNELS])(HardwareTimer *); //Callbacks: 0 for update, 1-4 for channels. (channel5/channel6, if any, doesn't have interrupt)
 };
 
 extern timerObj_t *HardwareTimer_Handle[TIMER_NUM];


### PR DESCRIPTION
This PR adds methods to HardwareTimer to change the "preload" setting of the overflow/ARR and CC registers. By enabling preload, updates to these registers can be made at overflow time rather than halfway a period, which can improve the output waveform, as well as prevent missing an overflow event (when decreasing the overflow value to below the current timer value).

These methods are fairly simple and use the LL_TIM HAL functions. I originally implemented this using the higher-level `TIM_Base_SetConfig` but then found that the prescaler was updated using LL_TIM functions, which did not update `_timerObj.handle.Init`, so `TIM_Base_SetConfig` would then revert to a 0 prescaler. So, following the example of `setPrescalerFactor`, these new methods just write to the registers directly with the LL_TIM functions (which are also more specific, `TIM_Base_SetConfig` would update a few different registers in addition to the preload enable bit).