### PR TITLE
core: backup: use register definition instead of serie name

### DIFF
--- a/cores/arduino/stm32/backup.h
+++ b/cores/arduino/stm32/backup.h
@@ -30,15 +30,7 @@ extern "C" {
 #endif
 
 /* Exported macro ------------------------------------------------------------*/
-#if (!defined(STM32F0xx) && !defined(STM32F3xx) && !defined(STM32L0xx) &&\
-  !defined(STM32L1xx) && !defined(STM32L4xx) && !defined(STM32MP1xx)) || \
-  defined(RTC_BACKUP_SUPPORT)
-#if !defined(STM32L412xx) && !defined(STM32L422xx)
-#define ENABLE_BACKUP_SUPPORT
-#endif
-#endif
-
-#if !defined(RTC_BKP_INDEX) && defined(ENABLE_BACKUP_SUPPORT)
+#if !defined(RTC_BKP_INDEX) && defined(LL_RTC_BKP_DR1)
 #define RTC_BKP_INDEX LL_RTC_BKP_DR1
 #else
 #define RTC_BKP_INDEX 0
@@ -109,37 +101,41 @@ static inline void disableBackupDomain(void)
 
 static inline void setBackupRegister(uint32_t index, uint32_t value)
 {
-#if defined(STM32F1xx)
+#if defined(BKP_BASE)
   LL_RTC_BKP_SetRegister(BKP, index, value);
-#elif defined(STM32G0xx)
-  LL_RTC_BKP_SetRegister(TAMP, index, value);
-#elif defined(STM32G4xx) || defined(STM32L5xx)
+#elif defined(RTC_BKP0R)
+  LL_RTC_BAK_SetRegister(RTC, index, value);
+#elif defined(TAMP_BKP0R)
+#if defined(STM32G4xx) || defined(STM32L5xx) || defined(STM32MP1xx)
+  /* For those series this API requires RTC even if it is not used
+     and TAMP is used instead */
   LL_RTC_BKP_SetRegister(RTC, index, value);
 #else
-#ifdef ENABLE_BACKUP_SUPPORT
-  LL_RTC_BAK_SetRegister(RTC, index, value);
+  LL_RTC_BKP_SetRegister(TAMP, index, value);
+#endif
 #else
   UNUSED(index);
   UNUSED(value);
-#endif
 #endif
 }
 
 static inline uint32_t getBackupRegister(uint32_t index)
 {
-#if defined(STM32F1xx)
+#if defined(BKP_BASE)
   return LL_RTC_BKP_GetRegister(BKP, index);
-#elif defined(STM32G0xx)
-  return LL_RTC_BKP_GetRegister(TAMP, index);
-#elif defined(STM32G4xx) || defined(STM32L5xx)
+#elif defined(RTC_BKP0R)
+  return LL_RTC_BAK_GetRegister(RTC, index);
+#elif defined(TAMP_BKP0R)
+#if defined(STM32G4xx) || defined(STM32L5xx) || defined(STM32MP1xx)
+  /* For those series this API requires RTC even if it is not used
+     and TAMP is used instead */
   return LL_RTC_BKP_GetRegister(RTC, index);
 #else
-#ifdef ENABLE_BACKUP_SUPPORT
-  return LL_RTC_BAK_GetRegister(RTC, index);
+  return LL_RTC_BKP_GetRegister(TAMP, index);
+#endif
 #else
   UNUSED(index);
   return 0;
-#endif
 #endif
 }
 


### PR DESCRIPTION
Some series still require to use their name due to wrong LL API prototype using RTC parameter instead of TAMP.



