### PR TITLE
[PYBStick]  Add Sx pin number naming  Eg. S3 (pin 3) = D0 (arduino) = PB9 (stm32 mcu)

### DIFF
--- a/variants/PYBSTICK26_DUINO/variant.h
+++ b/variants/PYBSTICK26_DUINO/variant.h
@@ -64,6 +64,29 @@ extern "C" {
 #define NUM_DIGITAL_PINS        32
 #define NUM_ANALOG_INPUTS       8
 
+// PYBSTICK26 Sx pinout
+#define S3  PB9
+#define S5  PB8
+#define S7  PB6
+#define S8  PA2
+#define S10 PA3
+#define S11 PB3
+#define S12 PA0
+#define S13 PB10
+#define S13A  PC3
+#define S15 PB12
+#define S15A  PC5
+#define S16 PB13
+#define S16A  PC6
+#define S18 PB14
+#define S18A  PC7
+#define S19 PA7
+#define S21 PAB4
+#define S22 PA10
+#define S23 PA5
+#define S24 PA15
+#define S26 PA4
+
 // On-board LED pin number
 #define LED_GREEN               PA14
 #define LED_RED                 PA13

--- a/variants/PYBSTICK26_LITE/variant.h
+++ b/variants/PYBSTICK26_LITE/variant.h
@@ -60,6 +60,29 @@ extern "C" {
 #define NUM_DIGITAL_PINS        28
 #define NUM_ANALOG_INPUTS       6
 
+// PYBSTICK26 Sx pinout
+#define S3  PB9
+#define S5  PB8
+#define S7  PB6
+#define S8  PA2
+#define S10 PA3
+#define S11 PB3
+#define S12 PA0
+#define S13 PB10
+// #define S13A  PC3
+#define S15 PB12
+// #define S15A  PC5
+#define S16 PB13
+// #define S16A  PC6
+#define S18 PB14
+// #define S18A  PC7
+#define S19 PA7
+#define S21 PAB4
+#define S22 PA10
+#define S23 PA5
+#define S24 PA15
+#define S26 PA4
+
 // On-board LED pin number
 #define LED_GREEN               PA14
 #define LED_RED                 PA13

--- a/variants/PYBSTICK26_PRO/variant.h
+++ b/variants/PYBSTICK26_PRO/variant.h
@@ -77,6 +77,29 @@ extern "C" {
 #define NUM_DIGITAL_PINS        43
 #define NUM_ANALOG_INPUTS       8
 
+// PYBSTICK26 Sx pinout
+#define S3  PB9
+#define S5  PB8
+#define S7  PB7
+#define S8  PA2
+#define S10 PA3
+#define S11 PB3
+#define S12 PA0
+#define S13 PB10
+#define S13A  PC3
+#define S15 PB12
+#define S15A  PC5
+#define S16 PB13
+#define S16A  PC6
+#define S18 PB14
+#define S18A  PC7
+#define S19 PA7
+#define S21 PAB4
+#define S22 PA10
+#define S23 PA5
+#define S24 PA15
+#define S26 PA4
+
 // On-board LED pin number
 #define LED_GREEN               PA14
 #define LED_RED                 PA13

--- a/variants/PYBSTICK26_STD/variant.h
+++ b/variants/PYBSTICK26_STD/variant.h
@@ -71,6 +71,29 @@ extern "C" {
 #define NUM_DIGITAL_PINS        38
 #define NUM_ANALOG_INPUTS       8
 
+// PYBSTICK26 Sx pinout
+#define S3  PB9
+#define S5  PB8
+#define S7  PB6
+#define S8  PA2
+#define S10 PA3
+#define S11 PB3
+#define S12 PA0
+#define S13 PB10
+#define S13A  PC3
+#define S15 PB12
+#define S15A  PC5
+#define S16 PB13
+#define S16A  PC6
+#define S18 PB14
+#define S18A  PC7
+#define S19 PA7
+#define S21 PAB4
+#define S22 PA10
+#define S23 PA5
+#define S24 PA15
+#define S26 PA4
+
 // On-board LED pin number
 #define LED_GREEN               PA14
 #define LED_RED                 PA13


### PR DESCRIPTION
Ajout nominations port par numéro de broches Sx. Eg. S3 (broche 3) = D0 (arduino) = PB9 (port micro stm32) pour garder la cohérence avec l'utilisation de la carte sous Micropython.

Merci d'avance.
