### PR TITLE
Enable PWR clock systematically when available

### DIFF
--- a/cores/arduino/stm32/backup.h
+++ b/cores/arduino/stm32/backup.h
@@ -77,12 +77,6 @@ static inline void resetBackupDomain(void)
 
 static inline void enableBackupDomain(void)
 {
-  /* Enable Power Clock */
-#ifdef __HAL_RCC_PWR_IS_CLK_DISABLED
-  if (__HAL_RCC_PWR_IS_CLK_DISABLED()) {
-    __HAL_RCC_PWR_CLK_ENABLE();
-  }
-#endif
 #ifdef HAL_PWR_MODULE_ENABLED
   /* Allow access to Backup domain */
   HAL_PWR_EnableBkUpAccess();
@@ -110,12 +104,6 @@ static inline void disableBackupDomain(void)
 #ifdef __HAL_RCC_BKP_CLK_DISABLE
   /* Disable BKP CLK for backup registers */
   __HAL_RCC_BKP_CLK_DISABLE();
-#endif
-  /* Disable Power Clock */
-#ifdef __HAL_RCC_PWR_IS_CLK_DISABLED
-  if (!__HAL_RCC_PWR_IS_CLK_DISABLED()) {
-    __HAL_RCC_PWR_CLK_DISABLE();
-  }
 #endif
 }
 

--- a/cores/arduino/stm32/usb/usbd_conf.c
+++ b/cores/arduino/stm32/usb/usbd_conf.c
@@ -53,16 +53,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
   const PinMap *map = NULL;
 #if defined(PWR_CR2_USV)
   /* Enable VDDUSB on Pwrctrl CR2 register*/
-#if !defined(STM32WBxx)
-  if (__HAL_RCC_PWR_IS_CLK_DISABLED()) {
-    __HAL_RCC_PWR_CLK_ENABLE();
-    HAL_PWREx_EnableVddUSB();
-    __HAL_RCC_PWR_CLK_DISABLE();
-  } else
-#endif
-  {
-    HAL_PWREx_EnableVddUSB();
-  }
+  HAL_PWREx_EnableVddUSB();
 #endif
 #ifdef STM32H7xx
   if (!LL_PWR_IsActiveFlag_USB()) {

--- a/libraries/SrcWrapper/src/stm32/PortNames.c
+++ b/libraries/SrcWrapper/src/stm32/PortNames.c
@@ -105,7 +105,6 @@ GPIO_TypeDef *set_GPIO_Port_Clock(uint32_t port_idx)
     case PortG:
 #if defined(STM32L4xx) && defined(PWR_CR2_IOSV)
       // Enable VDDIO2 supply for 14 I/Os (Port G[15:2])
-      __HAL_RCC_PWR_CLK_ENABLE();
       HAL_PWREx_EnableVddIO2();
 #endif
       gpioPort = (GPIO_TypeDef *)GPIOG_BASE;

--- a/libraries/SrcWrapper/src/stm32/hw_config.c
+++ b/libraries/SrcWrapper/src/stm32/hw_config.c
@@ -40,6 +40,11 @@ void hw_config_init(void)
 
   configHSECapacitorTuning();
 
+#if defined(__HAL_RCC_PWR_CLK_ENABLE)
+  /* Enable PWR clock, needed for example: voltage scaling, low power ... */
+  __HAL_RCC_PWR_CLK_ENABLE();
+#endif
+
   /* Configure the system clock */
   SystemClock_Config();
 


### PR DESCRIPTION
**Summary**

Enable PWR clock systematically when available

This avoid to miss it in system clock configuration,
    as it is not systematically done by cubeMX