### PR TITLE
docs: fix simple typo, transfered -> transferred

### DIFF
--- a/system/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_ll_adc.h
+++ b/system/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_ll_adc.h
@@ -2809,7 +2809,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsDisableOngoing(ADC_TypeDef *ADCx)
   *         On this STM32 serie, ADC DMA transfer request should be disabled
   *         during calibration:
   *         Calibration factor is available in data register
-  *         and also transfered by DMA.
+  *         and also transferred by DMA.
   *         To not insert ADC calibration factor among ADC conversion data
   *         in array variable, DMA transfer must be disabled during
   *         calibration.

--- a/system/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_adc_ex.c
+++ b/system/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_adc_ex.c
@@ -116,7 +116,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc)
     
     /* Disable ADC DMA transfer request during calibration */
     /* Note: Specificity of this STM32 serie: Calibration factor is           */
-    /*       available in data register and also transfered by DMA.           */
+    /*       available in data register and also transferred by DMA.           */
     /*       To not insert ADC calibration factor among ADC conversion data   */
     /*       in array variable, DMA transfer must be disabled during          */
     /*       calibration.                                                     */

--- a/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_ll_dma2d.h
+++ b/system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_ll_dma2d.h
@@ -129,7 +129,7 @@ typedef struct
 
                                       This parameter can be modified afterwards using unitary function @ref LL_DMA2D_SetNbrOfLines(). */
 
-  uint32_t NbrOfPixelsPerLines;  /*!< Specifies the number of pixels per lines of the area to be transfered.
+  uint32_t NbrOfPixelsPerLines;  /*!< Specifies the number of pixels per lines of the area to be transferred.
                                       - This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0x3FFF.
 
                                       This parameter can be modified afterwards using unitary function @ref LL_DMA2D_SetNbrOfPixelsPerLines(). */

--- a/system/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_dma2d.h
+++ b/system/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_dma2d.h
@@ -129,7 +129,7 @@ typedef struct
 
                                       This parameter can be modified afterwards using unitary function @ref LL_DMA2D_SetNbrOfLines(). */
 
-  uint32_t NbrOfPixelsPerLines;  /*!< Specifies the number of pixels per lines of the area to be transfered.
+  uint32_t NbrOfPixelsPerLines;  /*!< Specifies the number of pixels per lines of the area to be transferred.
                                       - This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0x3FFF.
 
                                       This parameter can be modified afterwards using unitary function @ref LL_DMA2D_SetNbrOfPixelsPerLines(). */

--- a/system/Drivers/STM32G0xx_HAL_Driver/Inc/stm32g0xx_ll_adc.h
+++ b/system/Drivers/STM32G0xx_HAL_Driver/Inc/stm32g0xx_ll_adc.h
@@ -4227,7 +4227,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsDisableOngoing(ADC_TypeDef *ADCx)
   *         On this STM32 serie, ADC DMA transfer request should be disabled
   *         during calibration:
   *         Calibration factor is available in data register
-  *         and also transfered by DMA.
+  *         and also transferred by DMA.
   *         To not insert ADC calibration factor among ADC conversion data
   *         in array variable, DMA transfer must be disabled during
   *         calibration.

--- a/system/Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_adc_ex.c
+++ b/system/Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_adc_ex.c
@@ -128,7 +128,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc)
 
     /* Disable ADC DMA transfer request during calibration */
     /* Note: Specificity of this STM32 serie: Calibration factor is           */
-    /*       available in data register and also transfered by DMA.           */
+    /*       available in data register and also transferred by DMA.           */
     /*       To not insert ADC calibration factor among ADC conversion data   */
     /*       in array variable, DMA transfer must be disabled during          */
     /*       calibration.                                                     */

--- a/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h
@@ -163,7 +163,7 @@ typedef struct
                                        If trigger source is set to ADC_SOFTWARE_START, this parameter is discarded.
                                        This parameter can be a value of @ref ADC_regular_external_trigger_edge */
 
-  uint32_t ConversionDataManagement; /*!< Specifies whether the Data conversion data is managed: using the DMA (oneshot or circular), or stored in the DR register or transfered to DFSDM register.
+  uint32_t ConversionDataManagement; /*!< Specifies whether the Data conversion data is managed: using the DMA (oneshot or circular), or stored in the DR register or transferred to DFSDM register.
                                        Note: In continuous mode, DMA must be configured in circular mode. Otherwise an overrun will be triggered when DMA buffer maximum pointer is reached.
                                        This parameter can be a value of @ref ADC_ConversionDataManagement.
                                        Note: This parameter must be modified when no conversion is on going on both regular and injected groups

--- a/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc_ex.h
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc_ex.h
@@ -415,7 +415,7 @@ typedef struct
   * @{
   */
 #define ADC_DFSDM_MODE_DISABLE     (0x00000000UL)                     /*!< ADC conversions are not transferred by DFSDM. */
-#define ADC_DFSDM_MODE_ENABLE      (LL_ADC_REG_DFSDM_TRANSFER_ENABLE) /*!< ADC conversion data are transfered to DFSDM for post processing. The ADC conversion data format must be 16-bit signed and right aligned, refer to reference manual. DFSDM transfer cannot be used if DMA transfer is enabled. */
+#define ADC_DFSDM_MODE_ENABLE      (LL_ADC_REG_DFSDM_TRANSFER_ENABLE) /*!< ADC conversion data are transferred to DFSDM for post processing. The ADC conversion data format must be 16-bit signed and right aligned, refer to reference manual. DFSDM transfer cannot be used if DMA transfer is enabled. */
 /**
   * @}
   */

--- a/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_dma2d.h
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_dma2d.h
@@ -137,7 +137,7 @@ typedef struct
 
                                       This parameter can be modified afterwards using unitary function @ref LL_DMA2D_SetNbrOfLines(). */
 
-  uint32_t NbrOfPixelsPerLines;  /*!< Specifies the number of pixels per lines of the area to be transfered.
+  uint32_t NbrOfPixelsPerLines;  /*!< Specifies the number of pixels per lines of the area to be transferred.
                                       - This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0x3FFF.
 
                                       This parameter can be modified afterwards using unitary function @ref LL_DMA2D_SetNbrOfPixelsPerLines(). */

--- a/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_mdma.c
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_mdma.c
@@ -1755,7 +1755,7 @@ uint32_t HAL_MDMA_GetError(MDMA_HandleTypeDef *hmdma)
   * @param  SrcAddress: The source memory Buffer address
   * @param  DstAddress: The destination memory Buffer address
   * @param  BlockDataLength : The length of a block transfer in bytes
-  * @param  BlockCount: The number of blocks to be transfered
+  * @param  BlockCount: The number of blocks to be transferred
   * @retval HAL status
   */
 static void MDMA_SetConfig(MDMA_HandleTypeDef *hmdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t BlockDataLength, uint32_t BlockCount)

--- a/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_mmc_ex.c
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_mmc_ex.c
@@ -77,8 +77,8 @@
 /**
   * @brief  Configure DMA Dual Buffer mode. The Data transfer is managed by an Internal DMA.
   * @param  hmmc: MMC handle
-  * @param  pDataBuffer0: Pointer to the buffer0 that will contain/receive the transfered data
-  * @param  pDataBuffer1: Pointer to the buffer1 that will contain/receive the transfered data
+  * @param  pDataBuffer0: Pointer to the buffer0 that will contain/receive the transferred data
+  * @param  pDataBuffer1: Pointer to the buffer1 that will contain/receive the transferred data
   * @param  BufferSize: Size of Buffer0 in Blocks. Buffer0 and Buffer1 must have the same size.
   * @retval HAL status
   */
@@ -180,7 +180,7 @@ HAL_StatusTypeDef HAL_MMCEx_ReadBlocksDMAMultiBuffer(MMC_HandleTypeDef *hmmc, ui
 }
 
 /**
-  * @brief  Write block(s) to a specified address in a card. The transfered Data are stored in Buffer0 and Buffer1.
+  * @brief  Write block(s) to a specified address in a card. The transferred Data are stored in Buffer0 and Buffer1.
   *         Buffer0, Buffer1 and BufferSize need to be configured by function HAL_MMCEx_ConfigDMAMultiBuffer before call this function.
   * @param  hmmc: MMC handle
   * @param  BlockAdd: Block Address from where data is to be read

--- a/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd_ex.c
+++ b/system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd_ex.c
@@ -74,8 +74,8 @@
 /**
   * @brief  Configure DMA Dual Buffer mode. The Data transfer is managed by an Internal DMA.
   * @param  hsd: SD handle
-  * @param  pDataBuffer0: Pointer to the buffer0 that will contain/receive the transfered data
-  * @param  pDataBuffer1: Pointer to the buffer1 that will contain/receive the transfered data
+  * @param  pDataBuffer0: Pointer to the buffer0 that will contain/receive the transferred data
+  * @param  pDataBuffer1: Pointer to the buffer1 that will contain/receive the transferred data
   * @param  BufferSize: Size of Buffer0 in Blocks. Buffer0 and Buffer1 must have the same size.
   * @retval HAL status
   */
@@ -179,7 +179,7 @@ HAL_StatusTypeDef HAL_SDEx_ReadBlocksDMAMultiBuffer(SD_HandleTypeDef *hsd, uint3
 }
 
 /**
-  * @brief  Write block(s) to a specified address in a card. The transfered Data are stored in Buffer0 and Buffer1.
+  * @brief  Write block(s) to a specified address in a card. The transferred Data are stored in Buffer0 and Buffer1.
   *         Buffer0, Buffer1 and BufferSize need to be configured by function HAL_SDEx_ConfigDMAMultiBuffer before call this function.
   * @param  hsd: SD handle
   * @param  BlockAdd: Block Address from where data is to be read

--- a/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_ll_adc.h
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_ll_adc.h
@@ -3416,7 +3416,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsDisableOngoing(ADC_TypeDef *ADCx)
   *         On this STM32 serie, ADC DMA transfer request should be disabled
   *         during calibration:
   *         Calibration factor is available in data register
-  *         and also transfered by DMA.
+  *         and also transferred by DMA.
   *         To not insert ADC calibration factor among ADC conversion data
   *         in array variable, DMA transfer must be disabled during
   *         calibration.

--- a/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_adc_ex.c
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_adc_ex.c
@@ -126,7 +126,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc, uint32_t 
 
     /* Disable ADC DMA transfer request during calibration */
     /* Note: Specificity of this STM32 serie: Calibration factor is           */
-    /*       available in data register and also transfered by DMA.           */
+    /*       available in data register and also transferred by DMA.           */
     /*       To not insert ADC calibration factor among ADC conversion data   */
     /*       in array variable, DMA transfer must be disabled during          */
     /*       calibration.                                                     */

--- a/system/Drivers/STM32L4xx_HAL_Driver/Inc/stm32l4xx_ll_dma2d.h
+++ b/system/Drivers/STM32L4xx_HAL_Driver/Inc/stm32l4xx_ll_dma2d.h
@@ -143,7 +143,7 @@ typedef struct
 
                                       This parameter can be modified afterwards using unitary function @ref LL_DMA2D_SetNbrOfLines(). */
 
-  uint32_t NbrOfPixelsPerLines;  /*!< Specifies the number of pixels per lines of the area to be transfered.
+  uint32_t NbrOfPixelsPerLines;  /*!< Specifies the number of pixels per lines of the area to be transferred.
                                       - This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0x3FFF.
 
                                       This parameter can be modified afterwards using unitary function @ref LL_DMA2D_SetNbrOfPixelsPerLines(). */

--- a/system/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_mmc_ex.c
+++ b/system/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_mmc_ex.c
@@ -77,8 +77,8 @@
 /**
   * @brief  Configure DMA Dual Buffer mode. The Data transfer is managed by an Internal DMA.
   * @param  hmmc MMC handle
-  * @param  pDataBuffer0 Pointer to the buffer0 that will contain/receive the transfered data
-  * @param  pDataBuffer1 Pointer to the buffer1 that will contain/receive the transfered data
+  * @param  pDataBuffer0 Pointer to the buffer0 that will contain/receive the transferred data
+  * @param  pDataBuffer1 Pointer to the buffer1 that will contain/receive the transferred data
   * @param  BufferSize Size of Buffer0 in Blocks. Buffer0 and Buffer1 must have the same size.
   * @retval HAL status
   */
@@ -179,7 +179,7 @@ HAL_StatusTypeDef HAL_MMCEx_ReadBlocksDMAMultiBuffer(MMC_HandleTypeDef *hmmc, ui
 }
 
 /**
-  * @brief  Write block(s) to a specified address in a card. The transfered Data are stored in Buffer0 and Buffer1.
+  * @brief  Write block(s) to a specified address in a card. The transferred Data are stored in Buffer0 and Buffer1.
   *         Buffer0, Buffer1 and BufferSize need to be configured by function HAL_MMCEx_ConfigDMAMultiBuffer before call this function.
   * @param  hmmc MMC handle
   * @param  BlockAdd Block Address from where data is to be read

--- a/system/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sd_ex.c
+++ b/system/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sd_ex.c
@@ -124,8 +124,8 @@ __weak void HAL_SDEx_DriveTransceiver_1_8V_Callback(FlagStatus status)
 /**
   * @brief  Configure DMA Dual Buffer mode. The Data transfer is managed by an Internal DMA.
   * @param  hsd SD handle
-  * @param  pDataBuffer0 Pointer to the buffer0 that will contain/receive the transfered data
-  * @param  pDataBuffer1 Pointer to the buffer1 that will contain/receive the transfered data
+  * @param  pDataBuffer0 Pointer to the buffer0 that will contain/receive the transferred data
+  * @param  pDataBuffer1 Pointer to the buffer1 that will contain/receive the transferred data
   * @param  BufferSize Size of Buffer0 in Blocks. Buffer0 and Buffer1 must have the same size.
   * @retval HAL status
   */
@@ -228,7 +228,7 @@ HAL_StatusTypeDef HAL_SDEx_ReadBlocksDMAMultiBuffer(SD_HandleTypeDef *hsd, uint3
 }
 
 /**
-  * @brief  Write block(s) to a specified address in a card. The transfered Data are stored in Buffer0 and Buffer1.
+  * @brief  Write block(s) to a specified address in a card. The transferred Data are stored in Buffer0 and Buffer1.
   *         Buffer0, Buffer1 and BufferSize need to be configured by function HAL_SDEx_ConfigDMAMultiBuffer before call this function.
   * @param  hsd SD handle
   * @param  BlockAdd Block Address from where data is to be read

--- a/system/Drivers/STM32MP1xx_HAL_Driver/Src/stm32mp1xx_hal_mdma.c
+++ b/system/Drivers/STM32MP1xx_HAL_Driver/Src/stm32mp1xx_hal_mdma.c
@@ -1778,7 +1778,7 @@ uint32_t HAL_MDMA_GetError(MDMA_HandleTypeDef *hmdma)
   * @param  SrcAddress: The source memory Buffer address
   * @param  DstAddress: The destination memory Buffer address
   * @param  BlockDataLength : The length of a block transfer in bytes
-  * @param  BlockCount: The number of blocks to be transfered
+  * @param  BlockCount: The number of blocks to be transferred
   * @retval HAL status
   */
 static void MDMA_SetConfig(MDMA_HandleTypeDef *hmdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t BlockDataLength, uint32_t BlockCount)

--- a/system/Drivers/STM32MP1xx_HAL_Driver/Src/stm32mp1xx_hal_sd_ex.c
+++ b/system/Drivers/STM32MP1xx_HAL_Driver/Src/stm32mp1xx_hal_sd_ex.c
@@ -75,8 +75,8 @@
 /**
   * @brief  Configure DMA Dual Buffer mode. The Data transfer is managed by an Internal DMA.
   * @param  hsd: SD handle
-  * @param  pDataBuffer0: Pointer to the buffer0 that will contain/receive the transfered data
-  * @param  pDataBuffer1: Pointer to the buffer1 that will contain/receive the transfered data
+  * @param  pDataBuffer0: Pointer to the buffer0 that will contain/receive the transferred data
+  * @param  pDataBuffer1: Pointer to the buffer1 that will contain/receive the transferred data
   * @param  BufferSize: Size of Buffer0 in Blocks. Buffer0 and Buffer1 must have the same size.
   * @retval HAL status
   */
@@ -179,7 +179,7 @@ HAL_StatusTypeDef HAL_SDEx_ReadBlocksDMAMultiBuffer(SD_HandleTypeDef *hsd, uint3
 }
 
 /**
-  * @brief  Write block(s) to a specified address in a card. The transfered Data are stored in Buffer0 and Buffer1.
+  * @brief  Write block(s) to a specified address in a card. The transferred Data are stored in Buffer0 and Buffer1.
   *         Buffer0, Buffer1 and BufferSize need to be configured by function HAL_SDEx_ConfigDMAMultiBuffer before call this function.
   * @param  hsd: SD handle
   * @param  BlockAdd: Block Address from where data is to be read  


### PR DESCRIPTION
There is a small typo in system/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_ll_adc.h, system/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_adc_ex.c, system/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_ll_dma2d.h, system/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_dma2d.h, system/Drivers/STM32G0xx_HAL_Driver/Inc/stm32g0xx_ll_adc.h, system/Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_adc_ex.c, system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h, system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc_ex.h, system/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_dma2d.h, system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_mdma.c, system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_mmc_ex.c, system/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd_ex.c, system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_ll_adc.h, system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_adc_ex.c, system/Drivers/STM32L4xx_HAL_Driver/Inc/stm32l4xx_ll_dma2d.h, system/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_mmc_ex.c, system/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sd_ex.c, system/Drivers/STM32MP1xx_HAL_Driver/Src/stm32mp1xx_hal_mdma.c, system/Drivers/STM32MP1xx_HAL_Driver/Src/stm32mp1xx_hal_sd_ex.c.

Should read `transferred` rather than `transfered`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md