### PR TITLE
Remove BRR definition for stm32l151xc devices

### DIFF
--- a/system/Drivers/CMSIS/Device/ST/STM32L1xx/Include/stm32l151xc.h
+++ b/system/Drivers/CMSIS/Device/ST/STM32L1xx/Include/stm32l151xc.h
@@ -339,7 +339,6 @@ typedef struct
   __IO uint32_t BSRR;         /*!< GPIO port bit set/reset registerBSRR,        Address offset: 0x18      */
   __IO uint32_t LCKR;         /*!< GPIO port configuration lock register,       Address offset: 0x1C      */
   __IO uint32_t AFR[2];       /*!< GPIO alternate function register,            Address offset: 0x20-0x24 */
-  __IO uint32_t BRR;          /*!< GPIO bit reset register,                     Address offset: 0x28      */
 } GPIO_TypeDef;
 
 /**
@@ -3607,24 +3606,6 @@ typedef struct
 #define GPIO_AFRH_AFSEL15_Pos                  (28U)
 #define GPIO_AFRH_AFSEL15_Msk                  (0xFUL << GPIO_AFRH_AFSEL15_Pos)     /*!< 0xF0000000 */
 #define GPIO_AFRH_AFSEL15                      GPIO_AFRH_AFSEL15_Msk
-
-/****************** Bit definition for GPIO_BRR register  *********************/
-#define GPIO_BRR_BR_0                        (0x00000001U)
-#define GPIO_BRR_BR_1                        (0x00000002U)
-#define GPIO_BRR_BR_2                        (0x00000004U)
-#define GPIO_BRR_BR_3                        (0x00000008U)
-#define GPIO_BRR_BR_4                        (0x00000010U)
-#define GPIO_BRR_BR_5                        (0x00000020U)
-#define GPIO_BRR_BR_6                        (0x00000040U)
-#define GPIO_BRR_BR_7                        (0x00000080U)
-#define GPIO_BRR_BR_8                        (0x00000100U)
-#define GPIO_BRR_BR_9                        (0x00000200U)
-#define GPIO_BRR_BR_10                       (0x00000400U)
-#define GPIO_BRR_BR_11                       (0x00000800U)
-#define GPIO_BRR_BR_12                       (0x00001000U)
-#define GPIO_BRR_BR_13                       (0x00002000U)
-#define GPIO_BRR_BR_14                       (0x00004000U)
-#define GPIO_BRR_BR_15                       (0x00008000U)
 
 /******************************************************************************/
 /*                                                                            */


### PR DESCRIPTION
Bug: Cannot set GPIO to low on stm32l151xc

The issue was described in #983

According to the reference manual (RM0038 Rev 16),
chapter 7.4.11 - GPIO bit reset register, the bit reset register (BRR)
is not available on stm32l151xc (Cat. 3) devices.


A PR on upstream project as been open: https://github.com/STMicroelectronics/STM32CubeL1/pull/5