### PR TITLE
Use Semaphore in this variant to control M0/M4

### DIFF
--- a/libraries/SrcWrapper/src/stm32/hw_config.c
+++ b/libraries/SrcWrapper/src/stm32/hw_config.c
@@ -66,7 +66,7 @@ void hw_config_init(void)
   USBD_CDC_init();
 #endif
 
-#if defined (STM32MP1xx)
+#if defined (STM32MP1xx) || defined (STM32WBxx)
   __HAL_RCC_HSEM_CLK_ENABLE();
 #endif
 

--- a/variants/PNUCLEO_WB55RG/variant.h
+++ b/variants/PNUCLEO_WB55RG/variant.h
@@ -121,6 +121,7 @@ extern "C" {
 #define FLASH_PAGE_NUMBER       127
 
 #define HAL_IPCC_MODULE_ENABLED
+#define HAL_HSEM_MODULE_ENABLED
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
To prepare the stm32duinoBLE running on the stm32wb55 to control the clock of the M4
Especially the CFG_HW_RCC_SEMID (3) is used when enabling the BLE and preventing the M0 to access the RCC.

This is required for the https://github.com/stm32duino/STM32duinoBLE/pull/25

Signed-off-by: Francois Ramu <francois.ramu@st.com>
