### PR TITLE
HardwareTimer: fix servo regression introduced by ARR preload enabled

### DIFF
--- a/libraries/Servo/src/stm32/Servo.cpp
+++ b/libraries/Servo/src/stm32/Servo.cpp
@@ -84,6 +84,7 @@ static void TimerServoInit()
   TimerServo.setPrescaleFactor(prescaler);
   TimerServo.setOverflow(REFRESH_INTERVAL); // thanks to prescaler Tick = microsec
   TimerServo.attachInterrupt(Servo_PeriodElapsedCallback);
+  TimerServo.setPreloadEnable(false);
   TimerServo.resume();
 }
 


### PR DESCRIPTION
**Summary**
HardwareTimer: fix servo regression introduced by ARR preload enabled

PR: HardwareTimer: Allow setting preload enable bits #900
introduced a regression in servo library.


