### PR TITLE
HardwareSerial: don't call STM32 HAL for every bytes to transfer

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -143,7 +143,8 @@ class HardwareSerial : public Stream {
     {
       return write((uint8_t)n);
     }
-    using Print::write; // pull in write(str) and write(buf, size) from Print
+    size_t write(const uint8_t *buffer, size_t size);
+    using Print::write; // pull in write(str) from Print
     operator bool()
     {
       return true;

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -80,6 +80,7 @@ struct serial_s {
   uint16_t tx_head;
   volatile uint16_t rx_head;
   volatile uint16_t tx_tail;
+  size_t tx_size;
 };
 
 /* Exported constants --------------------------------------------------------*/
@@ -186,7 +187,7 @@ void uart_config_lowpower(serial_t *obj);
 size_t uart_write(serial_t *obj, uint8_t data, uint16_t size);
 int uart_getc(serial_t *obj, unsigned char *c);
 void uart_attach_rx_callback(serial_t *obj, void (*callback)(serial_t *));
-void uart_attach_tx_callback(serial_t *obj, int (*callback)(serial_t *));
+void uart_attach_tx_callback(serial_t *obj, int (*callback)(serial_t *), size_t size);
 
 uint8_t serial_tx_active(serial_t *obj);
 uint8_t serial_rx_active(serial_t *obj);

--- a/libraries/SrcWrapper/src/stm32/uart.c
+++ b/libraries/SrcWrapper/src/stm32/uart.c
@@ -723,7 +723,7 @@ void uart_attach_rx_callback(serial_t *obj, void (*callback)(serial_t *))
  * @param callback : function call at the end of transmission
  * @retval none
  */
-void uart_attach_tx_callback(serial_t *obj, int (*callback)(serial_t *))
+void uart_attach_tx_callback(serial_t *obj, int (*callback)(serial_t *), size_t size)
 {
   if (obj == NULL) {
     return;
@@ -734,7 +734,7 @@ void uart_attach_tx_callback(serial_t *obj, int (*callback)(serial_t *))
   HAL_NVIC_DisableIRQ(obj->irq);
 
   /* The following function will enable UART_IT_TXE and error interrupts */
-  HAL_UART_Transmit_IT(uart_handlers[obj->index], &obj->tx_buff[obj->tx_tail], 1);
+  HAL_UART_Transmit_IT(uart_handlers[obj->index], &obj->tx_buff[obj->tx_tail], size);
 
   /* Enable interrupt */
   HAL_NVIC_EnableIRQ(obj->irq);
@@ -810,11 +810,8 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
 void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
 {
   serial_t *obj = get_serial_obj(huart);
-
-  if (obj && obj->tx_callback(obj) != -1) {
-    if (HAL_UART_Transmit_IT(huart, &obj->tx_buff[obj->tx_tail], 1) != HAL_OK) {
-      return;
-    }
+  if (obj) {
+    obj->tx_callback(obj);
   }
 }
 


### PR DESCRIPTION

**Summary**

HardwareSerial: don't call STM32 HAL for every bytes to transfer

Instead of calling HAL for each and every bytes,
try to call it only once for a string.
Several call may be needed to manage internal circular buffer (tx_buff)

Fixes #1309

