### PR TITLE
build options in source comments

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -111,8 +111,8 @@ build.opt.path={build.path}/sketch/{build.opt.name}
 extras.path={build.system.path}/extras
 
 # Create empty {build.opt} if not exists in the output sketch dir and force include of SrcWrapper library
-recipe.hooks.prebuild.1.pattern="{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}"
-recipe.hooks.prebuild.1.pattern.windows="{runtime.tools.STM32Tools.path}/win/busybox.exe" sh "{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}"
+recipe.hooks.prebuild.1.pattern="{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}" "{build.project_name}"
+recipe.hooks.prebuild.1.pattern.windows="{runtime.tools.STM32Tools.path}/win/busybox.exe" sh "{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}" "{build.project_name}"
 
 # compile patterns
 # ---------------------

--- a/system/extras/prebuild.sh
+++ b/system/extras/prebuild.sh
@@ -2,6 +2,7 @@
 
 BUILD_PATH="$1"
 BUILD_SOURCE_PATH="$2"
+BUILD_PROJECT_NAME="$3"
 
 # Create sketch dir if not exists
 if [ ! -f "$BUILD_PATH/sketch" ]; then
@@ -11,6 +12,11 @@ fi
 # Create empty build.opt.h if not exists in the original sketch dir
 if [ ! -f "$BUILD_SOURCE_PATH/build_opt.h" ]; then
   touch "$BUILD_PATH/sketch/build_opt.h"
+fi
+
+# add build options in source comments
+if [ -f "$BUILD_SOURCE_PATH/$BUILD_PROJECT_NAME" ]; then
+  grep '\/\/ build-opt' "$BUILD_SOURCE_PATH/$BUILD_PROJECT_NAME" | sed -e 's/\/\/ build-opt//' >> "$BUILD_PATH/sketch/build_opt.h"
 fi
 
 # Force include of SrcWrapper library


### PR DESCRIPTION
This PR allows embedding build options in project .ino source comments, like this:
```
// build-opt -DUSB_PRODUCT_STRING=\"device\ name\"

void setup() {
  // put your setup code here, to run once:
}

void loop() {
  // put your main code here, to run repeatedly:
}
```
This way there is no need for a separate build_opt.h file. This also works when using arduino ide 2.0.0.

