### PR TITLE
fix: Compile-time error caused by non-weak yield

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -47,10 +47,12 @@ extern void initVariant() __attribute__((weak));
 extern void setup(void) ;
 extern void loop(void) ;
 
-static void __empty() {
+static void __empty()
+{
   // Empty
 }
-void yield(void) __attribute__ ((weak, alias("__empty")));
+  
+void yield(void) __attribute__((weak, alias("__empty")));
 
 #ifdef __cplusplus
 } // extern "C"

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -47,7 +47,11 @@ extern void initVariant() __attribute__((weak));
 extern void setup(void) ;
 extern void loop(void) ;
 
-void yield(void);
+static void __empty() {
+  // Empty
+}
+void yield(void) __attribute__ ((weak, alias("__empty")));
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus


### PR DESCRIPTION
**Summary**

Error message to be fixed:

```
wiring_time.c:(.text.delay+0xc): undefined reference to `yield'
exit status 1
Error compiling for board Generic STM32F1 series.
```

This PR fixes/implements the following **bugs/features**

* [x] Bug
