### PR TITLE
SoftwareSerial stopListening at the begining

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -148,7 +148,9 @@ bool SoftwareSerial::listen()
   if (active_listener != this) {
     // wait for any transmit to complete as we may change speed
     while (active_out);
-    active_listener->stopListening();
+    if (active_listener != nullptr) {
+      active_listener->stopListening();
+    }
     rx_tick_cnt = 1; // 1 : next interrupt will decrease rx_tick_cnt to 0 which means RX pin level will be considered.
     rx_bit_cnt = -1; // rx_bit_cnt = -1 :  waiting for start bit
     setSpeed(_speed);


### PR DESCRIPTION
When begining the transaction, in the SoftwareSerial::begin
, the active_listener is not yet assigned, but null.
Then it differs from _this_ but should not act as if it was listening.

This is the case when testing on nucleo_l552ze board.

Signed-off-by: Francois Ramu <francois.ramu@st.com>