### PR TITLE
analogRead: don't set ADC common register when ADC doesn't support it.

### DIFF
--- a/libraries/SrcWrapper/src/stm32/analog.cpp
+++ b/libraries/SrcWrapper/src/stm32/analog.cpp
@@ -1006,8 +1006,9 @@ uint16_t adc_read_value(PinName pin, uint32_t resolution)
     return 0;
   }
 
-  LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(AdcHandle.Instance), LL_ADC_PATH_INTERNAL_NONE);
-
+  if (__LL_ADC_COMMON_INSTANCE(AdcHandle.Instance) != 0U) {
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(AdcHandle.Instance), LL_ADC_PATH_INTERNAL_NONE);
+  }
   return uhADCxConvertedValue;
 }
 #endif /* HAL_ADC_MODULE_ENABLED && !HAL_ADC_MODULE_ONLY*/


### PR DESCRIPTION
**Summary**
analogRead: don't set ADC common register when ADC doesn't support it.

STM32F103ZE: ADC3 doesn't support common settings.
__LL_ADC_COMMON_INSTANCE(ADC3) returns 0

Solve issue:
https://www.stm32duino.com/viewtopic.php?f=62&t=46&hilit=adc3&start=30