### PR TITLE
Fix DAC for F103RF and RG

### DIFF
--- a/variants/Generic_F103Rx/variant.h
+++ b/variants/Generic_F103Rx/variant.h
@@ -119,11 +119,6 @@ extern "C" {
 // Define here Serial instance number to map on Serial generic name
 #define SERIAL_UART_INSTANCE    1
 
-/* Extra HAL modules */
-#ifdef STM32F103xE
-#define HAL_DAC_MODULE_ENABLED
-#endif
-
 // Default pin used for 'Serial1' instance
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9

--- a/variants/Generic_F103Rx/variant.h
+++ b/variants/Generic_F103Rx/variant.h
@@ -123,6 +123,11 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
+/* Extra HAL modules */
+#if defined(STM32F103xE) || defined(STM32F103xG)
+#define HAL_DAC_MODULE_ENABLED
+#endif
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
These lines prevented the DAC implementation from working on F103RF and F103RG.
Note that the definition is located in PeripheralPins.c.
