### PR TITLE
servo: optional default servo angle on attach

### DIFF
--- a/libraries/Servo/src/Servo.h
+++ b/libraries/Servo/src/Servo.h
@@ -102,8 +102,8 @@ typedef struct {
 class Servo {
   public:
     Servo();
-    uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
-    uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes.
+    uint8_t attach(int pin, int value = DEFAULT_PULSE_WIDTH);           // attach the given pin to the next free channel, sets pinMode, set angle value, returns channel number or 0 if failure
+    uint8_t attach(int pin, int min, int max, int value = DEFAULT_PULSE_WIDTH); // as above but also sets min and max values for writes.
     void detach();
     void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds
     void writeMicroseconds(int value); // Write pulse width in microseconds

--- a/libraries/Servo/src/stm32/Servo.cpp
+++ b/libraries/Servo/src/stm32/Servo.cpp
@@ -111,17 +111,17 @@ Servo::Servo()
   }
 }
 
-uint8_t Servo::attach(int pin)
+uint8_t Servo::attach(int pin, int value)
 {
-  return this->attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH);
+  return this->attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH, value);
 }
 
-uint8_t Servo::attach(int pin, int min, int max)
+uint8_t Servo::attach(int pin, int min, int max, int value)
 {
   if (this->servoIndex < MAX_SERVOS) {
     pinMode(pin, OUTPUT);                                   // set servo pin to output
     servos[this->servoIndex].Pin.nbr = pin;
-    servos[this->servoIndex].ticks = DEFAULT_PULSE_WIDTH;
+    write(value);
     // todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128
     this->min  = (MIN_PULSE_WIDTH - min) / 4; //resolution of min/max is 4 uS
     this->max  = (MAX_PULSE_WIDTH - max) / 4;


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

servo: optional default servo angle on attach
Allow user to set servo default angle on attach.


**Closing issues**

Fixes #1301
