### PR TITLE
Review HAL/LL default configuration

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -772,7 +772,7 @@ STM32MP1.build.mcu=cortex-m4
 STM32MP1.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 STM32MP1.build.series=STM32MP1xx
 STM32MP1.build.cmsis_lib_gcc=arm_cortexM4l_math
-STM32MP1.build.extra_flags=-DCORE_CM4 -DUSE_FULL_LL_DRIVER -D{build.product_line} {build.enable_virtio} {build.xSerial}
+STM32MP1.build.extra_flags=-DCORE_CM4 -D{build.product_line} {build.enable_virtio} {build.xSerial}
 
 # STM32MP157A-DK1 board
 STM32MP1.menu.pnum.STM32MP157A_DK1=STM32MP157A-DK1

--- a/cores/arduino/stm32/stm32yyxx_hal_conf.h
+++ b/cores/arduino/stm32/stm32yyxx_hal_conf.h
@@ -9,9 +9,10 @@
 #define HAL_DMA_MODULE_ENABLED /* Required by other modules */
 #define HAL_FLASH_MODULE_ENABLED
 #define HAL_GPIO_MODULE_ENABLED
+#define HAL_HSEM_MODULE_ENABLED
+#define HAL_IPCC_MODULE_ENABLED
 #define HAL_PWR_MODULE_ENABLED
 #define HAL_RCC_MODULE_ENABLED
-#define HAL_HSEM_MODULE_ENABLED
 
 /*
  * Optional HAL modules, can be enabled/disabled using
@@ -32,11 +33,24 @@
   #undef HAL_I2C_MODULE_ENABLED
 #endif
 
+#if !defined(HAL_I2S_MODULE_DISABLED)
+  #define HAL_I2S_MODULE_ENABLED
+#else
+  #undef HAL_I2S_MODULE_ENABLED
+#endif
+
 #if !defined(HAL_RTC_MODULE_DISABLED)
   #define HAL_RTC_MODULE_ENABLED
 #else
   #undef HAL_RTC_MODULE_ENABLED
 #endif
+
+#if !defined(HAL_SAI_MODULE_DISABLED)
+  #define HAL_SAI_MODULE_ENABLED
+#else
+  #undef HAL_SAI_MODULE_ENABLED
+#endif
+
 
 #if !defined(HAL_SPI_MODULE_DISABLED)
   #define HAL_SPI_MODULE_ENABLED
@@ -48,18 +62,6 @@
   #define HAL_TIM_MODULE_ENABLED
 #else
   #undef HAL_TIM_MODULE_ENABLED
-#endif
-
-#if !defined(HAL_I2S_MODULE_DISABLED)
-  #define HAL_I2S_MODULE_ENABLED
-#else
-  #undef HAL_I2S_MODULE_ENABLED
-#endif
-
-#if !defined(HAL_SAI_MODULE_DISABLED)
-  #define HAL_SAI_MODULE_ENABLED
-#else
-  #undef HAL_SAI_MODULE_ENABLED
 #endif
 
 /*
@@ -85,10 +87,10 @@
   #undef HAL_ETH_MODULE_ENABLED
 #endif
 
-#if !defined(HAL_SD_MODULE_DISABLED)
-  /*#define HAL_SD_MODULE_ENABLED*/
+#if !defined(HAL_OSPI_MODULE_DISABLED)
+  /*#define HAL_OSPI_MODULE_ENABLED*/
 #else
-  #undef HAL_SD_MODULE_ENABLED
+  #undef HAL_OSPI_MODULE_ENABLED
 #endif
 
 #if !defined(HAL_QSPI_MODULE_DISABLED)
@@ -97,10 +99,10 @@
   #undef HAL_QSPI_MODULE_ENABLED
 #endif
 
-#if !defined(HAL_OSPI_MODULE_DISABLED)
-  /*#define HAL_OSPI_MODULE_ENABLED*/
+#if !defined(HAL_SD_MODULE_DISABLED)
+  /*#define HAL_SD_MODULE_ENABLED*/
 #else
-  #undef HAL_OSPI_MODULE_ENABLED
+  #undef HAL_SD_MODULE_ENABLED
 #endif
 
 /*
@@ -108,7 +110,6 @@
  */
 /*#define HAL_UART_MODULE_ENABLED*/
 /*#define HAL_PCD_MODULE_ENABLED*/
-/*#define HAL_IPCC_MODULE_ENABLED*/
 
 /*
  * Unused HAL modules
@@ -135,7 +136,6 @@
   HAL_HCD_MODULE_ENABLED
   HAL_HRTIM_MODULE_ENABLED
   HAL_ICACHE_MODULE_ENABLED
-  HAL_IPCC_MODULE_ENABLED
   HAL_IRDA_MODULE_ENABLED
   HAL_IWDG_MODULE_ENABLED // IWD built-in library uses LL
   HAL_JPEG_MODULE_ENABLED

--- a/libraries/SrcWrapper/src/stm32/PortNames.c
+++ b/libraries/SrcWrapper/src/stm32/PortNames.c
@@ -103,7 +103,7 @@ GPIO_TypeDef *set_GPIO_Port_Clock(uint32_t port_idx)
 #endif
 #if defined GPIOG_BASE
     case PortG:
-#if defined(STM32L4xx) && defined(PWR_CR2_IOSV)
+#if defined(PWR_CR2_IOSV)
       // Enable VDDIO2 supply for 14 I/Os (Port G[15:2])
       HAL_PWREx_EnableVddIO2();
 #endif

--- a/libraries/SrcWrapper/src/stm32/pinmap.c
+++ b/libraries/SrcWrapper/src/stm32/pinmap.c
@@ -98,12 +98,6 @@ void pin_function(PinName pin, int function)
   /* Enable GPIO clock */
   GPIO_TypeDef *gpio = set_GPIO_Port_Clock(port);
 
-#if defined (STM32L5xx)
-  /* Validate the VDDIO2 supply for electrical and logical isolation purpose. */
-  __HAL_RCC_PWR_CLK_ENABLE();
-  HAL_PWREx_EnableVddIO2();
-#endif /* STM32L5xx */
-
   hsem_lock(CFG_HW_GPIO_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
   /*  Set default speed to high.

--- a/platform.txt
+++ b/platform.txt
@@ -28,7 +28,7 @@ compiler.objcopy.cmd=arm-none-eabi-objcopy
 compiler.elf2hex.cmd=arm-none-eabi-objcopy
 compiler.libraries.ldflags=
 
-compiler.extra_flags=-mcpu={build.mcu} {build.flags.fp} -mthumb "@{build.opt.path}"
+compiler.extra_flags=-mcpu={build.mcu} {build.flags.fp} -DUSE_FULL_LL_DRIVER -mthumb "@{build.opt.path}"
 
 compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.stm.extra_include}
 

--- a/platform.txt
+++ b/platform.txt
@@ -85,7 +85,7 @@ build.pid=0
 # that the preprocessor cannot detect.
 
 # VirtIO RPMsg Serial Flags
-build.virtio_flags=-DVIRTIOCON -DHAL_IPCC_MODULE_ENABLED -DNO_ATOMIC_64_SUPPORT -DMETAL_INTERNAL -DMETAL_MAX_DEVICE_REGIONS=2 -DVIRTIO_SLAVE_ONLY -DVIRTIO_LOG
+build.virtio_flags=-DVIRTIOCON -DNO_ATOMIC_64_SUPPORT -DMETAL_INTERNAL -DMETAL_MAX_DEVICE_REGIONS=2 -DVIRTIO_SLAVE_ONLY -DVIRTIO_LOG
 build.virtio_extra_include="-I{build.system.path}/Middlewares/OpenAMP" "-I{build.system.path}/Middlewares/OpenAMP/open-amp/lib/include" "-I{build.system.path}/Middlewares/OpenAMP/libmetal/lib/include" "-I{build.system.path}/Middlewares/OpenAMP/virtual_driver"
 
 # Build information's


### PR DESCRIPTION
* Define `USE_FULL_LL_DRIVER` at top level as more and more HAL relies on LL drivers. So enable the full LL usage to ease access.
* Clean up generic HAL conf file
* Clean up Vddio2 Independent I/Os supply setting