### PR TITLE
variant: WL: add Nucleo-WL55JC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart:  | STM32L452RE-P | [Nucleo L452RE-P](http://www.st.com/en/evaluation-tools/nucleo-l452re-p.html) | *1.8.0* |  |
 | :green_heart:  | STM32L476RG | [Nucleo L476RG](http://www.st.com/en/evaluation-tools/nucleo-l476rg.html) | *0.1.0* |  |
 | :green_heart:  | STM32WB55RG<br>STM32WB55CG | [P-Nucleo-WB55RG](https://www.st.com/en/evaluation-tools/p-nucleo-wb55.html) | *1.6.0* | BLE support with [STM32duinoBLE](https://github.com/stm32duino/STM32duinoBLE) |
+| :yellow_heart:  | STM32WL55JC | [Nucleo WL55JC1](https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html) | **2.1.0** | LoRa support not available |
+
 
 ### [Nucleo 32](https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-eval-tools/stm32-mcu-eval-tools/stm32-nucleo-boards.html) boards
 

--- a/boards.txt
+++ b/boards.txt
@@ -502,6 +502,19 @@ Nucleo_64.menu.pnum.P_NUCLEO_WB55RG.build.product_line=STM32WB55xx
 Nucleo_64.menu.pnum.P_NUCLEO_WB55RG.build.variant=STM32WBxx/WB55R(C-E-G)V
 Nucleo_64.menu.pnum.P_NUCLEO_WB55RG.build.cmsis_lib_gcc=arm_cortexM4lf_math
 
+# NUCLEO_WL55JC1 board
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1=Nucleo WL55JC1
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.node="NOD_WL55JC"
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.upload.maximum_size=262144
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.upload.maximum_data_size=65536
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.build.board=NUCLEO_WL55JC1
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.build.series=STM32WLxx
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.build.product_line=STM32WLE5xx
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.build.variant=STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.build.cmsis_lib_gcc=arm_cortexM4lf_math
+Nucleo_64.menu.pnum.NUCLEO_WL55JC1.build.extra_flags=-D{build.product_line} -DUSE_CM4_STARTUP_FILE {build.xSerial}
+
 # Upload menu
 Nucleo_64.menu.upload_method.MassStorage=Mass Storage
 Nucleo_64.menu.upload_method.MassStorage.upload.protocol=

--- a/variants/STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I/variant_NUCLEO_WL55JC1.cpp
+++ b/variants/STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I/variant_NUCLEO_WL55JC1.cpp
@@ -1,0 +1,131 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2021, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#if defined(ARDUINO_NUCLEO_WL55JC1)
+#include "pins_arduino.h"
+
+// Digital PinName array
+const PinName digitalPin[] = {
+  PB_7,  // D0
+  PB_6,  // D1
+  PB_12, // D2
+  PB_3,  // D3/A6
+  PB_5,  // D4
+  PB_8,  // D5
+  PB_10, // D6
+  PC_1,  // D7
+  PC_2,  // D8
+  PA_9,  // D9
+  PA_4,  // D10
+  PA_7,  // D11
+  PA_6,  // D12
+  PA_5,  // D13
+  PA_11, // D14/A7
+  PA_12, // D15/A8
+  PB_1,  // D16/A0
+  PB_2,  // D17/A1
+  PA_10, // D18/A2
+  PB_4,  // D19/A3
+  PB_14, // D20/A4
+  PB_13, // D21/A5
+  PA_0,  // D22
+  PC_3,  // D23
+  PA_1,  // D24
+  PB_11, // D25
+  PB_15, // D26
+  PB_9,  // D27
+  PB_0,  // D28
+  PA_8,  // D29
+  PC_0,  // D30
+  PC_6,  // D31
+  PC_5,  // D32
+  PC_4,  // D33
+  PC_15, // D34
+  PC_14, // D35
+  PC_13, // D36
+  PA_15, // D37/A9
+  PA_14, // D38/A10
+  PA_13, // D39/A11
+  PA_2,  // D40
+  PA_3,  // D41
+  PH_3   // D42
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInputPin[] = {
+  16, // A0,  PB1
+  17, // A1,  PB2
+  18, // A2,  PA10
+  19, // A3,  PB4
+  20, // A4,  PB14
+  21, // A5,  PB13
+  3,  // A6,  PB3
+  14, // A7,  PA11
+  15, // A8,  PA12
+  37, // A9,  PA15
+  38, // A10, PA14
+  39  // A11, PA13
+};
+
+// ----------------------------------------------------------------------------
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief  System Clock Configuration
+  * @param  None
+  * @retval None
+  */
+WEAK void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {};
+
+  /** Configure LSE Drive Capability
+  */
+  HAL_PWR_EnableBkUpAccess();
+  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
+  /** Configure the main internal regulator output voltage
+  */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+  /** Initializes the CPU, AHB and APB busses clocks
+  */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_MSI;
+  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
+  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
+  */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3 | RCC_CLOCKTYPE_HCLK
+                                | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1
+                                | RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK) {
+    Error_Handler();
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ARDUINO_NUCLEO_WL55JC1 */

--- a/variants/STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I/variant_NUCLEO_WL55JC1.h
+++ b/variants/STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I/variant_NUCLEO_WL55JC1.h
@@ -1,0 +1,160 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2021, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#pragma once
+
+/*----------------------------------------------------------------------------
+ *        STM32 pins number
+ *----------------------------------------------------------------------------*/
+// Arduino UNO V3
+// CN9
+#define PB7                     0
+#define PB6                     1
+#define PB12                    2
+#define PB3                     PIN_A6
+#define PB5                     4
+#define PB8                     5
+#define PB10                    6
+#define PC1                     7
+// CN5
+#define PC2                     8
+#define PA9                     9
+#define PA4                     10
+#define PA7                     11
+#define PA6                     12
+#define PA5                     13
+#define PA11                    PIN_A7
+#define PA12                    PIN_A8
+// CN8
+#define PB1                     PIN_A0
+#define PB2                     PIN_A1
+#define PA10                    PIN_A2
+#define PB4                     PIN_A3
+#define PB14                    PIN_A4
+#define PB13                    PIN_A5
+// ST Morpho
+// CN10 Left Side
+#define PA0                     22
+// CN10 Right Side
+#define PC3                     23      // FE_CTRL3
+#define PA1                     24
+#define PB11                    25
+#define PB15                    26
+#define PB9                     27
+#define PB0                     28      // VDD_TCXO Supply voltage of TCXO
+#define PA8                     29
+#define PC0                     30
+#define PC6                     31
+#define PC5                     32      // FE_CTRL2
+#define PC4                     33      // FE_CTRL1
+// CN7 Left Side
+#define PC15                    34      // OSC32_OUT - SB11 OFF not connected to ST Morpho
+#define PC14                    35      // OSC32_IN - SB14 OFF not connected to ST Morpho
+#define PC13                    36
+#define PA15                    PIN_A9
+#define PA14                    PIN_A10
+#define PA13                    PIN_A11
+// Not on connectors
+#define PA2                     40     // Could be on D1. See Solder bridge configuration.
+#define PA3                     41     // Could be on D0. See Solder bridge configuration.
+#define PH3                     42     // BOOT0 - JP3 - GND
+
+// Alternate pins number
+#define PA1_ALT1                (PA1 | ALT1)
+#define PA2_ALT1                (PA2 | ALT1)
+#define PA3_ALT1                (PA3 | ALT1)
+#define PA7_ALT1                (PA7 | ALT1)
+#define PB8_ALT1                (PB8 | ALT1)
+#define PB9_ALT1                (PB9 | ALT1)
+
+#define NUM_DIGITAL_PINS        43
+#define NUM_ANALOG_INPUTS       12
+
+// On-board LED pin number
+#define LED1                    PB15
+#define LED2                    PB9
+#define LED3                    PB11
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN           LED1
+#endif
+#define LED_BLUE                LED1
+#define LED_GREEN               LED2
+#define LED_RED                 LED3
+
+// On-board user button
+#define B1_BTN                  PA0 // PC13 (!SB16 SB15)
+#define B2_BTN                  PA1
+#define B3_BTN                  PC6
+#ifndef USER_BTN
+  #define USER_BTN              B1_BTN
+#endif
+
+// Timer Definitions
+// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
+#ifndef TIMER_TONE
+  #define TIMER_TONE            TIM16
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO           TIM17
+#endif
+
+// UART Definitions
+#ifndef SERIAL_UART_INSTANCE
+  #define SERIAL_UART_INSTANCE  101
+#endif
+
+// Default pin used for generic 'Serial' instance
+// Mandatory for Firmata
+#ifndef PIN_SERIAL_RX
+  #define PIN_SERIAL_RX         PA3
+#endif
+#ifndef PIN_SERIAL_TX
+  #define PIN_SERIAL_TX         PA2
+#endif
+
+#ifndef UART_WAKEUP_EXTI_LINE
+  // For LPUART1
+  #define UART_WAKEUP_EXTI_LINE LL_EXTI_LINE_28
+#endif
+
+// Extra HAL modules
+#if !defined(HAL_DAC_MODULE_DISABLED)
+  #define HAL_DAC_MODULE_ENABLED
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+  // These serial port names are intended to allow libraries and architecture-neutral
+  // sketches to automatically default to the correct port name for a particular type
+  // of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+  // the first hardware serial port whose RX/TX pins are not dedicated to another use.
+  //
+  // SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+  //
+  // SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+  //
+  // SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+  //
+  // SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+  //
+  // SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+  //                            pins are NOT connected to anything by default.
+  #ifndef SERIAL_PORT_MONITOR
+    #define SERIAL_PORT_MONITOR   Serial
+  #endif
+  #ifndef SERIAL_PORT_HARDWARE
+    #define SERIAL_PORT_HARDWARE  Serial
+  #endif
+#endif


### PR DESCRIPTION
[NUCLEO-WL55JC](https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html)

# Tested:
- [x] GPIO
- [x] U(S)ART
- [x] ADC
- [x] DAC
- [x] I2C
- [x] SPI
- [x] Timer
- [x] RTC
- [x] Low Power
- [x] EEPROM

# Requirement:
- [x] https://github.com/stm32duino/STM32RTC/pull/51
- [x] https://github.com/stm32duino/STM32LowPower/pull/58