### PR TITLE
Arduino cli fix

### DIFF
--- a/CI/build/conf/cores_config.json
+++ b/CI/build/conf/cores_config.json
@@ -23,7 +23,7 @@
       ],
       "sketches": [
         {
-          "pattern": "^((?!BareMinimum.ino).)*$",
+          "pattern": "^((?!BareMinimum).)*$",
           "applicable": false,
           "boards": [ "DEMO_F030F4", "DEMO_F030F4_16M", "DEMO_F030F4_HSI", "RHF76_052" ]
         },
@@ -33,22 +33,22 @@
           "boards": [ "DISCO_L475VG_IOT" ]
         },
         {
-          "pattern": "SPBTLE_BeaconDemo.ino|SPBTLE_SensorDemo.ino|BTLE_sensors_TimeOfFlight_demo.ino",
+          "pattern": "SPBTLE_BeaconDemo|SPBTLE_SensorDemo|BTLE_sensors_TimeOfFlight_demo",
           "applicable": true,
           "boards": [ "DISCO_L475VG_IOT" ]
         },
         {
-          "pattern": "STM32Ethernet|Ethernet_MQTT_Adafruit.io.ino|Hello_stm32",
+          "pattern": "STM32Ethernet|Ethernet_MQTT_Adafruit.io|Hello_stm32",
           "applicable": true,
           "boards": [ "NUCLEO_F429ZI", "DISCO_F746NG" ]
         },
         {
-          "pattern": "ISM43362-M3G-L44|WiFi_MQTT_Adafruit.io.ino|mqtt_B-L475E-IOT01A.ino",
+          "pattern": "ISM43362-M3G-L44|WiFi_MQTT_Adafruit.io|mqtt_B-L475E-IOT01A",
           "applicable": true,
           "boards": [ "DISCO_L475VG_IOT" ]
         },
         {
-          "pattern": "ExternalWakeup.ino|BleSensors_SensiBLE|NucleoCar",
+          "pattern": "ExternalWakeup|BleSensors_SensiBLE|NucleoCar",
           "applicable": false,
           "boards": [
             "AFROFLIGHT_F103CB",
@@ -110,7 +110,7 @@
           ]
         },
         {
-          "pattern": "Blink(WithoutDelay)?.ino",
+          "pattern": "Blink(WithoutDelay)?",
           "applicable": false,
           "boards": [ "EEXTR_F030_V1", "MALYANM200_F103CB", "PRNTR_V2" ]
         },
@@ -148,7 +148,7 @@
           "options": "usb=HID"
         },
         {
-          "pattern": "X_NUCLEO_IDB05A1_HelloWorld.ino",
+          "pattern": "X_NUCLEO_IDB05A1_HelloWorld",
           "applicable": false,
           "boards": [
             "AFROFLIGHT_F103CB",
@@ -184,7 +184,7 @@
           ]
         },
         {
-          "pattern": "X_NUCLEO_NFC03A1_HelloWorld.ino",
+          "pattern": "X_NUCLEO_NFC03A1_HelloWorld",
           "applicable": false,
           "boards": [
             "DISCO_F030R8",
@@ -215,7 +215,7 @@
           ]
         },
         {
-          "pattern": "StringComparisonOperators.ino",
+          "pattern": "StringComparisonOperators",
           "applicable": false,
           "boards": [
             "ARMED_V1",
@@ -229,7 +229,7 @@
           ]
         },
         {
-          "pattern": "ADXL3xx.ino",
+          "pattern": "ADXL3xx",
           "applicable": false,
           "boards": [
             "ARMED_V1",
@@ -240,7 +240,7 @@
           ]
         },
         {
-          "pattern": "SerialLoop.ino|Tests_basic_functions.ino",
+          "pattern": "SerialLoop|Tests_basic_functions",
           "applicable": false,
           "boards": [ "BLUEPILL_F103C6", "NUCLEO_L031K6", "Wraith32_V1" ]
         },

--- a/platform.txt
+++ b/platform.txt
@@ -133,16 +133,14 @@ recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.f
 ## Create output (.bin file)
 recipe.objcopy.bin.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.elf2bin.flags} {compiler.elf2bin.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.bin"
 
-## Save bin
-recipe.output.tmp_file={build.project_name}.bin
-recipe.output.save_file={build.project_name}.{build.variant}.bin
-
 ## Create output (.hex file)
 recipe.objcopy.hex.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
 
-## Save hex
-recipe.output.tmp_file={build.project_name}.hex
-recipe.output.save_file={build.project_name}.{build.variant}.hex
+build.preferred_out_format=bin
+
+## Save binary
+recipe.output.tmp_file={build.project_name}.{build.preferred_out_format}
+recipe.output.save_file={build.project_name}.{build.variant}.{build.preferred_out_format}
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"


### PR DESCRIPTION
It fixes the issue raised here https://github.com/arduino/arduino-cli/issues/355
    
Following the documentation
https://arduino.github.io/arduino-cli/platform-specification/#recipes-to-export-compiled-binary
    
 Only one `recipe.output.tmp`_file and `recipe.output.save_file` should be defined. The ".bin" only should be copied.
Now upload with arduino-cli works as "Export compiled Binary".