### PR TITLE
Wire: change definition of MASTER_ADDRESS to avoid potential conflict

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -27,6 +27,10 @@ extern "C" {
 
 #include "Wire.h"
 
+// Distinguish master from slave.
+// 0x01 is a reserved value, and thus cannot be used by slave devices
+static const uint8_t MASTER_ADDRESS = 0x01;
+
 // Constructors ////////////////////////////////////////////////////////////////
 
 TwoWire::TwoWire()

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -30,8 +30,6 @@ extern "C" {
 
 #define BUFFER_LENGTH 32
 
-#define MASTER_ADDRESS 0x33
-
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 


### PR DESCRIPTION
Wire: change definition of MASTER_ADDRESS to avoid potential conflict

Define MASTER_ADDRESS in Wire.cpp to avoid potential conflict
with other libraries.
Use 0x01 for master as it is reserved for START
and thus cannot be used by slave devices.

Fixes #1278
