### PR TITLE
allow users to tweak the I2C timeout

### DIFF
--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -45,7 +45,9 @@ extern "C" {
 
 /* Private Defines */
 /// @brief I2C timout in tick unit
-#define I2C_TIMEOUT_TICK        100
+#if !defined(I2C_TIMEOUT_TICK)
+    #define I2C_TIMEOUT_TICK        100
+#endif
 
 #define SLAVE_MODE_TRANSMIT     0
 #define SLAVE_MODE_RECEIVE      1

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -45,8 +45,8 @@ extern "C" {
 
 /* Private Defines */
 /// @brief I2C timout in tick unit
-#if !defined(I2C_TIMEOUT_TICK)
-    #define I2C_TIMEOUT_TICK        100
+#ifndef I2C_TIMEOUT_TICK
+#define I2C_TIMEOUT_TICK        100
 #endif
 
 #define SLAVE_MODE_TRANSMIT     0


### PR DESCRIPTION
**Summary**

This PR allow advanced users to tweak I2C timeout.

In some real time critical devices (MakAir ventilator for example), I2C reading of any device timeout after 100ms in case of bus hardware failure (short circuit between lines or bus lines to ground).


