### PR TITLE
library: Wire/SPI: change default pins type

### DIFF
--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -80,8 +80,8 @@ static const uint32_t SCK  = PIN_SPI_SCK;
   #define PIN_WIRE_SCL              15
 #endif
 
-static const uint8_t SDA = PIN_WIRE_SDA;
-static const uint8_t SCL = PIN_WIRE_SCL;
+static const uint32_t SDA = PIN_WIRE_SDA;
+static const uint32_t SCL = PIN_WIRE_SCL;
 
 #ifdef __cplusplus
 extern "C" {

--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -64,13 +64,13 @@ _Static_assert(NUM_ANALOG_INPUTS <= MAX_ANALOG_INPUTS,
   #define PIN_SPI_SCK               13
 #endif
 
-static const uint8_t SS   = PIN_SPI_SS;
-static const uint8_t SS1  = PIN_SPI_SS1;
-static const uint8_t SS2  = PIN_SPI_SS2;
-static const uint8_t SS3  = PIN_SPI_SS3;
-static const uint8_t MOSI = PIN_SPI_MOSI;
-static const uint8_t MISO = PIN_SPI_MISO;
-static const uint8_t SCK  = PIN_SPI_SCK;
+static const uint32_t SS   = PIN_SPI_SS;
+static const uint32_t SS1  = PIN_SPI_SS1;
+static const uint32_t SS2  = PIN_SPI_SS2;
+static const uint32_t SS3  = PIN_SPI_SS3;
+static const uint32_t MOSI = PIN_SPI_MOSI;
+static const uint32_t MISO = PIN_SPI_MISO;
+static const uint32_t SCK  = PIN_SPI_SCK;
 
 /* I2C Definitions */
 #ifndef PIN_WIRE_SDA

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -43,7 +43,7 @@ SPIClass::SPIClass() : _CSPinConfig(NO_CONFIG)
   *         another CS pin and don't pass a CS pin as parameter to any functions
   *         of the class.
   */
-SPIClass::SPIClass(uint8_t mosi, uint8_t miso, uint8_t sclk, uint8_t ssel) : _CSPinConfig(NO_CONFIG)
+SPIClass::SPIClass(uint32_t mosi, uint32_t miso, uint32_t sclk, uint32_t ssel) : _CSPinConfig(NO_CONFIG)
 {
   _spi.pin_miso = digitalPinToPinName(miso);
   _spi.pin_mosi = digitalPinToPinName(mosi);

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -114,7 +114,7 @@ class SPISettings {
 class SPIClass {
   public:
     SPIClass();
-    SPIClass(uint8_t mosi, uint8_t miso, uint8_t sclk, uint8_t ssel = (uint8_t)NC);
+    SPIClass(uint32_t mosi, uint32_t miso, uint32_t sclk, uint32_t ssel = PNUM_NOT_DEFINED);
 
     // setMISO/MOSI/SCLK/SSEL have to be called before begin()
     void setMISO(uint32_t miso)

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -39,7 +39,7 @@ TwoWire::TwoWire()
   _i2c.scl = digitalPinToPinName(SCL);
 }
 
-TwoWire::TwoWire(uint8_t sda, uint8_t scl)
+TwoWire::TwoWire(uint32_t sda, uint32_t scl)
 {
   _i2c.sda = digitalPinToPinName(sda);
   _i2c.scl = digitalPinToPinName(scl);
@@ -47,7 +47,7 @@ TwoWire::TwoWire(uint8_t sda, uint8_t scl)
 
 // Public Methods //////////////////////////////////////////////////////////////
 
-void TwoWire::begin(uint8_t sda, uint8_t scl)
+void TwoWire::begin(uint32_t sda, uint32_t scl)
 {
   _i2c.sda = digitalPinToPinName(sda);
   _i2c.scl = digitalPinToPinName(scl);

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -64,7 +64,7 @@ class TwoWire : public Stream {
 
   public:
     TwoWire();
-    TwoWire(uint8_t sda, uint8_t scl);
+    TwoWire(uint32_t sda, uint32_t scl);
     // setSCL/SDA have to be called before begin()
     void setSCL(uint32_t scl)
     {
@@ -83,7 +83,7 @@ class TwoWire : public Stream {
       _i2c.sda = sda;
     };
     void begin(bool generalCall = false);
-    void begin(uint8_t, uint8_t);
+    void begin(uint32_t, uint32_t);
     void begin(uint8_t, bool generalCall = false);
     void begin(int, bool generalCall = false);
     void end();


### PR DESCRIPTION
Since `_ALTx` introduction, default Arduino API using `uint8_t` type for pin number could not use them and raised raised this error:

```log
warning: unsigned conversion from 'int' to 'uint8_t' {aka 'unsigned char'} changes value from '260' to '4' [-Woverflow]
   91 | #define PB5_ALT1                (PB5  | ALT1)
      |                                 ~~~~~~^~~~~~~
sketch_jul06a.ino:10:20: note: in expansion of macro 'PB5_ALT1'
   10 |   SPIClass SPI_3rd(PB5_ALT1, PC11, PC10);
      |                    ^~~~~~~~
```

Moving API to uint32_t allows to use `_ALTx`, anyway some libraries used the default pin definition as an uint8_t from the variant definition, for example: 
```C
#ifndef PIN_SPI_MOSI
  #define PIN_SPI_MOSI          PB5_ALT1
#endif
```

Which is stored in:
```C
static const uint32_t MISO = PIN_SPI_MISO;
```

With Arduino SD library:
https://github.com/arduino-libraries/SD/blob/a64c2bd907460dd01cef07fff003550cfcae0119/src/utility/Sd2Card.h#L75-L83

```log
libraries\SD\src\utility\Sd2PinMap.h:28:28: warning: conversion from 'uint32_t' {aka 'long unsigned int'} to 'uint8_t' {aka 'unsigned char'} changes value from '260' to '4' [-Woverflow]
   28 |   uint8_t const MOSI_PIN = MOSI;
      |                            ^~~~
```

In this case this is not risky as those conversion will use the correct pin for SOFTWARE_SPI (GPIO toggling) not related to a peripheral and in major way default pins uses value without `_ALTx` which mean an unit8_t size and so does not raised warning.
Anyway not all libraries could use `_ALTx` feature.

Fixes #1432 
