### PR TITLE
Optinally use TIM6 as timebase for the HAL, to allow usign the core inside FreeRTOS

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -42,6 +42,11 @@ timerObj_t *HardwareTimer_Handle[TIMER_NUM] = {NULL};
   */
 HardwareTimer::HardwareTimer(TIM_TypeDef *instance)
 {
+#ifdef USE_TIM6_TIMEBASE
+  if (instance == TIM6) {
+    Error_Handler();
+  }
+#endif
   uint32_t index = get_timer_index(instance);
   if (index == UNKNOWN_TIMER) {
     Error_Handler();
@@ -1421,6 +1426,12 @@ extern "C" {
 
   void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
   {
+#ifdef USE_TIM6_TIMEBASE
+    if (htim->Instance == TIM6) {
+      HAL_IncTick();
+      return;
+    }
+#endif
     HardwareTimer::updateCallback(htim);
   }
 
@@ -1521,6 +1532,13 @@ extern "C" {
 #endif //TIM5_BASE
 
 #if defined(TIM6_BASE)
+#ifdef USE_TIM6_TIMEBASE
+  extern TIM_HandleTypeDef        h_tim6;
+  void TIM6_IRQHandler(void)
+  {
+    HAL_TIM_IRQHandler(&h_tim6);
+  }
+#else // !defined(USE_TIM6_TIMEBASE)
   /**
     * @brief  TIM6 IRQHandler
     * @param  None
@@ -1532,6 +1550,7 @@ extern "C" {
       HAL_TIM_IRQHandler(&HardwareTimer_Handle[TIMER6_INDEX]->handle);
     }
   }
+#endif // USE_TIM6_TIMEBASE
 #endif //TIM6_BASE
 
 #if defined(TIM7_BASE)

--- a/libraries/SrcWrapper/src/stm32/clock.c
+++ b/libraries/SrcWrapper/src/stm32/clock.c
@@ -50,6 +50,8 @@ uint32_t getCurrentMillis(void)
   return HAL_GetTick();
 }
 
+#ifndef USE_TIM6_TIMEBASE
+
 void noOsSystickHandler()
 {
 
@@ -67,6 +69,8 @@ void SysTick_Handler(void)
   HAL_SYSTICK_IRQHandler();
   osSystickHandler();
 }
+
+#endif // USE_TIM6_TIMEBASE
 
 /**
   * @brief  Enable the specified clock if not already set

--- a/variants/PRNTR_Vx/variant.cpp
+++ b/variants/PRNTR_Vx/variant.cpp
@@ -196,6 +196,58 @@ WEAK void SystemClock_Config(void)
   __HAL_RCC_CCMDATARAMEN_CLK_ENABLE();
 }
 
+#ifdef USE_TIM6_TIMEBASE
+TIM_HandleTypeDef h_tim6;
+extern uint32_t uwTickPrio;
+
+HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
+{
+  RCC_ClkInitTypeDef    clkconfig;
+  uint32_t              uwTimclock = 0;
+  uint32_t              uwPrescalerValue = 0;
+  uint32_t              pFLatency;
+
+  if (TickPriority > 15) {
+    TickPriority = 15;
+  }
+  HAL_NVIC_SetPriority(TIM6_DAC_IRQn, TickPriority, 0);
+  HAL_NVIC_EnableIRQ(TIM6_DAC_IRQn);
+  uwTickPrio = TickPriority;
+
+  __HAL_RCC_TIM6_CLK_ENABLE();
+
+  HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
+  uwTimclock = 2 * HAL_RCC_GetPCLK1Freq();
+  /* Compute the prescaler value to have TIM6 counter clock equal to 1MHz */
+  uwPrescalerValue = (uint32_t)((uwTimclock / 1000000) - 1);
+
+  h_tim6.Instance = TIM6;
+
+  h_tim6.Init.Period = (1000000 / 1000) - 1;
+  h_tim6.Init.Prescaler = uwPrescalerValue;
+  h_tim6.Init.ClockDivision = 0;
+  h_tim6.Init.CounterMode = TIM_COUNTERMODE_UP;
+  if (HAL_TIM_Base_Init(&h_tim6) == HAL_OK) {
+    /* Start the TIM time Base generation in interrupt mode */
+    return HAL_TIM_Base_Start_IT(&h_tim6);
+  }
+
+  /* Return function status */
+  return HAL_ERROR;
+}
+
+void HAL_SuspendTick(void)
+{
+  __HAL_TIM_DISABLE_IT(&h_tim6, TIM_IT_UPDATE);
+}
+
+void HAL_ResumeTick(void)
+{
+  __HAL_TIM_ENABLE_IT(&h_tim6, TIM_IT_UPDATE);
+}
+
+#endif // USE_TIM6_TIMEBASE
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
**Summary**

RepRap firmware (RRF) is being ported to STM32. RRF is using FreeRTOS for multitasking.
When using FreeRTOS, the CubeMX suggests not to use SysTick as timebase for the HAL. I believe this is because there is conflict between the HAL and RTOS use of the SysTick timer. This PR is a simple hack that allows using TIM6 as timebase for the HAL for the PRNTR_Vx variant.

I propose this code to be used as basis for a more generic approach to allow configurable timebase.
