### PR TITLE
Fix flash offset on HY_TinySTM103T variant.

### DIFF
--- a/variants/HY_TinySTM103T/ldscript.ld
+++ b/variants/HY_TinySTM103T/ldscript.ld
@@ -60,7 +60,7 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
+RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
 FLASH (rx)      : ORIGIN = 0x8000000 + LD_FLASH_OFFSET, LENGTH = LD_MAX_SIZE - LD_FLASH_OFFSET
 }
 

--- a/variants/HY_TinySTM103T/ldscript.ld
+++ b/variants/HY_TinySTM103T/ldscript.ld
@@ -2,10 +2,10 @@
 *****************************************************************************
 **
 
-**  File        : LinkerScript.ld
+**  File        : ldscript.ld
 **
-**  Abstract    : Linker script for STM32F103CBTx Device with
-**                128KByte FLASH, 20KByte RAM
+**  Abstract    : Linker script for STM32F103C(8-B)Tx Device with
+**                32/64/128KByte FLASH, 10/20KByte RAM
 **
 **                Set heap size, stack size and stack location according
 **                to application requirements.
@@ -52,7 +52,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20005000;    /* end of RAM */
+_estack = 0x20000000 + LD_MAX_DATA_SIZE;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
@@ -60,8 +60,8 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 20K
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 128K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
+FLASH (rx)      : ORIGIN = 0x8000000 + LD_FLASH_OFFSET, LENGTH = LD_MAX_SIZE - LD_FLASH_OFFSET
 }
 
 /* Define output sections */


### PR DESCRIPTION
The linker script for the HY_TinySTM103T variant ignored the
LD_FLASH_OFFSET linker flags. This prevented proper operation when using
a bootloader on these boards. The linker script has been replaced with
the generic F103 linkerscript that properly implements this.
