### PR TITLE
Daisy Seed - added missing ram section to linker

### DIFF
--- a/variants/DAISY_SEED/ldscript.ld
+++ b/variants/DAISY_SEED/ldscript.ld
@@ -187,6 +187,18 @@ SECTIONS
     __bss_end__ = _ebss;
   } >RAM_D1
 
+  .sram1_bss (NOLOAD) :
+  {
+    . = ALIGN(4);
+    _ssram1_bss = .;
+    PROVIDE(__sram1_bss_start = _ssram1_bss);
+    *(.sram1_bss)
+    *(.sram1_bss*)
+    . = ALIGN(4);
+    _esram1_bss = .;
+    PROVIDE(__sram1_bss_end = _esram1_bss);
+  } >RAM_D2
+
   /* User_heap_stack section, used to check that there is enough "RAM_D1" Ram  type memory left */
   ._user_heap_stack :
   {


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Adds an additional sram section to the linker for the Daisy Seed H7 variant

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Adding this provides a memory section that can be used for DMA buffers, and other non-cacheable data so that DCache can be enabled without requiring maintenance.  