### PR TITLE
variant NUCLEO_H743ZI: fix digitalPin typo

### DIFF
--- a/variants/STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT/variant_NUCLEO_H743ZI.cpp
+++ b/variants/STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT/variant_NUCLEO_H743ZI.cpp
@@ -208,7 +208,7 @@ const PinName digitalPin[] = {
   PF_1,
   PF_2,
   PA_7,
-  NC_,
+  NC,
   PA_3,
   PC_0,
   PC_3_C,


### PR DESCRIPTION

**Summary**
variant NUCLEO_H743ZI: fix digitalPin typo

