### PR TITLE
Fix typo in the Fysetc board definition

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1736,8 +1736,8 @@ LoRa.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.pnum.FYSETC_S6.build.product_line=STM32F446xx
 3dprinter.menu.pnum.FYSETC_S6.build.variant=FYSETC_S6
 3dprinter.menu.pnum.FYSETC_S6.build.cmsis_lib_gcc=arm_cortexM4lf_math
-3dprinter.menu.pnum.MALYANM300_F070CB.build.flash_offset=0x10000
-3dprinter.menu.pnum.MALYANM200_F070CB.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET={build.flash_offset}
+3dprinter.menu.pnum.FYSETC_S6.build.flash_offset=0x10000
+3dprinter.menu.pnum.FYSETC_S6.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET={build.flash_offset}
 
 # Upload menu
 3dprinter.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)


### PR DESCRIPTION
Looks like a copy/paste typo in the boards.txt