### PR TITLE
EEPROM hardfault: eeprom_buffer should be 8 bytes aligned

### DIFF
--- a/libraries/SrcWrapper/src/stm32/stm32_eeprom.c
+++ b/libraries/SrcWrapper/src/stm32/stm32_eeprom.c
@@ -142,7 +142,7 @@ static inline uint32_t get_flash_end(void)
 #endif
 #endif /* FLASH_BASE_ADDRESS */
 
-static uint8_t eeprom_buffer[E2END + 1] = {0};
+static uint8_t eeprom_buffer[E2END + 1] __attribute__((aligned(8))) = {0};
 
 /**
   * @brief  Function reads a byte from emulated eeprom (flash)


### PR DESCRIPTION
**Summary**
EEPROM hardfault: eeprom_buffer should be 8 bytes aligned

Due to some cast on (uint64_t *) of eeprom_buffer,
compiler may use asm instruction LDRD which required an alignment:
4 bytes on Armv7 architecture,
and 8 bytes (depending on SCTLR.U) on Armv6 architecture.
To fit to all cases, alignment is made on 8 bytes.

Fixes #930