### PR TITLE
Fix HAL not properly initialized on F105x series

### DIFF
--- a/system/Drivers/CMSIS/Device/ST/STM32F1xx/Source/Templates/gcc/startup_stm32f105xc.s
+++ b/system/Drivers/CMSIS/Device/ST/STM32F1xx/Source/Templates/gcc/startup_stm32f105xc.s
@@ -91,6 +91,8 @@ LoopFillZerobss:
   bcc FillZerobss
 /* Call the clock system intitialization function.*/
     bl  SystemInit
+/* Call static constructors */
+  bl __libc_init_array
 /* Call the application's entry point.*/
   bl main
   bx lr


### PR DESCRIPTION

**Summary**

<!-- Summary of the PR -->

This PR fixes the necessary initialization procedures which should be run before user code is called. 

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

`premain()` function in [main.cpp](/cores/arduino/main.cpp) is essential for the HAL library to initize properly, more specifically it called `HAL_Init` which setup the systick interrupt handler which is necessary for writing a hello world.....

The issue #869 has already mentioned this bug but didn't find a solution to it. After some trials and errors and comparasion between assemblies for different products, the patch here is likely solving it.

If possible, is there's any chance we talk about this a bit further because I don't know why this workaround works in fact...

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Validation**

* Ensure CI build is passed.
  * CI should run after the PR is posted. let's see the result 😉 
* Demonstrate the code is solid.
  * The demostration is based on my fork supporting generic STM32F105Cx boards, which is located here (https://github.com/ttimasdf/Arduino_Core_STM32/tree/variant-generic-stm32f105x).

Demostration:

Detail step-by-step is To-Be-Filled. The following code is a modified blinking LED use loop based `manual_delay()` and HAL provided `delay()` altogether. The original `delay()` would stuck if HAL_Init is not called beforehand, the same as described in #869.

```cpp
/*
 * Blink
 * Turns on an LED on for one second,
 * then off for one second, repeatedly.
 */

#include <Arduino.h>

#ifndef LED_BUILTIN
  #define LED_BUILTIN PD2
#endif

uint32_t manual_delay(volatile uint32_t time) {
  volatile uint32_t factor = 0xFF, i = time;
  while (factor > 0) {
    while (i > 0)  {
      i -= 1;
    }
    factor -= 1;
  }
  return time;
}

uint32_t blink(int pin, int times) {
  int i = times;
  while (i > 0) {
    uint32_t delay = 0xFFFF * 4;
    // turn the LED on (HIGH is the voltage level)
    digitalWrite(LED_BUILTIN, HIGH);
    manual_delay(delay);
    // wait for a second
    // delay(1000);
    // turn the LED off by making the voltage LOW
    digitalWrite(LED_BUILTIN, LOW);
    manual_delay(delay);
    // wait for a second
    // delay(1000);

    i -= 1;
  }
  return i;
}

void setup()
{
  // initialize LED digital pin as an output.
  pinMode(LED_BUILTIN, OUTPUT);
}

void loop()
{
  blink(LED_BUILTIN, 10);
  delay(1000);
}
```


<!-- Make sure tests pass on both CI. -->

**Code formatting**

* Ensure AStyle check is passed thanks CI

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #869
