### PR TITLE
Add PlatformIO Test to the workflow

### DIFF
--- a/.github/actions/pio-build/Dockerfile
+++ b/.github/actions/pio-build/Dockerfile
@@ -1,0 +1,18 @@
+# Container image that runs your code
+FROM ubuntu:latest
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# Install prerequisites
+RUN apt-get update && apt-get install -y git python3 python3-pip wget
+
+# Install PlatformIO
+RUN pip3 install -U platformio
+CMD /bin/bash
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/pio-build/README.md
+++ b/.github/actions/pio-build/README.md
@@ -1,0 +1,15 @@
+# PlatformIO build action
+
+This action build thanks PIO.
+
+## Inputs
+
+### `cmsis-version`
+
+The CMSIS version to use. Default `"5.5.1"`.
+
+## Example usage
+
+```yaml
+uses: ./.github/actions/pio-build
+```

--- a/.github/actions/pio-build/action.yml
+++ b/.github/actions/pio-build/action.yml
@@ -1,0 +1,12 @@
+# action.yml
+name: 'PlatformIO Build'
+description: 'Compile using PlatformIO'
+inputs:
+  cmsis-version:
+    description: 'CMSIS package version to use'
+    default: '5.5.1'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.cmsis-version }}

--- a/.github/actions/pio-build/entrypoint.sh
+++ b/.github/actions/pio-build/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -x
+
+CMSIS_VERSION=$1
+CMSIS_ARCHIVE=CMSIS-${CMSIS_VERSION}.tar.bz2
+
+# Install the development version of ststm32 platform
+platformio platform install https://github.com/platformio/platform-ststm32.git
+
+# Prepare framework for CI
+python3 -c "import json; import os; fp=open(os.path.expanduser('~/.platformio/platforms/ststm32/platform.json'), 'r+'); data=json.load(fp); data['packages']['framework-arduinoststm32']['version'] = '*'; fp.seek(0); fp.truncate(); json.dump(data, fp); fp.close()"
+
+ln -sf $GITHUB_WORKSPACE $HOME/.platformio/packages/framework-arduinoststm32
+# Download and unpack CMSIS package
+wget https://github.com/stm32duino/ArduinoModule-CMSIS/releases/download/$CMSIS_VERSION/CMSIS-$CMSIS_VERSION.tar.bz2
+tar -xvjf CMSIS-$CMSIS_VERSION.tar.bz2
+cd $GITHUB_WORKSPACE/CI/build/
+python3 platformio-builder.py --board=blackpill_f103c8 --board=remram_v1
+
+exit $?

--- a/.github/workflows/Continuous-Integration.yml
+++ b/.github/workflows/Continuous-Integration.yml
@@ -57,3 +57,14 @@ jobs:
       run: |
         cat ${{ steps.Compile.outputs.compile-result }}
         exit 1
+  pio_build:
+    runs-on: ubuntu-latest
+    name: PlatformIO test
+    steps:
+      # First of all, clone the repo using the checkout action.
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: PlatformIO
+      id: Compile
+      uses: ./.github/actions/pio-build

--- a/CI/build/platformio-builder.py
+++ b/CI/build/platformio-builder.py
@@ -35,7 +35,7 @@ def main():
     if boards is None:
         boards = ["nucleo_f401re"]
 
-    libs_dir = os.path.join(os.environ["TRAVIS_BUILD_DIR"], "libraries")
+    libs_dir = os.path.join(os.environ["GITHUB_WORKSPACE"], "libraries")
     if any(run_platformio(example, boards) for example in collect_examples(libs_dir)):
         sys.exit(1)
 


### PR DESCRIPTION
Create a local action for PlatformIO test and add it ti the CI workflow.

Based on @valeros Travis CI added in #924.