### PR TITLE
Fix issue with HAL_PPP_MODULE_DISABLED

### DIFF
--- a/cores/arduino/stm32/stm32yyxx_hal_conf.h
+++ b/cores/arduino/stm32/stm32yyxx_hal_conf.h
@@ -27,6 +27,28 @@
   #undef HAL_ADC_MODULE_ENABLED
 #endif
 
+#if !defined(HAL_DAC_MODULE_DISABLED)
+  #if defined(DAC_BASE) || defined(DAC1_BASE)
+    #define HAL_DAC_MODULE_ENABLED
+  #endif
+#else
+  #undef HAL_DAC_MODULE_ENABLED
+#endif
+
+#if !defined(HAL_ETH_MODULE_DISABLED)
+  #define HAL_ETH_MODULE_ENABLED
+#else
+  #undef HAL_ETH_MODULE_ENABLED
+#endif
+
+/* Note: interrupt API does not used HAL EXTI module */
+/* anyway API is cleaned with HAL_EXTI_MODULE_DISABLED */
+#if !defined(HAL_EXTI_MODULE_DISABLED)
+  /*#define HAL_EXTI_MODULE_ENABLED*/
+#else
+  #undef HAL_EXTI_MODULE_ENABLED
+#endif
+
 #if !defined(HAL_I2C_MODULE_DISABLED)
   #define HAL_I2C_MODULE_ENABLED
 #else
@@ -39,6 +61,22 @@
   #undef HAL_I2S_MODULE_ENABLED
 #endif
 
+#if !defined(HAL_OSPI_MODULE_DISABLED)
+  #if defined(OCTOSPI1_BASE)
+    #define HAL_OSPI_MODULE_ENABLED
+  #endif
+#else
+  #undef HAL_OSPI_MODULE_ENABLED
+#endif
+
+#if !defined(HAL_QSPI_MODULE_DISABLED)
+  #if defined(QSPI_BASE)
+    #define HAL_QSPI_MODULE_ENABLED
+  #endif
+#else
+  #undef HAL_QSPI_MODULE_ENABLED
+#endif
+
 #if !defined(HAL_RTC_MODULE_DISABLED)
   #define HAL_RTC_MODULE_ENABLED
 #else
@@ -46,11 +84,20 @@
 #endif
 
 #if !defined(HAL_SAI_MODULE_DISABLED)
-  #define HAL_SAI_MODULE_ENABLED
+  #if defined(SAI1_BASE)
+    #define HAL_SAI_MODULE_ENABLED
+  #endif
 #else
   #undef HAL_SAI_MODULE_ENABLED
 #endif
 
+#if !defined(HAL_SD_MODULE_DISABLED)
+  #if defined(SDIO_BASE) || defined(SDMMC1_BASE)
+    #define HAL_SD_MODULE_ENABLED
+  #endif
+#else
+  #undef HAL_SD_MODULE_ENABLED
+#endif
 
 #if !defined(HAL_SPI_MODULE_DISABLED)
   #define HAL_SPI_MODULE_ENABLED
@@ -62,47 +109,6 @@
   #define HAL_TIM_MODULE_ENABLED
 #else
   #undef HAL_TIM_MODULE_ENABLED
-#endif
-
-/*
- * Not defined by default
- */
-#if !defined(HAL_DAC_MODULE_DISABLED)
-  /*#define HAL_DAC_MODULE_ENABLED*/
-#else
-  #undef HAL_DAC_MODULE_ENABLED
-#endif
-
-/* Note: interrupt API does not used HAL EXTI module */
-/* anyway API is cleaned with HAL_EXTI_MODULE_DISABLED */
-#if !defined(HAL_EXTI_MODULE_DISABLED)
-  /*#define HAL_EXTI_MODULE_ENABLED*/
-#else
-  #undef HAL_EXTI_MODULE_ENABLED
-#endif
-
-#if !defined(HAL_ETH_MODULE_DISABLED)
-  /*#define HAL_ETH_MODULE_ENABLED*/
-#else
-  #undef HAL_ETH_MODULE_ENABLED
-#endif
-
-#if !defined(HAL_OSPI_MODULE_DISABLED)
-  /*#define HAL_OSPI_MODULE_ENABLED*/
-#else
-  #undef HAL_OSPI_MODULE_ENABLED
-#endif
-
-#if !defined(HAL_QSPI_MODULE_DISABLED)
-  /*#define HAL_QSPI_MODULE_ENABLED*/
-#else
-  #undef HAL_QSPI_MODULE_ENABLED
-#endif
-
-#if !defined(HAL_SD_MODULE_DISABLED)
-  /*#define HAL_SD_MODULE_ENABLED*/
-#else
-  #undef HAL_SD_MODULE_ENABLED
 #endif
 
 /*

--- a/variants/BLACK_F407XX/variant.h
+++ b/variants/BLACK_F407XX/variant.h
@@ -297,10 +297,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_SD_MODULE_ENABLED
-
 // This indicates that there is an external and fixed 1.5k pullup
 // on the D+ line. This define is only needed on boards that have
 // internal pullups *and* an external pullup. Note that it would have

--- a/variants/BLUE_F407VE_Mini/variant.h
+++ b/variants/BLUE_F407VE_Mini/variant.h
@@ -180,10 +180,6 @@ extern "C" {
 /* HAL configuration */
 #define HSE_VALUE               25000000U
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_SD_MODULE_ENABLED
-
 // This indicates that there is an external and fixed 1.5k pullup
 // on the D+ line. This define is only needed on boards that have
 // internal pullups *and* an external pullup. Note that it would have

--- a/variants/B_L4S5I_IOT01A/variant.h
+++ b/variants/B_L4S5I_IOT01A/variant.h
@@ -138,10 +138,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PB7
 #define PIN_SERIAL_TX           PB6
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_OSPI_MODULE_ENABLED
-
 /* OCTOSPI pins for MX25R6435F (used in QSPI mode) */
 #define MX25R6435F_D0           PE12
 #define MX25R6435F_D1           PE13

--- a/variants/DAISY_SEED/variant.h
+++ b/variants/DAISY_SEED/variant.h
@@ -81,9 +81,6 @@ extern "C" {
 // HSE is 16MHz on Daisy Seed.
 #define HSE_VALUE 16000000
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/DISCO_F100RB/variant.h
+++ b/variants/DISCO_F100RB/variant.h
@@ -116,9 +116,6 @@ extern "C" {
 #define PIN_SERIAL_RX           8
 #define PIN_SERIAL_TX           7
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/DISCO_F407VG/variant.h
+++ b/variants/DISCO_F407VG/variant.h
@@ -149,9 +149,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/DISCO_F413ZH/variant.h
+++ b/variants/DISCO_F413ZH/variant.h
@@ -172,9 +172,6 @@ extern "C" {
 
 // SD detect signal
 #define SD_DETECT_PIN           PF11
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_SD_MODULE_ENABLED
 
 #ifdef __cplusplus
 } // extern "C"

--- a/variants/DISCO_F746NG/variant.h
+++ b/variants/DISCO_F746NG/variant.h
@@ -82,11 +82,6 @@ extern "C" {
 // SD detect signal
 #define SD_DETECT_PIN           PC13
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_ETH_MODULE_ENABLED
-#define HAL_SD_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/DISCO_L475VG_IOT/variant.h
+++ b/variants/DISCO_L475VG_IOT/variant.h
@@ -138,10 +138,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PB7
 #define PIN_SERIAL_TX           PB6
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_QSPI_MODULE_ENABLED
-
 /* QSPI pins for MX25R6435F */
 #define MX25R6435F_D0           PE12
 #define MX25R6435F_D1           PE13

--- a/variants/DIYMORE_F407VGT/variant.h
+++ b/variants/DIYMORE_F407VGT/variant.h
@@ -179,9 +179,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/ELEKTOR_F072Cx/variant.h
+++ b/variants/ELEKTOR_F072Cx/variant.h
@@ -115,9 +115,6 @@ extern "C" {
 #define PIN_SERIAL2_TX         PA2
 #define PIN_SERIAL2_RX         PA3
 
-// Extra HAL modules
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/FEATHER_F405/variant.h
+++ b/variants/FEATHER_F405/variant.h
@@ -89,7 +89,7 @@ extern "C" {
 #define PA12 36  // USB_DP
 
 #define PA13 37  // SWDIO
-#define PA14 38  // SWCLK 
+#define PA14 38  // SWCLK
 
 // This must be a literal
 #define NUM_DIGITAL_PINS        39
@@ -132,10 +132,6 @@ extern "C" {
 
 /* HAL configuration */
 #define HSE_VALUE               12000000U
-
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_SD_MODULE_ENABLED
 
 #ifdef __cplusplus
 } // extern "C"

--- a/variants/FK407M1/variant.h
+++ b/variants/FK407M1/variant.h
@@ -162,9 +162,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/Generic_F103Rx/variant.h
+++ b/variants/Generic_F103Rx/variant.h
@@ -123,11 +123,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
-/* Extra HAL modules */
-#if defined(STM32F103xE) || defined(STM32F103xG)
-#define HAL_DAC_MODULE_ENABLED
-#endif
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/Generic_F103Vx/variant.h
+++ b/variants/Generic_F103Vx/variant.h
@@ -140,12 +140,6 @@ extern "C" {
 // Define here Serial instance number to map on Serial generic name
 #define SERIAL_UART_INSTANCE    1
 
-// Extra HAL modules
-#if defined(STM32F103xE) || defined(STM32F103xG)
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_SD_MODULE_ENABLED
-#endif
-
 // Default pin used for 'Serial' instance (ex: ST-Link)
 // Mandatory for Firmata
 #define PIN_SERIAL_RX           PA10

--- a/variants/Generic_F103Zx/variant.h
+++ b/variants/Generic_F103Zx/variant.h
@@ -197,11 +197,7 @@ extern "C" {
 #define PIN_SERIAL3_RX          PB11
 #define PIN_SERIAL3_TX          PB10
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef ARDUINO_VCCGND_F103ZET6_MINI
-#define HAL_SD_MODULE_ENABLED
 // SD card slot Definitions
 // SD detect signal can be defined if required
 #define SD_DETECT_PIN           PF10

--- a/variants/Generic_F410Cx/variant.h
+++ b/variants/Generic_F410Cx/variant.h
@@ -110,9 +110,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/Generic_F410Rx/variant.h
+++ b/variants/Generic_F410Rx/variant.h
@@ -125,9 +125,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/Generic_F446Rx/variant.h
+++ b/variants/Generic_F446Rx/variant.h
@@ -126,9 +126,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/Generic_F4x5RG/variant.h
+++ b/variants/Generic_F4x5RG/variant.h
@@ -115,9 +115,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/Generic_F4x7Vx/variant.h
+++ b/variants/Generic_F4x7Vx/variant.h
@@ -159,9 +159,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_F207ZG/variant.h
+++ b/variants/NUCLEO_F207ZG/variant.h
@@ -154,10 +154,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PD9
 #define PIN_SERIAL_TX           PD8
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_ETH_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_F302R8/variant.h
+++ b/variants/NUCLEO_F302R8/variant.h
@@ -110,9 +110,6 @@ extern "C" {
 #define PIN_SERIAL_RX           0
 #define PIN_SERIAL_TX           1
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_F303K8/variant.h
+++ b/variants/NUCLEO_F303K8/variant.h
@@ -79,9 +79,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA15 // 22
 #define PIN_SERIAL_TX           PA2  // 21
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_F303RE/variant.h
+++ b/variants/NUCLEO_F303RE/variant.h
@@ -110,9 +110,6 @@ extern "C" {
 #define PIN_SERIAL_RX           0
 #define PIN_SERIAL_TX           1
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_F429ZI/variant.h
+++ b/variants/NUCLEO_F429ZI/variant.h
@@ -143,10 +143,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PD9
 #define PIN_SERIAL_TX           PD8
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_ETH_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_F446RE/variant.h
+++ b/variants/NUCLEO_F446RE/variant.h
@@ -110,9 +110,6 @@ extern "C" {
 #define PIN_SERIAL_RX           0
 #define PIN_SERIAL_TX           1
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_F767ZI/variant.h
+++ b/variants/NUCLEO_F767ZI/variant.h
@@ -143,10 +143,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PD9
 #define PIN_SERIAL_TX           PD8
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_ETH_MODULE_ENABLED
-
 // Last Flash sector used for EEPROM emulation, address/sector depends on single/dual bank configuration.
 // By default 2MB single bank
 #define FLASH_BASE_ADDRESS  0x081C0000

--- a/variants/NUCLEO_F7x6ZG/variant.h
+++ b/variants/NUCLEO_F7x6ZG/variant.h
@@ -171,10 +171,6 @@ extern "C" {
 // Value of the External oscillator in Hz
 #define HSE_VALUE               8000000U
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_ETH_MODULE_ENABLED
-
 // Last Flash sector used for EEPROM emulation, address/sector depends on single/dual bank configuration.
 // By default 1MB single bank
 #define FLASH_BASE_ADDRESS      0x080C0000

--- a/variants/NUCLEO_G071RB/variant.h
+++ b/variants/NUCLEO_G071RB/variant.h
@@ -117,9 +117,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_G431KB/variant.h
+++ b/variants/NUCLEO_G431KB/variant.h
@@ -79,9 +79,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_G431RB/variant.h
+++ b/variants/NUCLEO_G431RB/variant.h
@@ -106,9 +106,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_G474RE/variant.h
+++ b/variants/NUCLEO_G474RE/variant.h
@@ -106,9 +106,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_H743ZI/variant.h
+++ b/variants/NUCLEO_H743ZI/variant.h
@@ -211,10 +211,6 @@ extern "C" {
 #define HSE_VALUE 8000000
 #endif
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_ETH_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_L053R8/variant.h
+++ b/variants/NUCLEO_L053R8/variant.h
@@ -109,9 +109,6 @@ extern "C" {
 #define PIN_SERIAL_RX           0
 #define PIN_SERIAL_TX           1
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_L073RZ/variant.h
+++ b/variants/NUCLEO_L073RZ/variant.h
@@ -123,9 +123,6 @@ extern "C" {
 #define PIN_SERIAL_RX           0
 #define PIN_SERIAL_TX           1
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_L152RE/variant.h
+++ b/variants/NUCLEO_L152RE/variant.h
@@ -109,9 +109,6 @@ extern "C" {
 #define PIN_SERIAL_RX           0
 #define PIN_SERIAL_TX           1
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_L432KC/variant.h
+++ b/variants/NUCLEO_L432KC/variant.h
@@ -80,9 +80,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA15
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_L433RC_P/variant.h
+++ b/variants/NUCLEO_L433RC_P/variant.h
@@ -108,9 +108,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-// Enable DAC
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_L452RE/variant.h
+++ b/variants/NUCLEO_L452RE/variant.h
@@ -176,9 +176,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_L476RG/variant.h
+++ b/variants/NUCLEO_L476RG/variant.h
@@ -109,9 +109,6 @@ extern "C" {
 #define PIN_SERIAL_RX           0
 #define PIN_SERIAL_TX           1
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_L496ZG/variant.h
+++ b/variants/NUCLEO_L496ZG/variant.h
@@ -203,9 +203,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PG8
 #define PIN_SERIAL_TX           PG7
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/NUCLEO_L4R5ZI/variant.h
+++ b/variants/NUCLEO_L4R5ZI/variant.h
@@ -202,9 +202,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PG8
 #define PIN_SERIAL_TX           PG7
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/PILL_F303XX/variant.h
+++ b/variants/PILL_F303XX/variant.h
@@ -110,9 +110,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/PNUCLEO_WB55RG/variant.h
+++ b/variants/PNUCLEO_WB55RG/variant.h
@@ -120,8 +120,6 @@ extern "C" {
 // for EEPROM emulation to the last 512k pages.
 #define FLASH_PAGE_NUMBER       127
 
-#define HAL_IPCC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/PRNTR_Vx/variant.h
+++ b/variants/PRNTR_Vx/variant.h
@@ -220,12 +220,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
-/* Extra HAL modules */
-#ifdef ARDUINO_PRNTR_F407_V1
-#define HAL_DAC_MODULE_ENABLED
-#endif
-#define HAL_SD_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/PX_HER0/variant.h
+++ b/variants/PX_HER0/variant.h
@@ -191,9 +191,6 @@ extern "C" {
 #define PIN_SERIALLP1_TX        PA2
 #define PIN_SERIALLP1_RX        PA3
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/PYBSTICK26_DUINO/variant.h
+++ b/variants/PYBSTICK26_DUINO/variant.h
@@ -124,9 +124,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL definitions */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/PYBSTICK26_PRO/variant.h
+++ b/variants/PYBSTICK26_PRO/variant.h
@@ -137,9 +137,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL definitions */
-#define HAL_SD_MODULE_ENABLED
-#define HAL_QSPI_MODULE_ENABLED
 #define HSE_VALUE               16000000U
 
 #ifdef __cplusplus

--- a/variants/PYBSTICK26_STD/variant.h
+++ b/variants/PYBSTICK26_STD/variant.h
@@ -130,8 +130,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 
-/* Extra HAL definitions */
-#define HAL_SD_MODULE_ENABLED
 #define HSE_VALUE               16000000U
 
 #ifdef __cplusplus

--- a/variants/SPARKY_F303CC/variant.h
+++ b/variants/SPARKY_F303CC/variant.h
@@ -112,9 +112,6 @@ extern "C" {
 #define PIN_SERIAL_RX           PB11
 #define PIN_SERIAL_TX           PB10
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/ST3DP001_EVAL/variant.h
+++ b/variants/ST3DP001_EVAL/variant.h
@@ -180,9 +180,6 @@ extern "C" {
 /* HAL configuration */
 #define HSE_VALUE               25000000U
 
-/* Extra HAL modules */
-#define HAL_SD_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/STEVAL_MKSBOX1V1/variant.h
+++ b/variants/STEVAL_MKSBOX1V1/variant.h
@@ -166,10 +166,6 @@ extern "C" {
 /* HAL configuration */
 #define HSE_VALUE               16000000U
 
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#define HAL_SD_MODULE_ENABLED
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/variants/THUNDERPACK/variant.h
+++ b/variants/THUNDERPACK/variant.h
@@ -95,10 +95,7 @@ extern "C" {
 #define PIN_SERIAL_RX           PB7
 #define PIN_SERIAL_TX           PB6
 
-#ifdef ARDUINO_THUNDERPACK_L072
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
-#else
+#ifndef ARDUINO_THUNDERPACK_L072
 #define HSE_VALUE               24000000U
 #endif
 

--- a/variants/WRAITH32_F051K6/variant.h
+++ b/variants/WRAITH32_F051K6/variant.h
@@ -45,7 +45,7 @@ extern "C" {
 #define PA1  15 // A1
 #define PA3  16 // A2
 #define PA4  17 // A3
-#define PA5  18 // A4 
+#define PA5  18 // A4
 #define PA6  19 // A5
 #define PA7  20 // A6
 #define PA2  21 // RC Input
@@ -80,9 +80,6 @@ extern "C" {
 // Serial Pin Firmata
 #define PIN_SERIAL_RX           PB7  // 4
 #define PIN_SERIAL_TX           PB6  // 5
-
-/* Extra HAL modules */
-#define HAL_DAC_MODULE_ENABLED
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
variant does not have to enable the HAL peripheral module else it cannot be disabled properly using HAL_PPP_MODULE_DISABLED
