### PR TITLE
Add requestFrom(uint8_t address, size_t quantity, bool sendStop)

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -172,6 +172,11 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint32_t)0, (uint8_t)0, (uint8_t)sendStop);
 }
 
+uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop)
+{
+  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)sendStop);
+}
+
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
 {
   return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -96,6 +96,7 @@ class TwoWire : public Stream {
     uint8_t endTransmission(uint8_t);
     uint8_t requestFrom(uint8_t, uint8_t);
     uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
+    uint8_t requestFrom(uint8_t, size_t, bool);
     uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
     uint8_t requestFrom(int, int);
     uint8_t requestFrom(int, int, int);


### PR DESCRIPTION
This PR adds a missing function declaration that aligns further with the arduino spec as specified in issue #1183 

This is to fix compilation with an external Arduino library [ArduinoECCX08](https://github.com/arduino-libraries/ArduinoECCX08)

Fixes #1183 
