### PR TITLE
Moved from arm-none-eabi-gcc 9.3.1-1.2 to 9.3.1-1.3

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -17,7 +17,7 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
-compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-9.3.1-1.2.path}/bin/
+compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-9.3.1-1.3.path}/bin/
 
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.c.cmd=arm-none-eabi-gcc


### PR DESCRIPTION
See https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/v9.3.1-1.3/

