### PR TITLE
DAC fixes

### DIFF
--- a/libraries/SrcWrapper/src/stm32/analog.cpp
+++ b/libraries/SrcWrapper/src/stm32/analog.cpp
@@ -389,12 +389,6 @@ void dac_write_value(PinName pin, uint32_t value, uint8_t do_init)
     return;
   }
   if (do_init == 1) {
-
-    if (HAL_DAC_DeInit(&DacHandle) != HAL_OK) {
-      /* DeInitialization Error */
-      return;
-    }
-
     /*##-1- Configure the DAC peripheral #######################################*/
     g_current_pin = pin;
     if (HAL_DAC_Init(&DacHandle) != HAL_OK) {

--- a/libraries/SrcWrapper/src/stm32/analog.cpp
+++ b/libraries/SrcWrapper/src/stm32/analog.cpp
@@ -404,6 +404,9 @@ void dac_write_value(PinName pin, uint32_t value, uint8_t do_init)
 
     dacChannelConf.DAC_Trigger = DAC_TRIGGER_NONE;
     dacChannelConf.DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE;
+#if defined(DAC_OUTPUTSWITCH_ENABLE)
+    dacChannelConf.DAC_OutputSwitch = DAC_OUTPUTSWITCH_ENABLE;
+#endif
     /*##-2- Configure DAC channel1 #############################################*/
     if (HAL_DAC_ConfigChannel(&DacHandle, &dacChannelConf, dacChannel) != HAL_OK) {
       /* Channel configuration Error */


### PR DESCRIPTION
**Summary**
* DAC: STM32F3 dac may have output switch instead of output buffer
  For STM32F3 serie, depending on instance/channel used,
  output buffer may be replaced by output switch
  Both being exclusive, they can be both set in HAL structure.

* DAC: remove HAL_DAC_DeInit() to avoid other channel deconfiguration
    
Fixes #1324
