### PR TITLE
USB CDC line state

### DIFF
--- a/cores/arduino/USBSerial.cpp
+++ b/cores/arduino/USBSerial.cpp
@@ -188,7 +188,7 @@ bool USBSerial::dtr(void)
 
 bool USBSerial::rts(void)
 {
-  return false;
+  return rtsState;
 }
 
 USBSerial::operator bool()

--- a/cores/arduino/USBSerial.cpp
+++ b/cores/arduino/USBSerial.cpp
@@ -24,7 +24,8 @@
 #include "usbd_desc.h"
 #include "wiring.h"
 
-extern __IO  uint32_t lineState;
+extern __IO bool dtrState;
+extern __IO bool rtsState;
 
 USBSerial SerialUSB;
 void serialEventUSB() __attribute__((weak));
@@ -175,9 +176,14 @@ uint8_t USBSerial::numbits()
   return 8;
 }
 
+void USBSerial::dtr(bool enable)
+{
+  CDC_enableDTR(enable);
+}
+
 bool USBSerial::dtr(void)
 {
-  return false;
+  return dtrState;
 }
 
 bool USBSerial::rts(void)
@@ -187,12 +193,8 @@ bool USBSerial::rts(void)
 
 USBSerial::operator bool()
 {
-  bool result = false;
-  if (lineState == 1) {
-    result = true;
-  }
   delay(10);
-  return result;
+  return dtrState;
 }
 
 #endif // USBCON && USBD_USE_CDC

--- a/cores/arduino/USBSerial.h
+++ b/cores/arduino/USBSerial.h
@@ -51,6 +51,8 @@ class USBSerial : public Stream {
     uint8_t stopbits();
     uint8_t paritytype();
     uint8_t numbits();
+
+    void dtr(bool enable);
     bool dtr();
     bool rts();
     enum {

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc.c
@@ -527,7 +527,7 @@ static uint8_t USBD_CDC_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 }
 
 /**
-  * @brief  USBD_CDC_Init
+  * @brief  USBD_CDC_DeInit
   *         DeInitialize the CDC layer
   * @param  pdev: device instance
   * @param  cfgidx: Configuration index

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc.h
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc.h
@@ -73,6 +73,10 @@ extern "C" {
 #define CDC_SET_CONTROL_LINE_STATE                  0x22U
 #define CDC_SEND_BREAK                              0x23U
 
+// Control Line State bits
+#define CLS_DTR   (1 << 0)
+#define CLS_RTS   (1 << 1)
+
 /**
   * @}
   */

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.c
@@ -53,6 +53,7 @@ static bool CDC_DTR_enabled = true;
 CDC_TransmitQueue_TypeDef TransmitQueue;
 CDC_ReceiveQueue_TypeDef ReceiveQueue;
 __IO bool dtrState = false; /* lineState */
+__IO bool rtsState = false;
 __IO bool receivePended = true;
 static uint32_t transmitStart = 0;
 
@@ -190,6 +191,7 @@ static int8_t USBD_CDC_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length)
       if (dtrState) { // Reset the transmit timeout when the port is connected
         transmitStart = 0;
       }
+      rtsState = (((USBD_SetupReqTypedef *)pbuf)->wValue & CLS_RTS);
 #ifdef DTR_TOGGLING_SEQ
       dtr_toggling++; /* Count DTR toggling */
 #endif

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.h
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.h
@@ -51,6 +51,7 @@ bool CDC_resume_receive(void);
 void CDC_init(void);
 void CDC_deInit(void);
 bool CDC_connected(void);
+void CDC_enableDTR(bool enable);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add api to manage the DTR usage.
 Usage: 
```C++
Serial.dtr(false); // Disable the DTR
Serial.dtr(true); // Enable the DTR - default state
```

Assuming `Serial` is mapped on `SerialUSB`

Also implement `rts()` and `dtr()` to return correct state,

Fixes #1193