### PR TITLE
Prevent redefine of HSE_VALUE if already user-overridden

### DIFF
--- a/variants/Generic_F401Cx/variant.h
+++ b/variants/Generic_F401Cx/variant.h
@@ -110,7 +110,9 @@ extern "C" {
 #define PIN_SERIAL_TX           PA9
 
 #ifdef ARDUINO_BLACKPILL_F401CC
+#ifndef HSE_VALUE
 #define HSE_VALUE               25000000U
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/variants/Generic_F411Cx/variant.h
+++ b/variants/Generic_F411Cx/variant.h
@@ -113,7 +113,9 @@ extern "C" {
 #define PIN_SERIAL_TX           PA9
 
 #ifdef ARDUINO_BLACKPILL_F411CE
+#ifndef HSE_VALUE
 #define HSE_VALUE               25000000U
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

Commercially sold Blackpill F411CE boards feature a 25MHz crystal, but if a board differs, HSE_VALUE can still be overridden while keeping everything else the same. With defensive programming like this, users of a custom (or differing commercially sold) board can easily use this variant with the same chip but just a slightly different crystal.

This PR fixes/implements the following **bugs/features**

* [X] Feature: Let users redefine `HSE_VALUE` if needed

This topic e.g. appeared in https://community.platformio.org/t/env-blackpill-f401ce-consistently-creates-bad-binaries-that-hangs-the-mcu/18567 when a user was trying to user this Arduino core with a custom board with the 3 interchangable chips F401CC, F401CE and F411CE, all having a 25MHz crystal. 

If a user would ever want to use a similiar setup but with a 25MHz crystal where the Arduino core uses the default 8MHz one or vice versa, it would be nice to always let the user redefine `HSE_VALUE`. With a simple `#ifndef` check, that's implemented here.