### PR TITLE
HardwareTimer: Fix resume after pause issue introduced with G4 Cube update

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -113,6 +113,13 @@ void HardwareTimer::pause()
 
   // Disable timer unconditionally
   LL_TIM_DisableCounter(_timerObj.handle.Instance);
+
+#if defined(TIM_CHANNEL_STATE_SET_ALL)
+  /* Starting from G4, new Channel state implementation prevents to restart a channel,
+     if the channel has not been explicitly be stopped with HAL interface */
+  TIM_CHANNEL_STATE_SET_ALL(&(_timerObj.handle), HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET_ALL(&(_timerObj.handle), HAL_TIM_CHANNEL_STATE_READY);
+#endif
 }
 
 /**
@@ -137,6 +144,15 @@ void HardwareTimer::pauseChannel(uint32_t channel)
   // Disable channel and corresponding interrupt
   __HAL_TIM_DISABLE_IT(&(_timerObj.handle), interrupt);
   LL_TIM_CC_DisableChannel(_timerObj.handle.Instance, LLChannel);
+#if defined(TIM_CHANNEL_STATE_SET)
+  /* Starting from G4, new Channel state implementation prevents to restart a channel,
+     if the channel has not been explicitly be stopped with HAL interface */
+  if (isComplementaryChannel[channel - 1]) {
+    TIM_CHANNEL_N_STATE_SET(&(_timerObj.handle), getChannel(channel), HAL_TIM_CHANNEL_STATE_READY);
+  } else {
+    TIM_CHANNEL_STATE_SET(&(_timerObj.handle), getChannel(channel), HAL_TIM_CHANNEL_STATE_READY);
+  }
+#endif
 
   // In case 2 channels are used, disbale also the 2nd one
   if (_ChannelMode[channel - 1] == TIMER_INPUT_FREQ_DUTY_MEASUREMENT) {


### PR DESCRIPTION
**Summary**

HardwareTimer: Fix resume after pause issue introduced with G4 Cube update

New hardening has been implemented in Timer HAL (starting with G4):
The new Channel state implementation prevent to restart a channel,
if the channel has not been explicitly be stopped with HAL interface.
Arduino workaround: Channel state is forced ready when pause() or pauseChannel() is called.
