### PR TITLE
Fixed setting HardwareTimer interrupt priority

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -35,9 +35,6 @@
 /* Private Variables */
 timerObj_t *HardwareTimer_Handle[TIMER_NUM] = {NULL};
 
-IRQn_Type getTimerUpIrq(TIM_TypeDef *tim);
-IRQn_Type getTimerCCIrq(TIM_TypeDef *tim);
-
 /**
   * @brief  HardwareTimer constructor: set default configuration values
   * @param  Timer instance ex: TIM1, ...
@@ -913,6 +910,10 @@ void HardwareTimer::setPWM(uint32_t channel, PinName pin, uint32_t frequency, ui
   */
 void HardwareTimer::setInterruptPriority(uint32_t preemptPriority, uint32_t subPriority)
 {
+  // Set priority for immediate use
+  NVIC_SetPriority(getTimerUpIrq(_timerObj.handle.Instance), NVIC_EncodePriority(NVIC_GetPriorityGrouping(), preemptPriority, subPriority));
+
+  // Store priority for use if timer is re-initialized
   _timerObj.preemptPriority = preemptPriority;
   _timerObj.subPriority = subPriority;
 }

--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -910,8 +910,13 @@ void HardwareTimer::setPWM(uint32_t channel, PinName pin, uint32_t frequency, ui
   */
 void HardwareTimer::setInterruptPriority(uint32_t preemptPriority, uint32_t subPriority)
 {
-  // Set priority for immediate use
-  NVIC_SetPriority(getTimerUpIrq(_timerObj.handle.Instance), NVIC_EncodePriority(NVIC_GetPriorityGrouping(), preemptPriority, subPriority));
+  // Set Update interrupt priority for immediate use
+  HAL_NVIC_SetPriority(getTimerUpIrq(_timerObj.handle.Instance), preemptPriority, subPriority);
+
+  // Set Capture/Compare interrupt priority if timer provides a unique IRQ
+  if (getTimerCCIrq(_timerObj.handle.Instance) != getTimerUpIrq(_timerObj.handle.Instance)) {
+    HAL_NVIC_SetPriority(getTimerCCIrq(_timerObj.handle.Instance), preemptPriority, subPriority);
+  }
 
   // Store priority for use if timer is re-initialized
   _timerObj.preemptPriority = preemptPriority;


### PR DESCRIPTION
**Summary**

HardwareTimer interrupt priority is currently set in the constructor inside the call to `HAL_TIM_Base_Init`. Setting the priority using `HardwareTimer::setInterruptPriority` stored the priority, but it was only applied if the timer was re-initialized. This would be unlikely to ever occur for typical HardwareTimer users.

This change applies the interrupt priority immediately in addition to storing it, so that it impacts already initialized timers.

The motivation for this change is to allow Marlin firmware to utilize the latest version of this framework, without having to maintain workarounds to ensure proper interrupt priorities.

**Validation**

I verified this fix by reworking Marlin to build with the latest code from this repo. With this fix I am able to delete Marlin's HardwareTimer priority workarounds and custom copy of SoftwareSerial.

Without this change SoftwareSerial bit timing was inconsistent due to conflicting interrupts, causing communication errors.
