### PR TITLE
HardwareTimer: specific F1 GPIO needs Alternate Function configuration

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -668,17 +668,15 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin)
 
   if (pin != NC) {
     if ((int)get_pwm_channel(pin) == timChannel) {
+      /* Configure PWM GPIO pins */
+      pinmap_pinout(pin, PinMap_PWM);
 #if defined(STM32F1xx)
       if ((mode == TIMER_INPUT_CAPTURE_RISING) || (mode == TIMER_INPUT_CAPTURE_FALLING) \
           || (mode == TIMER_INPUT_CAPTURE_BOTHEDGE) || (mode == TIMER_INPUT_FREQ_DUTY_MEASUREMENT)) {
         // on F1 family, input alternate function must configure GPIO in input mode
-        pinMode(pin, INPUT);
-      } else
-#endif
-      {
-        /* Configure PWM GPIO pins */
-        pinmap_pinout(pin, PinMap_PWM);
+        pinMode(pinNametoDigitalPin(pin), INPUT);
       }
+#endif
     } else {
       // Pin doesn't match with timer output channels
       Error_Handler();

--- a/libraries/SrcWrapper/src/stm32/pinmap.c
+++ b/libraries/SrcWrapper/src/stm32/pinmap.c
@@ -121,6 +121,10 @@ void pin_function(PinName pin, int function)
   switch (mode) {
     case STM_PIN_INPUT:
       ll_mode = LL_GPIO_MODE_INPUT;
+#if defined(STM32F1xx)
+      // on F1 family, input mode may be associated with an alternate function
+      pin_SetAFPin(gpio, pin, afnum);
+#endif
       break;
     case STM_PIN_OUTPUT:
       ll_mode = LL_GPIO_MODE_OUTPUT;


### PR DESCRIPTION
**Summary**
HardwareTimer: specific F1 GPIO needs Alternate Function configuration

Fixes #1036