### PR TITLE
Add bootloader support for PRNTRBoard V2.

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1916,6 +1916,8 @@ LoRa.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.pnum.PRNTR_V2.build.product_line=STM32F407xx
 3dprinter.menu.pnum.PRNTR_V2.build.variant=PRNTR_Vx
 3dprinter.menu.pnum.PRNTR_V2.build.cmsis_lib_gcc=arm_cortexM4lf_math
+3dprinter.menu.pnum.PRNTR_V2.build.flash_offset=0x8000
+3dprinter.menu.pnum.PRNTR_V2.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DVECT_TAB_OFFSET={build.flash_offset}
 
 # EEXTR_F030_V1 board
 3dprinter.menu.pnum.EEXTR_F030_V1=EExtruder F030 V1

--- a/variants/PRNTR_Vx/ldscript.ld
+++ b/variants/PRNTR_Vx/ldscript.ld
@@ -60,8 +60,8 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 MEMORY
 {
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
-CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 512K
+CCMRAM (rw)    : ORIGIN = 0x10000000, LENGTH = 64K
+FLASH (rx)     : ORIGIN = 0x08000000 + LD_FLASH_OFFSET, LENGTH = LD_MAX_SIZE - LD_FLASH_OFFSET
 }
 
 /* Define output sections */


### PR DESCRIPTION
**Summary**

Update the board definition for PRNTR_V2 to support a bootloader (0x08000000 to 0x08007fff)

This PR fixes/implements the following **bugs/features**

* [ ] Bug 1
* [ ] Bug 2
* [X] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

Updating the firmware using the build-in ROM bootloader is not very reliable via USB, the device is often not detected properly when powered in boot loader mode. Decided to add a custom boot-loader that updates the firmware from sd-card if one is present.

Update the ldscript.ld to account for the flash space used by the bootloader.

**Validation**
Tested Marlin can be build and boots correctly.
