### PR TITLE
Fix flash latency for F4x5RG running full speed at 168MHz

### DIFF
--- a/variants/Generic_F4x5RG/variant.cpp
+++ b/variants/Generic_F4x5RG/variant.cpp
@@ -158,7 +158,7 @@ static uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
   RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         // 168 MHz
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;           // 42 MHz
   RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;           // 84 MHz
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK) {
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5) != HAL_OK) {
     return 0; // FAIL
   }
 
@@ -208,7 +208,7 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         // 168 MHz
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;           // 42 MHz
   RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;           // 84 MHz
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK) {
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5) != HAL_OK) {
     return 0; // FAIL
   }
 


### PR DESCRIPTION
Change 2 instances:

From:
HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1)
To:
HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5)

**Summary**
This PR fixes/implements the following **bugs/features**

[x] Bug 1 - incorrect FLASH LATENCY at 168MHz causing processor crash upon startup.

Also discussed here https://community.platformio.org/t/stm32duino-stm32f405rg-on-vesc-bldc-controller/14671