### PR TITLE
EEPROM emulation: wrong flash sector used for some F7 variants

### DIFF
--- a/variants/NUCLEO_F767ZI/variant.h
+++ b/variants/NUCLEO_F767ZI/variant.h
@@ -147,6 +147,11 @@ extern "C" {
 #define HAL_DAC_MODULE_ENABLED
 #define HAL_ETH_MODULE_ENABLED
 
+// Last Flash sector used for EEPROM emulation, address/sector depends on single/dual bank configuration.
+// By default 2MB single bank
+#define FLASH_BASE_ADDRESS  0x081C0000
+#define FLASH_DATA_SECTOR   11
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/REMRAM_V1/variant.h
+++ b/variants/REMRAM_V1/variant.h
@@ -172,6 +172,11 @@ extern "C"
 /* HAL configuration */
 #define HSE_VALUE               24000000U
 
+// Last Flash sector used for EEPROM emulation, address/sector depends on single/dual bank configuration.
+// By default 2MB single bank
+#define FLASH_BASE_ADDRESS  0x081C0000
+#define FLASH_DATA_SECTOR   11
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
**Summary**
EEPROM emulation: wrong flash sector used for some STM32F7 variants

Default configuration for F76xx and F77xx chip is single bank.
But HAL define FLASH_SECTOR_TOTAL doesn't represent the real number of sector,
instead, it represents the maximum number of sectors (for single and dual bank).
So for variants using F76xx and F77xx chip,
we must define FLASH_BASE_ADDRESS and FLASH_DATA_SECTOR in order to use the last sector of the flash corresponding to the default single bank configuration.

Variants concerned: NUCLEO_F767ZI and REMRAM

Fixes #297

