### PR TITLE
[WIP] stm32L0xx soc series has an embedded EEPROM

### DIFF
--- a/cores/arduino/stm32/stm32_eeprom.h
+++ b/cores/arduino/stm32/stm32_eeprom.h
@@ -107,10 +107,12 @@ extern "C" {
 uint8_t eeprom_read_byte(const uint32_t pos);
 void eeprom_write_byte(uint32_t pos, uint8_t value);
 
+#if !defined(DATA_EEPROM_BASE)
 void eeprom_buffer_fill();
 void eeprom_buffer_flush();
 uint8_t eeprom_buffered_read_byte(const uint32_t pos);
 void eeprom_buffered_write_byte(uint32_t pos, uint8_t value);
+#endif /* ! DATA_EEPROM_BASE */
 
 #ifdef __cplusplus
 }

--- a/cores/arduino/stm32/stm32_eeprom.h
+++ b/cores/arduino/stm32/stm32_eeprom.h
@@ -80,7 +80,25 @@ extern "C" {
  */
 #define FLASH_PAGE_SIZE     ((uint32_t)(16*1024)) /* 16kB page */
 #endif
+
+#if defined(DATA_EEPROM_BASE) || defined(FLASH_EEPROM_BASE)
+
+#if defined (DATA_EEPROM_END)
+#define E2END (DATA_EEPROM_END - DATA_EEPROM_BASE)
+#elif defined (DATA_EEPROM_BANK2_END)
+/* assuming two contiguous banks */
+#define DATA_EEPROM_END DATA_EEPROM_BANK2_END
+#define E2END (DATA_EEPROM_BANK2_END - DATA_EEPROM_BASE)
+#elif defined (FLASH_EEPROM_END)
+#define DATA_EEPROM_BASE FLASH_EEPROM_BASE
+#define DATA_EEPROM_END FLASH_EEPROM_END
+#define E2END (DATA_EEPROM_END - DATA_EEPROM_BASE)
+#endif /* __EEPROM_END */
+
+#else /* _EEPROM_BASE */
 #define E2END (FLASH_PAGE_SIZE - 1)
+#endif /* _EEPROM_BASE */
+
 #endif
 
 /* Exported macro ------------------------------------------------------------*/

--- a/libraries/SrcWrapper/src/stm32/stm32_eeprom.c
+++ b/libraries/SrcWrapper/src/stm32/stm32_eeprom.c
@@ -142,7 +142,9 @@ static inline uint32_t get_flash_end(void)
 #endif
 #endif /* FLASH_BASE_ADDRESS */
 
+#if !defined(DATA_EEPROM_BASE)
 static uint8_t eeprom_buffer[E2END + 1] __attribute__((aligned(8))) = {0};
+#endif
 
 /**
   * @brief  Function reads a byte from emulated eeprom (flash)
@@ -156,8 +158,6 @@ uint8_t eeprom_read_byte(const uint32_t pos)
   if (pos <= (DATA_EEPROM_END - DATA_EEPROM_BASE)) {
     /* with actual EEPROM, pos is a relative address */
     data = *(__IO uint8_t *)(DATA_EEPROM_BASE + pos);
-    /* align content of the buffered eeprom */
-    eeprom_buffer[pos] = (uint8_t)data;
   }
   return (uint8_t)data;
 #else
@@ -182,13 +182,13 @@ void eeprom_write_byte(uint32_t pos, uint8_t value)
       HAL_FLASHEx_DATAEEPROM_Lock();
     }
   }
-  /* align content of the buffered eeprom */
-  eeprom_buffer[pos] = (uint8_t)value;
 #else
   eeprom_buffered_write_byte(pos, value);
   eeprom_buffer_flush();
 #endif /* _EEPROM_BASE */
 }
+
+#if !defined(DATA_EEPROM_BASE)
 
 /**
   * @brief  Function reads a byte from the eeprom buffer
@@ -330,6 +330,8 @@ void eeprom_buffer_flush(void)
 }
 
 #endif /* defined(EEPROM_RETRAM_MODE) */
+
+#endif /* ! DATA_EEPROM_BASE */
 
 #ifdef __cplusplus
 }

--- a/libraries/SrcWrapper/src/stm32/stm32_eeprom.c
+++ b/libraries/SrcWrapper/src/stm32/stm32_eeprom.c
@@ -42,8 +42,8 @@ extern "C" {
 /* Be able to change FLASH_BANK_NUMBER to use if relevant */
 #if !defined(FLASH_BANK_NUMBER) &&\
     (defined(STM32F0xx) || defined(STM32F1xx) || defined(STM32G4xx) ||\
-     defined(STM32H7xx) || defined(STM32L1xx) || defined(STM32L4xx))
-/* Fo STM32F0xx, FLASH_BANK_1 is not defined only FLASH_BANK1_END is defined */
+     defined(STM32H7xx) || defined(STM32L4xx))
+/* For STM32F0xx, FLASH_BANK_1 is not defined only FLASH_BANK1_END is defined */
 #if defined(STM32F0xx)
 #define FLASH_BANK_1 1U
 #endif
@@ -58,7 +58,7 @@ extern "C" {
 #endif /* !FLASH_BANK_NUMBER */
 
 /* Be able to change FLASH_DATA_SECTOR to use if relevant */
-#if defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32F7xx)  ||\
+#if defined(STM32F2xx) || defined(STM32F4xx) || defined(STM32F7xx) ||\
     defined(STM32H7xx)
 #if !defined(FLASH_DATA_SECTOR)
 #define FLASH_DATA_SECTOR   ((uint32_t)(FLASH_SECTOR_TOTAL - 1))
@@ -77,8 +77,8 @@ extern "C" {
 #endif /* !FLASH_PAGE_NUMBER */
 
 /* Be able to change FLASH_END to use */
-#if !defined(FLASH_END) && !defined(STM32L0xx)
-#if defined (STM32F0xx) || defined (STM32F1xx) || defined(STM32L1xx)
+#if !defined(FLASH_END)
+#if defined (STM32F0xx) || defined (STM32F1xx)
 #if defined (FLASH_BANK2_END) && (FLASH_BANK_NUMBER == FLASH_BANK_2)
 #define FLASH_END  FLASH_BANK2_END
 #elif defined (FLASH_BANK1_END) && (FLASH_BANK_NUMBER == FLASH_BANK_1)
@@ -117,6 +117,8 @@ static inline uint32_t get_flash_end(void)
 #define FLASH_END  ((uint32_t)(FLASH_BASE + (((FLASH_PAGE_NUMBER +1) * FLASH_PAGE_SIZE))-1))
 #elif defined(EEPROM_RETRAM_MODE)
 #define FLASH_END  ((uint32_t)(EEPROM_RETRAM_START_ADDRESS + EEPROM_RETRAM_MODE_SIZE -1))
+#elif defined(DATA_EEPROM_END)
+#define FLASH_END DATA_EEPROM_END
 #endif
 #ifndef FLASH_END
 #error "FLASH_END could not be defined"
@@ -130,9 +132,7 @@ static inline uint32_t get_flash_end(void)
  * in order to prevent overwritting
  * program data
  */
-#if defined(STM32L0xx)
-#define FLASH_BASE_ADDRESS  ((uint32_t)(DATA_EEPROM_BASE))
-#elif defined(EEPROM_RETRAM_MODE)
+#if defined(EEPROM_RETRAM_MODE)
 #define FLASH_BASE_ADDRESS  EEPROM_RETRAM_START_ADDRESS
 #else
 #define FLASH_BASE_ADDRESS  ((uint32_t)((FLASH_END + 1) - FLASH_PAGE_SIZE))
@@ -247,8 +247,8 @@ void eeprom_buffer_flush(void)
   uint32_t address = FLASH_BASE_ADDRESS;
   uint32_t address_end = FLASH_BASE_ADDRESS + E2END;
 #if defined (STM32F0xx) || defined (STM32F1xx) || defined (STM32F3xx) || \
-    defined (STM32G0xx) || defined (STM32G4xx) || defined (STM32L0xx) || \
-    defined (STM32L1xx) || defined (STM32L4xx) || defined (STM32WBxx)
+    defined (STM32G0xx) || defined (STM32G4xx) || \
+    defined (STM32L4xx) || defined (STM32WBxx)
   uint32_t pageError = 0;
   uint64_t data = 0;
 
@@ -266,19 +266,7 @@ void eeprom_buffer_flush(void)
   EraseInitStruct.NbPages = 1;
 
   if (HAL_FLASH_Unlock() == HAL_OK) {
-#if defined(STM32L0xx)
-    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | \
-                           FLASH_FLAG_SIZERR | FLASH_FLAG_OPTVERR | FLASH_FLAG_RDERR | \
-                           FLASH_FLAG_FWWERR | FLASH_FLAG_NOTZEROERR);
-#elif defined(STM32L1xx)
-#if defined(FLASH_SR_RDERR)
-    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | \
-                           FLASH_FLAG_SIZERR | FLASH_FLAG_OPTVERR | FLASH_FLAG_RDERR);
-#else
-    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | \
-                           FLASH_FLAG_SIZERR | FLASH_FLAG_OPTVERR);
-#endif
-#elif defined (STM32G0xx) || defined (STM32G4xx) || defined (STM32L4xx) || \
+#if defined (STM32G0xx) || defined (STM32G4xx) || defined (STM32L4xx) || \
       defined (STM32WBxx)
     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
 #else
@@ -286,18 +274,12 @@ void eeprom_buffer_flush(void)
 #endif
     if (HAL_FLASHEx_Erase(&EraseInitStruct, &pageError) == HAL_OK) {
       while (address <= address_end) {
-#if defined(STM32L0xx) || defined(STM32L1xx)
-        memcpy(&data, eeprom_buffer + offset, sizeof(uint32_t));
-        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, data) == HAL_OK) {
-          address += 4;
-          offset += 4;
-#else
+
         data = *((uint64_t *)((uint8_t *)eeprom_buffer + offset));
 
         if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address, data) == HAL_OK) {
           address += 8;
           offset += 8;
-#endif
         } else {
           address = address_end + 1;
         }


### PR DESCRIPTION
The EEPROM area of the stm32L0xx or stm32L1xx devices is mapped in the non volatile memory
and accessed with dedicated HAL functions.
The `eeprom_write_byte` and `eeprom_read_byte` functions are valid for this actual EEPROM area to access byte per byte. 
For stm32L0 and L1 devices the buffered method (`eeprom_buffer_fill`, `eeprom_buffer_flush`) is not well suited especially for writing.
I**t is decided to  remove `eeprom_buffer_fill`, `eeprom_buffer_flush` in case of stm32L0x and stm32L1x.**

> Note:  the eeprom_buffer structure used for buffered operations is sized by a FLASH PAGE (usually 128 or 256 bytes). For stm32L0 and stm32L1, the eeprom_buffer cannot map the whole EEPROM area, else is the time to flush (write) too long (up to 15 seconds to flush 16K).

With this patch the EEPROM.length() reports 0x1800  for stm32L0 devices with 6K-EEPROM.

Fixes #1016
