### PR TITLE
fix: variant default i2c pointed to i2c2

### DIFF
--- a/variants/Generic_F4x3Cx/variant.h
+++ b/variants/Generic_F4x3Cx/variant.h
@@ -94,8 +94,8 @@ extern "C" {
 #define PIN_SPI_SCK             PA5
 
 // I2C definitions
-#define PIN_WIRE_SDA            PB9
-#define PIN_WIRE_SCL            PB8
+#define PIN_WIRE_SDA            PB7
+#define PIN_WIRE_SCL            PB6
 
 // Timer Definitions
 #define TIMER_TONE              TIM10


### PR DESCRIPTION
## Pull Request template

Please, Make sure that your PR is not a duplicate.
Search among the [Pull request](https://github.com/stm32duino/Arduino_Core_STM32/pulls) before creating one.

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

Thanks for submitting a pull request.
Please provide enough information so that others can review your pull request:

**Summary**

The default (channel 1) i2c pins for these chips is SCL: pb6 and SDA pb7.

This PR fixes/implements the following **bugs/features**

* [x] Fixes default i2c pins for these chip
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Validation**

* Ensure CI build is passed.
* Demonstrate the code is solid. [e.g. Provide a sketch]

<!-- Make sure tests pass on both CI. -->

**Code formatting**

* Ensure AStyle check is passed thanks CI

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #xxx
