### PR TITLE
Fix Java PATH problem (improved version)

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -198,7 +198,7 @@ tools.maple_upload.path.macosx={runtime.tools.STM32Tools.path}/tools/macosx
 tools.maple_upload.path.linux={runtime.tools.STM32Tools.path}/tools/linux
 tools.maple_upload.upload.params.verbose=-d
 tools.maple_upload.upload.params.quiet=n
-tools.maple_upload.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.altID} {upload.usbID} "{build.path}/{build.project_name}.bin"
+tools.maple_upload.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.altID} {upload.usbID} "{build.path}/{build.project_name}.bin" "{runtime.ide.path}"
 
 # STM32MP1 self-contained shell script
 tools.remoteproc_gen.path={runtime.tools.STM32Tools.path}/tools


### PR DESCRIPTION
### Summary
This change enables passing the Arduino IDE installation path to the ``maple_upload.bat``-file in order to fix the Java PATH problem on Windows (see Issue in "stm32duino/Arduino_Tools": [#67](https://github.com/stm32duino/Arduino_Tools/issues/67)). 
This PR only works in combination with the PR in "stm32duino/Arduino_Tools": [#68](https://github.com/stm32duino/Arduino_Tools/pull/68).

### Test/Verification
The whole fix has been verified by me and was also successfully merged into the ``Arduino_STM32``-repository of Roger Clark. (See: [merged PR](https://github.com/rogerclarkmelbourne/Arduino_STM32/pull/814))
