### PR TITLE
Included OpenOCD as a programmer

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -973,6 +973,10 @@ GenF1.menu.upload_method.dfuoMethod.upload.altID=1
 GenF1.menu.upload_method.dfuoMethod.build.flash_offset=0x5000
 GenF1.menu.upload_method.dfuoMethod.build.bootloader_flags=-DBL_LEGACY_LEAF -DVECT_TAB_OFFSET={build.flash_offset}
 
+GenF1.menu.upload_method.openocd=OpenOCD
+GenF1.menu.upload_method.openocd.upload.protocol=0
+GenF1.menu.upload_method.openocd.upload.tool=openocd
+
 ################################################################################
 # Generic F3
 

--- a/platform.txt
+++ b/platform.txt
@@ -210,3 +210,10 @@ tools.remoteproc_gen.script=run_arduino_gen.sh
 tools.remoteproc_gen.upload.params.verbose=
 tools.remoteproc_gen.upload.params.quiet=
 tools.remoteproc_gen.upload.pattern="{busybox}" sh "{path}/{script}" generate "{build.path}/{build.project_name}.elf" "{build.path}/run_arduino_{build.project_name}.sh" 
+
+# Openocd upload
+tools.openocd.cmd=openocd
+tools.openocd.path.linux= /usr/bin
+tools.openocd.upload.params.verbose=
+tools.openocd.upload.params.quiet=
+tools.openocd.upload.pattern="{path}/{cmd}" -s /usr/share/openocd/scripts/ -f interface/stlink-v2.cfg -f board/stm32f103c8_blue_pill.cfg -c "program {build.path}/{build.project_name}.elf verify reset exit"


### PR DESCRIPTION
OpenOCD is missing as a programmer tool from the Arduino STM32 board. I think this makes a good addition to the STM32 core.

There are some workarounds needed to get this fully working... as it is highly dependent on OpenOCD.

I have used the ST-Link V2 (cheap clone) debugger on linux with one of the latest openocd version (self compiled). 

OpenOCD config file used: https://github.com/ntfreak/openocd/blob/master/tcl/board/stm32f103c8_blue_pill.cfg

Other config files are available if needed. 