### PR TITLE
exclude fpu options from stm32wl55

### DIFF
--- a/tools/platformio/platformio-build.py
+++ b/tools/platformio/platformio-build.py
@@ -146,7 +146,7 @@ def configure_application_offset(mcu, upload_protocol):
     env.Append(LINKFLAGS=["-Wl,--defsym=LD_FLASH_OFFSET=%s" % hex(offset)])
 
 
-if any(mcu in board_config.get("build.cpu") for mcu in ("cortex-m4", "cortex-m7")):
+if any(mcu in board_config.get("build.cpu") for mcu in ("cortex-m4", "cortex-m7")) and "stm32wl" not in mcu:
     env.Append(
         CCFLAGS=["-mfpu=fpv4-sp-d16", "-mfloat-abi=hard"],
         LINKFLAGS=["-mfpu=fpv4-sp-d16", "-mfloat-abi=hard"],


### PR DESCRIPTION
**Summary**

This PR fixes **bug**

* [x] #1473 


<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Arduino Core STM32 provides a platformio-build.py file that sets compiler build flags for Arduino Core STM32 in platformio. This file sets the -mfpu flag automatically for every cortex-m4 MCU. But according to the CMSIS drivers, the STM32WL55 does not contain an FPU, causing this python script to set the wrong compile time flags. The proposed PR fixes this by excluding the -mfpu option from the CPPDEFINES flags. 



<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Validation**

* Ensure CI build is passed.
The following sketch won't compile without it, but will with this fix:
```
#include <Arduino.h>

void setup() {
}

void loop() {
}
```

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #1473
