### PR TITLE
Use more efficient mode for STM32L4XX stop mode

### DIFF
--- a/libraries/SrcWrapper/src/stm32/low_power.c
+++ b/libraries/SrcWrapper/src/stm32/low_power.c
@@ -233,8 +233,7 @@ void LowPower_stop(serial_t *obj)
 
   /* Enter Stop mode */
 #if defined(STM32L4xx) 
-  if (WakeUpUart == NULL)
-  {
+  if (WakeUpUart == NULL) {
     // STM32L4xx supports STOP2 mode which halves consumption
     HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
   } else

--- a/libraries/SrcWrapper/src/stm32/low_power.c
+++ b/libraries/SrcWrapper/src/stm32/low_power.c
@@ -233,12 +233,14 @@ void LowPower_stop(serial_t *obj)
 
   /* Enter Stop mode */
 #if defined(STM32L4xx)
-  if (WakeUpUart == NULL) {
+  if ((WakeUpUart == NULL) || (WakeUpUart->Instance == (USART_TypeDef *)LPUART1_BASE)) {
     // STM32L4xx supports STOP2 mode which halves consumption
     HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
   } else
 #endif
-    HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
+  {
+      HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
+  }
 
   /* Exit Stop mode reset clocks */
   SystemClock_ConfigFromStop();

--- a/libraries/SrcWrapper/src/stm32/low_power.c
+++ b/libraries/SrcWrapper/src/stm32/low_power.c
@@ -244,7 +244,8 @@ void LowPower_stop(serial_t *obj)
   /* Exit Stop mode reset clocks */
   SystemClock_ConfigFromStop();
 #if defined(UART_IT_WUF) && defined(HAL_UART_MODULE_ENABLED) && !defined(HAL_UART_MODULE_ONLY)
-  if (WakeUpUart != NULL) {
+  if (WakeUpUart != NULL)
+  {
     /* In case of WakeUp from UART, reset its clock source to HSI */
     uart_config_lowpower(obj);
     HAL_UARTEx_DisableStopMode(WakeUpUart);

--- a/libraries/SrcWrapper/src/stm32/low_power.c
+++ b/libraries/SrcWrapper/src/stm32/low_power.c
@@ -239,7 +239,7 @@ void LowPower_stop(serial_t *obj)
   } else
 #endif
   {
-      HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
+    HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
   }
 
   /* Exit Stop mode reset clocks */

--- a/libraries/SrcWrapper/src/stm32/low_power.c
+++ b/libraries/SrcWrapper/src/stm32/low_power.c
@@ -224,20 +224,21 @@ void LowPower_stop(serial_t *obj)
 #endif
 #ifdef __HAL_RCC_WAKEUPSTOP_CLK_CONFIG
   /* Select MSI or HSI as system clock source after Wake Up from Stop mode */
-  #ifdef RCC_STOP_WAKEUPCLOCK_MSI
-    __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_MSI);
-  #else
-    __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_HSI);
-  #endif
+#ifdef RCC_STOP_WAKEUPCLOCK_MSI
+  __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_MSI);
+#else
+  __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_HSI);
+#endif
 #endif
 
   /* Enter Stop mode */
- #if defined(STM32L4xx) 
+#if defined(STM32L4xx) 
   if (WakeUpUart == NULL)
+  {
     // STM32L4xx supports STOP2 mode which halves consumption
     HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
-  else
- #endif
+  } else
+#endif
     HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
 
   /* Exit Stop mode reset clocks */

--- a/libraries/SrcWrapper/src/stm32/low_power.c
+++ b/libraries/SrcWrapper/src/stm32/low_power.c
@@ -232,7 +232,7 @@ void LowPower_stop(serial_t *obj)
 #endif
 
   /* Enter Stop mode */
-#if defined(STM32L4xx) 
+#if defined(STM32L4xx)
   if (WakeUpUart == NULL) {
     // STM32L4xx supports STOP2 mode which halves consumption
     HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
@@ -243,8 +243,7 @@ void LowPower_stop(serial_t *obj)
   /* Exit Stop mode reset clocks */
   SystemClock_ConfigFromStop();
 #if defined(UART_IT_WUF) && defined(HAL_UART_MODULE_ENABLED) && !defined(HAL_UART_MODULE_ONLY)
-  if (WakeUpUart != NULL)
-  {
+  if (WakeUpUart != NULL) {
     /* In case of WakeUp from UART, reset its clock source to HSI */
     uart_config_lowpower(obj);
     HAL_UARTEx_DisableStopMode(WakeUpUart);

--- a/libraries/SrcWrapper/src/stm32/low_power.c
+++ b/libraries/SrcWrapper/src/stm32/low_power.c
@@ -235,7 +235,7 @@ void LowPower_stop(serial_t *obj)
  #if defined(STM32L4xx) 
   if (WakeUpUart == NULL)
     // STM32L4xx supports STOP2 mode which halves consumption
-    HAL_PWREx_EnterSTOP2Mode(STOPEntry);
+    HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
   else
  #endif
     HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);

--- a/libraries/SrcWrapper/src/stm32/low_power.c
+++ b/libraries/SrcWrapper/src/stm32/low_power.c
@@ -223,12 +223,22 @@ void LowPower_stop(serial_t *obj)
   HAL_PWREx_EnableFastWakeUp();
 #endif
 #ifdef __HAL_RCC_WAKEUPSTOP_CLK_CONFIG
-  /* Select HSI as system clock source after Wake Up from Stop mode */
-  __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_HSI);
+  /* Select MSI or HSI as system clock source after Wake Up from Stop mode */
+  #ifdef RCC_STOP_WAKEUPCLOCK_MSI
+    __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_MSI);
+  #else
+    __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_HSI);
+  #endif
 #endif
 
   /* Enter Stop mode */
-  HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
+ #if defined(STM32L4xx) 
+  if (WakeUpUart == NULL)
+    // STM32L4xx supports STOP2 mode which halves consumption
+    HAL_PWREx_EnterSTOP2Mode(STOPEntry);
+  else
+ #endif
+    HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
 
   /* Exit Stop mode reset clocks */
   SystemClock_ConfigFromStop();


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [X] Feature 1 - save power in stop mode for STM32L4XX devices
* [X] Feature 2 - Use MSI as wake up clock when available
* [ ] Breaking changes

**Feature 1**
Currently the low power library uses HAL_PWR_EnterSTOPMode for all devices. This does not leverage the stop2 mode which is available in the STM32L4XX. This results in 4,6 uA instead of 1,35 uA in my nucleo_l412kb.

Stop1 is only required when the UART device needs to wake up. So when not used the patch calls HAL_PWREx_EnterSTOP2Mode directly.

**Feature 2**
When available use the MSI as wake up clock. This avoids starting the HSI which generates a short spike of ca 300 uA until the SystemClock_ConfigFromStop is called.

**Validation**

* Ensure CI build is passed.
* Demonstrate the code is solid. [e.g. Provide a sketch]

Not adding a new sketch since no external APIs are changed by this patch. 

**Code formatting**

* Ensure AStyle check is passed thanks CI

**Closing issues**
NA
