### PR TITLE
WIP: Allow uploading using open-ocd-supported programmers

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -795,6 +795,7 @@ GenF1.build.mcu=cortex-m3
 GenF1.build.series=STM32F1xx
 GenF1.build.cmsis_lib_gcc=arm_cortexM3l_math
 GenF1.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
+GenF1.build.openocd_script=openocd.cfg
 
 # BLUEPILL_F103C6 board
 GenF1.menu.pnum.BLUEPILL_F103C6=BluePill F103C6 (32K)

--- a/platform.txt
+++ b/platform.txt
@@ -210,3 +210,28 @@ tools.remoteproc_gen.script=run_arduino_gen.sh
 tools.remoteproc_gen.upload.params.verbose=
 tools.remoteproc_gen.upload.params.quiet=
 tools.remoteproc_gen.upload.pattern="{busybox}" sh "{path}/{script}" generate "{build.path}/{build.project_name}.elf" "{build.path}/run_arduino_{build.project_name}.sh" 
+
+#
+# OpenOCD, for upload using programmer
+#
+tools.openocd.path={runtime.tools.openocd-0.10.0-arduino7.path}
+tools.openocd.cmd=bin/openocd
+tools.openocd.cmd.windows=bin/openocd.exe
+
+tools.openocd.program.params.verbose=-d2
+tools.openocd.program.params.quiet=-d0
+tools.openocd.program.init_args=-c "telnet_port disabled" -s "{path}/share/openocd/scripts/"
+tools.openocd.program.interface_args=-c "source [find interface/{program.interface}]"
+tools.openocd.program.board_args=-f "{runtime.platform.path}/variants/{build.variant}/{build.openocd_script}"
+tools.openocd.program.program_args=-c "program {{build.path}/{build.project_name}.elf} verify reset; shutdown"
+tools.openocd.program.pattern="{path}/{cmd}" {program.verbose} {program.init_args} {program.interface_args} {program.board_args} {program.program_args}
+
+# Used for burn bootloader, must exist even if empty
+tools.openocd.erase.params.verbose=-d2
+tools.openocd.erase.params.quiet=-d0
+tools.openocd.erase.pattern=
+
+# Upload bootloader, but which?
+#tools.openocd.bootloader.params.verbose=-d2
+#tools.openocd.bootloader.params.quiet=-d0
+#tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -s "{path}/share/openocd/scripts/" -f "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "telnet_port disabled; init; halt; at91samd bootloader 0; program {{runtime.platform.path}/bootloaders/{bootloader.file}} verify reset; shutdown"

--- a/programmers.txt
+++ b/programmers.txt
@@ -1,0 +1,15 @@
+cmsis_dap.name=CMSIS-DAP compatible programmer
+cmsis_dap.communication=USB
+cmsis_dap.protocol=
+cmsis_dap.program.protocol=
+cmsis_dap.program.interface=cmsis-dap.cfg
+cmsis_dap.program.tool=openocd
+cmsis_dap.program.extra_params=
+
+stlink.name=ST-LINK
+stlink.communication=USB
+stlink.protocol=
+stlink.program.protocol=
+stlink.program.interface=stlink.cfg
+stlink.program.tool=openocd
+stlink.program.extra_params=

--- a/variants/PILL_F103XX/openocd.cfg
+++ b/variants/PILL_F103XX/openocd.cfg
@@ -1,0 +1,1 @@
+source [find target/stm32f1x.cfg]


### PR DESCRIPTION
This is just a proof of concept so far, but it allows using external programmers such as ST-LINK or the Atmel JTAGICE3 or Atmel ICE through the IDE "Upload using programmer" option.

I needed uploading through my Atmel JTAGICE3, which was my only SWD programmer available (though I just also got an STLINK I have not tested yet). The JTAGICE3 is a generic CMSIS-DAP SWD programmer, so it also supports STM32.

It did not make sense to add this programmer as another upload method for all boards, since that would be a lot of work, and the IDE already has a mechanism for external programmers: Upload using programmer.

This implements support for uploads using openocd-supported external programmers to (for now) just the PILL_F103XX variant boards. Each variant still needs a openocd config file (alternatively, the openocd target name could be specified in boards.txt as well).

Most of this configuration can later probably be reused for step-by-step debugging support using openocd (which is being added to arduino-cli right now).

I've tested this using JTAGICE3 on a bluepill. I've also added entries for STLINK, but have not tested them yet (yet to unpack my new vSTLINK programmer).

To use this:
 - Select the board as normal
 - Select any upload method without a custom bootloader (to get the flash start address correct)
 - Select the programmer from the "Tools -> Programmer" menu (note that this currently shows *all* programmers which is not really useful, this should be [fixed in Arduino](https://github.com/arduino/Arduino/issues/9373)).
 - Select sketch -> Upload using programmer