### PR TITLE
Kill break warnings

### DIFF
--- a/system/Drivers/CMSIS/Device/ST/STM32F1xx/Source/Templates/system_stm32f1xx.c
+++ b/system/Drivers/CMSIS/Device/ST/STM32F1xx/Source/Templates/system_stm32f1xx.c
@@ -371,23 +371,21 @@ void SystemCoreClockUpdate (void)
   */
 void SystemInit_ExtMemCtl(void)
 {
-  __IO uint32_t tmpreg;
-  /*!< FSMC Bank1 NOR/SRAM3 is used for the STM3210E-EVAL, if another Bank is
+   /*!< FSMC Bank1 NOR/SRAM3 is used for the STM3210E-EVAL, if another Bank is
     required, then adjust the Register Addresses */
 
   /* Enable FSMC clock */
   RCC->AHBENR = 0x00000114U;
 
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_FSMCEN);
+  READ_BIT(RCC->AHBENR, RCC_AHBENR_FSMCEN);
 
   /* Enable GPIOD, GPIOE, GPIOF and GPIOG clocks */
   RCC->APB2ENR = 0x000001E0U;
 
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_IOPDEN);
+  READ_BIT(RCC->APB2ENR, RCC_APB2ENR_IOPDEN);
 
-  (void)(tmpreg);
 
 /* ---------------  SRAM Data lines, NOE and NWE configuration ---------------*/
 /*----------------  SRAM Address lines configuration -------------------------*/

--- a/system/Drivers/CMSIS/Device/ST/STM32F1xx/Source/Templates/system_stm32f1xx.c
+++ b/system/Drivers/CMSIS/Device/ST/STM32F1xx/Source/Templates/system_stm32f1xx.c
@@ -371,7 +371,7 @@ void SystemCoreClockUpdate (void)
   */
 void SystemInit_ExtMemCtl(void)
 {
-   /*!< FSMC Bank1 NOR/SRAM3 is used for the STM3210E-EVAL, if another Bank is
+  /*!< FSMC Bank1 NOR/SRAM3 is used for the STM3210E-EVAL, if another Bank is
     required, then adjust the Register Addresses */
 
   /* Enable FSMC clock */

--- a/system/Drivers/CMSIS/Device/ST/STM32L1xx/Source/Templates/system_stm32l1xx.c
+++ b/system/Drivers/CMSIS/Device/ST/STM32L1xx/Source/Templates/system_stm32l1xx.c
@@ -269,8 +269,6 @@ void SystemCoreClockUpdate (void)
   */
 void SystemInit_ExtMemCtl(void)
 {
-  __IO uint32_t tmpreg = 0;
-
   /* Flash 1 wait state */
   FLASH->ACR |= FLASH_ACR_LATENCY;
 
@@ -278,7 +276,7 @@ void SystemInit_ExtMemCtl(void)
   RCC->APB1ENR |= RCC_APB1ENR_PWREN;
 
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_PWREN);
+  READ_BIT(RCC->APB1ENR, RCC_APB1ENR_PWREN);
 
   /* Select the Voltage Range 1 (1.8 V) */
   PWR->CR = PWR_CR_VOS_0;
@@ -312,7 +310,7 @@ void SystemInit_ExtMemCtl(void)
   RCC->AHBENR   = 0x000080D8;
 
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIODEN);
+  READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIODEN);
 
   /* Connect PDx pins to FSMC Alternate function */
   GPIOD->AFR[0]  = 0x00CC00CC;
@@ -367,9 +365,7 @@ void SystemInit_ExtMemCtl(void)
   RCC->AHBENR    = 0x400080D8;
 
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_FSMCEN);
-
-  (void)(tmpreg);
+  READ_BIT(RCC->AHBENR, RCC_AHBENR_FSMCEN);
 
   /* Configure and enable Bank1_SRAM3 */
   FSMC_Bank1->BTCR[4]  = 0x00001011;

--- a/system/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_ll_tim.h
+++ b/system/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_ll_tim.h
@@ -2765,11 +2765,9 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
   */
 __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
 {
-  __IO uint32_t tmpreg;
   SET_BIT(TIMx->BDTR, TIM_BDTR_BKE);
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**
@@ -2782,11 +2780,9 @@ __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
 {
-  __IO uint32_t tmpreg;
   CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BKE);
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**
@@ -2802,11 +2798,9 @@ __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity)
 {
-  __IO uint32_t tmpreg;
   MODIFY_REG(TIMx->BDTR, TIM_BDTR_BKP, BreakPolarity);
   /* Note: Any write operation to BKP bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**

--- a/system/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_ll_tim.h
+++ b/system/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_ll_tim.h
@@ -2697,11 +2697,9 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
   */
 __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
 {
-  __IO uint32_t tmpreg;
   SET_BIT(TIMx->BDTR, TIM_BDTR_BKE);
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**
@@ -2714,11 +2712,9 @@ __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
 {
-  __IO uint32_t tmpreg;
   CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BKE);
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**
@@ -2734,11 +2730,9 @@ __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity)
 {
-  __IO uint32_t tmpreg;
   MODIFY_REG(TIMx->BDTR, TIM_BDTR_BKP, BreakPolarity);
   /* Note: Any write operation to BKP bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**

--- a/system/Drivers/STM32F2xx_HAL_Driver/Inc/stm32f2xx_ll_tim.h
+++ b/system/Drivers/STM32F2xx_HAL_Driver/Inc/stm32f2xx_ll_tim.h
@@ -2786,11 +2786,9 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
   */
 __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
 {
-  __IO uint32_t tmpreg;
   SET_BIT(TIMx->BDTR, TIM_BDTR_BKE);
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**
@@ -2803,11 +2801,9 @@ __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
 {
-  __IO uint32_t tmpreg;
   CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BKE);
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**
@@ -2823,11 +2819,9 @@ __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity)
 {
-  __IO uint32_t tmpreg;
   MODIFY_REG(TIMx->BDTR, TIM_BDTR_BKP, BreakPolarity);
   /* Note: Any write operation to BKP bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**

--- a/system/Drivers/STM32F3xx_HAL_Driver/Inc/stm32f3xx_ll_tim.h
+++ b/system/Drivers/STM32F3xx_HAL_Driver/Inc/stm32f3xx_ll_tim.h
@@ -3505,13 +3505,11 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
 __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
 {
 #if defined(TIM_IP_V2_1)
-  __IO uint32_t tmpreg;
 #endif /* TIM_IP_V2_1 */
   SET_BIT(TIMx->BDTR, TIM_BDTR_BKE);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 #endif /* TIM_IP_V2_1 */
 }
 
@@ -3526,13 +3524,11 @@ __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
 __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
 {
 #if defined(TIM_IP_V2_1)
-  __IO uint32_t tmpreg;
 #endif /* TIM_IP_V2_1 */
   CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BKE);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 #endif /* TIM_IP_V2_1 */
 }
 
@@ -3570,13 +3566,11 @@ __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity,
                                       uint32_t BreakFilter)
 {
 #if defined(TIM_IP_V2_1)
-  __IO uint32_t tmpreg;
 #endif /* TIM_IP_V2_1 */
   MODIFY_REG(TIMx->BDTR, TIM_BDTR_BKP | TIM_BDTR_BKF, BreakPolarity | BreakFilter);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to BKP bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 #endif /* TIM_IP_V2_1 */
 }
 
@@ -3595,13 +3589,11 @@ __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity,
 __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity)
 {
 #if defined(TIM_IP_V2_1)
-  __IO uint32_t tmpreg;
 #endif /* TIM_IP_V2_1 */
   MODIFY_REG(TIMx->BDTR, TIM_BDTR_BKP, BreakPolarity);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to BKP bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 #endif /* TIM_IP_V2_1 */
 }
 
@@ -3618,13 +3610,11 @@ __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity)
 __STATIC_INLINE void LL_TIM_EnableBRK2(TIM_TypeDef *TIMx)
 {
 #if defined(TIM_IP_V2_1)
-  __IO uint32_t tmpreg;
 #endif /* TIM_IP_V2_1 */
   SET_BIT(TIMx->BDTR, TIM_BDTR_BK2E);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 #endif /* TIM_IP_V2_1 */
 }
 
@@ -3639,13 +3629,11 @@ __STATIC_INLINE void LL_TIM_EnableBRK2(TIM_TypeDef *TIMx)
 __STATIC_INLINE void LL_TIM_DisableBRK2(TIM_TypeDef *TIMx)
 {
 #if defined(TIM_IP_V2_1)
-  __IO uint32_t tmpreg;
 #endif /* TIM_IP_V2_1 */
   CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BK2E);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 #endif /* TIM_IP_V2_1 */
 }
 

--- a/system/Drivers/STM32F3xx_HAL_Driver/Inc/stm32f3xx_ll_tim.h
+++ b/system/Drivers/STM32F3xx_HAL_Driver/Inc/stm32f3xx_ll_tim.h
@@ -3504,8 +3504,6 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
   */
 __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
 {
-#if defined(TIM_IP_V2_1)
-#endif /* TIM_IP_V2_1 */
   SET_BIT(TIMx->BDTR, TIM_BDTR_BKE);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
@@ -3523,8 +3521,6 @@ __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
 {
-#if defined(TIM_IP_V2_1)
-#endif /* TIM_IP_V2_1 */
   CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BKE);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
@@ -3565,8 +3561,6 @@ __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
 __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity,
                                       uint32_t BreakFilter)
 {
-#if defined(TIM_IP_V2_1)
-#endif /* TIM_IP_V2_1 */
   MODIFY_REG(TIMx->BDTR, TIM_BDTR_BKP | TIM_BDTR_BKF, BreakPolarity | BreakFilter);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to BKP bit takes a delay of 1 APB clock cycle to become effective. */
@@ -3588,8 +3582,6 @@ __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity,
   */
 __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity)
 {
-#if defined(TIM_IP_V2_1)
-#endif /* TIM_IP_V2_1 */
   MODIFY_REG(TIMx->BDTR, TIM_BDTR_BKP, BreakPolarity);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to BKP bit takes a delay of 1 APB clock cycle to become effective. */
@@ -3609,8 +3601,6 @@ __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity)
   */
 __STATIC_INLINE void LL_TIM_EnableBRK2(TIM_TypeDef *TIMx)
 {
-#if defined(TIM_IP_V2_1)
-#endif /* TIM_IP_V2_1 */
   SET_BIT(TIMx->BDTR, TIM_BDTR_BK2E);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
@@ -3628,8 +3618,6 @@ __STATIC_INLINE void LL_TIM_EnableBRK2(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_DisableBRK2(TIM_TypeDef *TIMx)
 {
-#if defined(TIM_IP_V2_1)
-#endif /* TIM_IP_V2_1 */
   CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BK2E);
 #if defined(TIM_IP_V2_1)
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */

--- a/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_ll_tim.h
+++ b/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_ll_tim.h
@@ -2790,11 +2790,9 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
   */
 __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
 {
-  __IO uint32_t tmpreg;
   SET_BIT(TIMx->BDTR, TIM_BDTR_BKE);
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**
@@ -2807,11 +2805,9 @@ __STATIC_INLINE void LL_TIM_EnableBRK(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
 {
-  __IO uint32_t tmpreg;
   CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BKE);
   /* Note: Any write operation to this bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**
@@ -2827,11 +2823,9 @@ __STATIC_INLINE void LL_TIM_DisableBRK(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_ConfigBRK(TIM_TypeDef *TIMx, uint32_t BreakPolarity)
 {
-  __IO uint32_t tmpreg;
   MODIFY_REG(TIMx->BDTR, TIM_BDTR_BKP, BreakPolarity);
   /* Note: Any write operation to BKP bit takes a delay of 1 APB clock cycle to become effective. */
-  tmpreg = READ_REG(TIMx->BDTR);
-  (void)(tmpreg);
+  READ_REG(TIMx->BDTR);
 }
 
 /**

--- a/system/STM32F1xx/system_stm32f1xx.c
+++ b/system/STM32F1xx/system_stm32f1xx.c
@@ -364,7 +364,6 @@ void SystemCoreClockUpdate (void)
   */
 void SystemInit_ExtMemCtl(void)
 {
-  __IO uint32_t tmpreg;
   /*!< FSMC Bank1 NOR/SRAM3 is used for the STM3210E-EVAL, if another Bank is
     required, then adjust the Register Addresses */
 
@@ -372,15 +371,14 @@ void SystemInit_ExtMemCtl(void)
   RCC->AHBENR = 0x00000114U;
 
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_FSMCEN);
+  READ_BIT(RCC->AHBENR, RCC_AHBENR_FSMCEN);
 
   /* Enable GPIOD, GPIOE, GPIOF and GPIOG clocks */
   RCC->APB2ENR = 0x000001E0U;
 
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_IOPDEN);
+  READ_BIT(RCC->APB2ENR, RCC_APB2ENR_IOPDEN);
 
-  (void)(tmpreg);
 
 /* ---------------  SRAM Data lines, NOE and NWE configuration ---------------*/
 /*----------------  SRAM Address lines configuration -------------------------*/

--- a/system/STM32L1xx/system_stm32l1xx.c
+++ b/system/STM32L1xx/system_stm32l1xx.c
@@ -262,8 +262,6 @@ void SystemCoreClockUpdate (void)
   */
 void SystemInit_ExtMemCtl(void)
 {
-  __IO uint32_t tmpreg = 0;
-
   /* Flash 1 wait state */
   FLASH->ACR |= FLASH_ACR_LATENCY;
   
@@ -271,7 +269,7 @@ void SystemInit_ExtMemCtl(void)
   RCC->APB1ENR |= RCC_APB1ENR_PWREN;
   
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_PWREN);
+  READ_BIT(RCC->APB1ENR, RCC_APB1ENR_PWREN);
 
   /* Select the Voltage Range 1 (1.8 V) */
   PWR->CR = PWR_CR_VOS_0;
@@ -305,7 +303,7 @@ void SystemInit_ExtMemCtl(void)
   RCC->AHBENR   = 0x000080D8;
   
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIODEN);
+  READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIODEN);
   
   /* Connect PDx pins to FSMC Alternate function */
   GPIOD->AFR[0]  = 0x00CC00CC;
@@ -360,9 +358,8 @@ void SystemInit_ExtMemCtl(void)
   RCC->AHBENR    = 0x400080D8;
 
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_FSMCEN);
+  READ_BIT(RCC->AHBENR, RCC_AHBENR_FSMCEN);
   
-  (void)(tmpreg);
   
   /* Configure and enable Bank1_SRAM3 */
   FSMC_Bank1->BTCR[4]  = 0x00001011;


### PR DESCRIPTION
"(void)(tmpreg);" is causing a lot of compiler warnings which is making it hard to see if there are any real problems.

`warning: conversion to void will not access object of type 'volatile uint32_t {aka volatile long unsigned int}'`

As best I can tell there is not a functional need for this variable.

---

I am using PlatformIO to compile.  The GCC library JSON says:

```
{
    "description": "gcc-arm-embedded",
    "name": "toolchain-gccarmnoneeabi",
    "system": [
        "windows",
        "windows_amd64",
        "windows_x86"
    ],
    "url": "https://launchpad.net/gcc-arm-embedded",
    "version": "1.70201.0"
} 
```