### PR TITLE
HardwareTimer: pause() need to call HAL API to restore HAL state

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -108,7 +108,11 @@ void HardwareTimer::pause()
   __HAL_TIM_DISABLE_IT(&(_timerObj.handle), TIM_IT_CC3);
   __HAL_TIM_DISABLE_IT(&(_timerObj.handle), TIM_IT_CC4);
 
-  // Disable timer unconditionally
+  // Stop timer. Required to restore HAL State: HAL_TIM_STATE_READY
+  HAL_TIM_Base_Stop(&(_timerObj.handle));
+
+  /* Disable timer unconditionally. Required to guarantee timer is stopped,
+   * even if some channels are still running */
   LL_TIM_DisableCounter(_timerObj.handle.Instance);
 
 #if defined(TIM_CHANNEL_STATE_SET_ALL)


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->
HardwareTimer: pause() need to call HAL API to restore HAL state


Due to HAL Cube update (ex: for STM32L4 sha1 f41f10ebd7d73cc055449424a9dd85589de92924)
it is now required to stop timer with HAL API
otherwise HAL state is not restored to HAL_TIM_STATE_READY,
and it is not possible to `resume()` a HardwareTimer after a `pause().`
Nevertheless it is not sufficient to guarantee that timer is stopped.
specially if some channels are still running.
So it is also necessary to keep also the call to LL_TIM_DisableCounter()


