### PR TITLE
Wire fixes for repeated start(slave) and multiple .write in onRequestEvent()

### DIFF
--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -846,10 +846,10 @@ i2c_status_e i2c_slave_write_IT(i2c_t *obj, uint8_t *data, uint16_t size)
   } else {
     // Check the communication status
     for (i = 0; i < size; i++) {
-      obj->i2cTxRxBuffer[i] = *(data + i);
+      obj->i2cTxRxBuffer[obj->i2cTxRxBufferSize + i] = *(data + i);
     }
 
-    obj->i2cTxRxBufferSize = size;
+    obj->i2cTxRxBufferSize += size;
   }
   return ret;
 }
@@ -986,6 +986,7 @@ void HAL_I2C_AddrCallback(I2C_HandleTypeDef *hi2c, uint8_t TransferDirection, ui
       obj->slaveMode = SLAVE_MODE_TRANSMIT;
 
       if (obj->i2c_onSlaveTransmit != NULL) {
+        obj->i2cTxRxBufferSize = 0;
         obj->i2c_onSlaveTransmit(obj);
       }
 #if defined(STM32F0xx) || defined(STM32F1xx) || defined(STM32F2xx) || defined(STM32F3xx) ||\

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -980,6 +980,11 @@ void i2c_attachSlaveTxEvent(i2c_t *obj, void (*function)(i2c_t *))
 void HAL_I2C_AddrCallback(I2C_HandleTypeDef *hi2c, uint8_t TransferDirection, uint16_t AddrMatchCode)
 {
   i2c_t *obj = get_i2c_obj(hi2c);
+  if ((obj->slaveMode == SLAVE_MODE_RECEIVE) && (obj->slaveRxNbData != 0)) {
+    obj->i2c_onSlaveReceive(obj);
+    obj->slaveMode = SLAVE_MODE_LISTEN;
+    obj->slaveRxNbData = 0;
+  }
 
   if (AddrMatchCode == hi2c->Init.OwnAddress1) {
     if (TransferDirection == I2C_DIRECTION_RECEIVE) {


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] when in slave mode and we are receiving a write/read combo with a repeated start(so no stop condition in between), the write part doesn't trigger an onReceiveEvent()
* [x] when doing multiple .write() calls in onRequestEvent(), only the last one is used. (as outlined in #488 )

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Description**

* The slave implementation doesn't seem to work with repeated starts, but this is also a quick fix by sending out an onReceiveEvent() when getting the new address callback.

* In #488 it was mentioned to just use one write, but I think this is not good behavior, since it's not mentioned in the documentation. Nevertheless, it seems to be a quick fix, so I just created this PR.

**How it works**

* When getting the address callback, the data which has been cached is sent to an onReceiveEvent, when still in SLAVE_MODE_RECEIVE mode.

* We are resetting i2cTxRxBufferSize before calling i2c_onSlaveTransmit() in HAL_I2C_AddrCallback()
and modify the function i2c_slave_write_IT() to start writing in the i2cTxRxBuffer with the size of the buffer as offset and add up the sizes.
