### PR TITLE
[G0] Fix USART IRQ handler

### DIFF
--- a/libraries/SrcWrapper/src/stm32/uart.c
+++ b/libraries/SrcWrapper/src/stm32/uart.c
@@ -914,7 +914,7 @@ void USART3_IRQHandler(void)
   if (uart_handlers[UART3_INDEX] != NULL) {
     HAL_UART_IRQHandler(uart_handlers[UART3_INDEX]);
   }
-#if defined(STM32F0xx)
+#if defined(STM32F0xx) || defined(STM32G0xx)
   /* USART3_4_IRQn */
   if (uart_handlers[UART4_INDEX] != NULL) {
     HAL_UART_IRQHandler(uart_handlers[UART4_INDEX]);
@@ -927,7 +927,12 @@ void USART3_IRQHandler(void)
     HAL_UART_IRQHandler(uart_handlers[UART6_INDEX]);
   }
 #endif /* STM32F030xC */
-#endif /* STM32F0xx */
+#if defined(STM32G0xx) && defined(LPUART1_BASE)
+  if (uart_handlers[LPUART1_INDEX] != NULL) {
+    HAL_UART_IRQHandler(uart_handlers[LPUART1_INDEX]);
+  }
+#endif /* STM32G0xx && LPUART1_BASE */
+#endif /* STM32F0xx || STM32G0xx */
 #endif /* STM32F091xC || STM32F098xx */
 }
 #endif


### PR DESCRIPTION
After fixing this issue https://github.com/stm32duino/Arduino_Core_STM32/pull/1141
IRQ handler was not updated then for `USART4 `and `LPUART1 `the  `HAL_UART_IRQHandler` is not called.

Fix #1188