### PR TITLE
Update variant.cpp

### DIFF
--- a/variants/ELEKTOR_F072C8/variant.cpp
+++ b/variants/ELEKTOR_F072C8/variant.cpp
@@ -66,7 +66,7 @@ const PinName digitalPin[] = {
   //Analog Pins
   PA_0,  //D27, A0
   PA_1,  //D28, A1
-  PA_3,  //D29, A2
+  PA_2,  //D29, A2
   PA_3,  //D30, A3
   PA_4,  //D31, A4
   PA_5,  //D32, A5


### PR DESCRIPTION
Removed entry of PA_3 for where PA_2 should be. Makes PA_2 now work



**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ x ] Fixes broken definition for PA_2 in variant Elektor LoRa Node Core F072

Due to a typo in variant.cpp PA_2 is not working and may lead also to undefined behaviour
