### PR TITLE
[CI] Build built-in libraries

### DIFF
--- a/CI/build/examples/BareMinimum/BareMinimum.ino
+++ b/CI/build/examples/BareMinimum/BareMinimum.ino
@@ -1,9 +1,122 @@
-void setup() {
-  // put your setup code here, to run once:
+/*
+ * This sketch is for CI build purpose.
+ * It allows to test build of built-in libraries
+ * and can not be executed.
+ */
 
+#include <EEPROM.h>
+#ifndef STM32MP1xx
+#include <IWatchdog.h>
+#endif
+#ifdef TIMER_SERVO
+#include <Servo.h>
+#endif
+#include <SPI.h>
+#include <SoftwareSerial.h>
+#include <Wire.h>
+
+#ifndef USER_BTN
+#define USER_BTN      2
+#endif
+
+#ifndef LED_BUILTIN
+#define LED_BUILTIN   13
+#endif
+
+#ifndef PIN_SERIAL_RX
+#define PIN_SERIAL_RX 0
+#endif
+
+#ifndef PIN_SERIAL_TX
+#define PIN_SERIAL_TX 1
+#endif
+
+#ifndef Serial
+HardwareSerial Serial(PIN_SERIAL_RX, PIN_SERIAL_TX);
+#endif
+
+#ifdef TIMER_SERVO
+Servo servo;
+#endif
+SoftwareSerial swSerial(10, 11);
+
+void setup() {
+  // Serial HW & SW
+#if !defined(USBD_USE_CDC) && !defined(DISABLE_GENERIC_SERIALUSB)
+  Serial.setRx(PIN_SERIAL_RX);
+  Serial.setTx(digitalPinToPinName(PIN_SERIAL_TX));
+#endif
+  Serial.begin(9600);  // start serial for output
+  while (!Serial) {};
+
+  swSerial.begin(4800);
+  swSerial.write("x");
+  if (!swSerial.isListening()) {
+    swSerial.listen();
+    if (swSerial.available()) {
+      swSerial.read();
+    }
+  }
+  swSerial.end();
+
+  // EEPROM
+  byte value = EEPROM.read(0x01);
+  EEPROM.write(EEPROM.length()-1, value);
+
+#ifndef STM32MP1xx
+  // IWDG
+  if (!IWatchdog.isReset(true)) {
+    IWatchdog.begin(10000000);
+    IWatchdog.isEnabled();
+  }
+  IWatchdog.reload();
+#endif
+
+#ifdef TIMER_SERVO
+  // Servo
+  servo.attach(3, 900, 2100);
+  servo.write(1500);
+  servo.detach();
+#endif
+
+  // SPI
+  SPISettings settings(SPI_SPEED_CLOCK_DEFAULT, MSBFIRST, SPI_MODE_0);
+  SPI.setMISO(PIN_SPI_MISO);
+  SPI.setMOSI(PIN_SPI_MOSI);
+  SPI.setSCLK(PIN_SPI_SCK);
+  SPI.setSSEL(digitalPinToPinName(PIN_SPI_SS));
+  SPI.begin(PIN_SPI_SS);
+  SPI.beginTransaction(1, settings);
+  SPI.endTransaction();
+  SPI.transfer(1);
+  SPI.end();
+
+  // Wire
+  Wire.setSCL(PIN_WIRE_SCL);
+  Wire.setSDA(digitalPinToPinName(PIN_WIRE_SDA));
+  Wire.setClock(400000);
+  Wire.begin(4);
+  Wire.onRequest(requestEvent);
+  Wire.onReceive(receiveEvent);
+  Wire.beginTransmission(4);
+  Wire.endTransmission();
+  Wire.requestFrom(2, 1);
+  Wire.end();
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
+}
 
+// Wire
+// function that executes whenever data is received from master
+// this function is registered as an event, see setup()
+void receiveEvent(int) {
+  while (1 < Wire.available()) {
+    Wire.read();
+  }
+}
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  Wire.write("x");
 }

--- a/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_rcc_ex.h
+++ b/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_rcc_ex.h
@@ -4969,7 +4969,6 @@ typedef struct
                                       tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_RTCAPBEN);\
                                       UNUSED(tmpreg); \
                                       } while(0U)
-#if defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_USART3_CLK_ENABLE() do { \
                                       __IO uint32_t tmpreg = 0x00U; \
                                       SET_BIT(RCC->APB1ENR, RCC_APB1ENR_USART3EN);\
@@ -4977,8 +4976,6 @@ typedef struct
                                       tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_USART3EN);\
                                       UNUSED(tmpreg); \
                                       } while(0U)
-#endif /* STM32F412Zx || STM32F412Vx || STM32F412Rx || STM32F413xx || STM32F423xx */
-
 #if defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_UART4_CLK_ENABLE()  do { \
                                       __IO uint32_t tmpreg = 0x00U; \
@@ -5098,9 +5095,7 @@ typedef struct
 #endif /* STM32F413xx || STM32F423xx */
 #define __HAL_RCC_RTCAPB_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_RTCAPBEN))
 #define __HAL_RCC_SPI3_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI3EN))
-#if defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_USART3_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_USART3EN))
-#endif /* STM32F412Zx || STM32F412Vx || STM32F412Rx || STM32F413xx || STM32F423xx */
 #if defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_UART4_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_UART4EN))
 #define __HAL_RCC_UART5_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_UART5EN))
@@ -5140,9 +5135,7 @@ typedef struct
 #endif /* STM32F413xx || STM32F423xx */
 #define __HAL_RCC_RTCAPB_IS_CLK_ENABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_RTCAPBEN)) != RESET)
 #define __HAL_RCC_SPI3_IS_CLK_ENABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_SPI3EN)) != RESET)
-#if defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_USART3_IS_CLK_ENABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_USART3EN)) != RESET)
-#endif /* STM32F412Zx || STM32F412Vx || STM32F412Rx || STM32F413xx | STM32F423xx */
 #if defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_UART4_IS_CLK_ENABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_UART4EN)) != RESET)
 #define __HAL_RCC_UART5_IS_CLK_ENABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_UART5EN)) != RESET)
@@ -5171,9 +5164,7 @@ typedef struct
 #endif /* STM32F413xx || STM32F423xx */
 #define __HAL_RCC_RTCAPB_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_RTCAPBEN)) == RESET)
 #define __HAL_RCC_SPI3_IS_CLK_DISABLED()    ((RCC->APB1ENR & (RCC_APB1ENR_SPI3EN)) == RESET)
-#if defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_USART3_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_USART3EN)) == RESET)
-#endif /* STM32F412Zx || STM32F412Vx || STM32F412Rx || STM32F413xx | STM32F423xx */
 #if defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_UART4_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_UART4EN)) == RESET)
 #define __HAL_RCC_UART5_IS_CLK_DISABLED()  ((RCC->APB1ENR & (RCC_APB1ENR_UART5EN)) == RESET)
@@ -5445,9 +5436,7 @@ typedef struct
 #define __HAL_RCC_LPTIM1_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_LPTIM1RST))
 #endif /* STM32F413xx || STM32F423xx */
 #define __HAL_RCC_SPI3_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_SPI3RST))
-#if defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_USART3_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_USART3RST))
-#endif /* STM32F412Zx || STM32F412Vx || STM32F412Rx || STM32F413xx || STM32F423xx */
 #if defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_UART4_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART4RST))
 #define __HAL_RCC_UART5_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART5RST))
@@ -5475,9 +5464,7 @@ typedef struct
 #define __HAL_RCC_LPTIM1_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_LPTIM1RST))
 #endif /* STM32F413xx || STM32F423xx */
 #define __HAL_RCC_SPI3_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_SPI3RST))
-#if defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_USART3_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_USART3RST))
-#endif /* STM32F412Zx || STM32F412Vx || STM32F412Rx || STM32F413xx || STM32F423xx */
 #if defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_UART4_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART4RST))
 #define __HAL_RCC_UART5_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART5RST))
@@ -5633,9 +5620,7 @@ typedef struct
 #endif /* STM32F413xx || STM32F423xx */
 #define __HAL_RCC_RTCAPB_CLK_SLEEP_ENABLE()  (RCC->APB1LPENR |= (RCC_APB1LPENR_RTCAPBLPEN))
 #define __HAL_RCC_SPI3_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_SPI3LPEN))
-#if defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_USART3_CLK_SLEEP_ENABLE()  (RCC->APB1LPENR |= (RCC_APB1LPENR_USART3LPEN))
-#endif /* STM32F412Zx || STM32F412Vx || STM32F412Rx || STM32F413xx || STM32F423xx */
 #if defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_UART4_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART4LPEN))
 #define __HAL_RCC_UART5_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART5LPEN))
@@ -5664,9 +5649,7 @@ typedef struct
 #endif /* STM32F413xx || STM32F423xx */
 #define __HAL_RCC_RTCAPB_CLK_SLEEP_DISABLE() (RCC->APB1LPENR &= ~(RCC_APB1LPENR_RTCAPBLPEN))
 #define __HAL_RCC_SPI3_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_SPI3LPEN))
-#if defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) || defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_USART3_CLK_SLEEP_DISABLE() (RCC->APB1LPENR &= ~(RCC_APB1LPENR_USART3LPEN))
-#endif /* STM32F412Zx || STM32F412Vx || STM32F412Rx || STM32F413xx || STM32F423xx */
 #if defined(STM32F413xx) || defined(STM32F423xx)
 #define __HAL_RCC_UART4_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART4LPEN))
 #define __HAL_RCC_UART5_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART5LPEN))

--- a/variants/Generic_F410Cx/variant.h
+++ b/variants/Generic_F410Cx/variant.h
@@ -99,9 +99,8 @@ extern "C" {
 #define PIN_WIRE_SCL            PB8
 
 // Timer Definitions
-// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #define TIMER_TONE              TIM6
-#define TIMER_SERVO             TIM7
+#define TIMER_SERVO             TIM11
 
 // UART Definitions
 #define SERIAL_UART_INSTANCE    2 // Connected to ST-Link

--- a/variants/Generic_F410Rx/variant.h
+++ b/variants/Generic_F410Rx/variant.h
@@ -100,9 +100,8 @@ extern "C" {
 #endif
 
 // Timer Definitions
-// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #define TIMER_TONE              TIM6
-#define TIMER_SERVO             TIM7
+#define TIMER_SERVO             TIM11
 
 // SPI definitions
 #define PIN_SPI_SS              PA4


### PR DESCRIPTION
Since {whole-archive} option has been removed the CI is  not fully relevant. So need to explicitly used basic functions of the built-in library.
    
The arduino-cli script have been updated to handle properly  region overflowed which is not a real issue while there is no other issue.

Fix 2 issues raised using the updated BareMinimum.ino:
* [F4] Fix HAL_RCC_USART3 definition for STM32F412Cx
* [Generic F410xx] Fix wrong TIMER_SERVO definition