### PR TITLE
fix: wrong timer source for frequency calculation with STM32G0xx controllers

### DIFF
--- a/libraries/SrcWrapper/src/stm32/timer.c
+++ b/libraries/SrcWrapper/src/stm32/timer.c
@@ -629,7 +629,7 @@ uint8_t getTimerClkSrc(TIM_TypeDef *tim)
   uint8_t clkSrc = 0;
 
   if (tim != (TIM_TypeDef *)NC)
-#ifdef STM32F0xx
+#if defined(STM32F0xx) || defined(STM32G0xx)
     /* TIMx source CLK is PCKL1 */
     clkSrc = 1;
 #else


### PR DESCRIPTION
This PR fixes the wrong returned timer source in STM32G0xx MCUs. The G0xx controllers also have only PCLK1 (like the F0 familiy), so the function should always return 1 in this case. Otherwise, e.g. if TIM1 in combination with PWM is used, 2 is returned which will crash the function HardwareTimer::getTimerClkFreq because of an unexpected timer source.