### PR TITLE
USB: Disable Vbus sensing by default

### DIFF
--- a/cores/arduino/stm32/usb/usbd_conf.c
+++ b/cores/arduino/stm32/usb/usbd_conf.c
@@ -28,6 +28,11 @@
 #else
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+#if !defined(USBD_VBUS_DETECTION_ENABLE)
+#define VBUS_SENSING DISABLE
+#else
+#define VBUS_SENSING ENABLE
+#endif
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
@@ -479,14 +484,14 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
   g_hpcd.Init.phy_itface = PCD_PHY_ULPI;
 #endif
   g_hpcd.Init.speed = PCD_SPEED_HIGH;
-  g_hpcd.Init.vbus_sensing_enable = ENABLE;
+  g_hpcd.Init.vbus_sensing_enable = VBUS_SENSING;
   g_hpcd.Init.use_external_vbus = DISABLE;
 #else /* USE_USB_FS */
 #ifdef USB_OTG_FS
   g_hpcd.Instance = USB_OTG_FS;
   g_hpcd.Init.use_dedicated_ep1 = DISABLE;
   g_hpcd.Init.dma_enable = DISABLE;
-  g_hpcd.Init.vbus_sensing_enable = DISABLE;
+  g_hpcd.Init.vbus_sensing_enable = VBUS_SENSING;
   g_hpcd.Init.use_external_vbus = DISABLE;
 #else
   g_hpcd.Instance = USB;

--- a/variants/board_template/variant.h
+++ b/variants/board_template/variant.h
@@ -157,6 +157,11 @@ extern "C" {
 // SD Read/Write timeout, default value defined in STM32SD library
 //#define SD_DATATIMEOUT          x
 
+// USB Vbus sensing. Require to have Vbus pin connected to Vbus signal.
+// Warning, pin is different depending on FullSpeed or High Speed mode used
+// See AN4879 https://www.st.com/content/st_com/en/search.html#q=AN4879-t=resources-page=1
+//#define USBD_VBUS_DETECTION_ENABLE
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
**Summary**
USB: Disable Vbus sensing by default

Tested on STM32F746-DISCO: 
Full Speed and High Speed
ST-link power supply and USB Power supply 

Fixes #886

