### PR TITLE
Fix `bitWrite` with parenthesis

### DIFF
--- a/cores/arduino/wiring_constants.h
+++ b/cores/arduino/wiring_constants.h
@@ -91,7 +91,7 @@ enum BitOrder {
 #define bitRead(value, bit) (((value) >> (bit)) & 0x01)
 #define bitSet(value, bit) ((value) |= (1UL << (bit)))
 #define bitClear(value, bit) ((value) &= ~(1UL << (bit)))
-#define bitWrite(value, bit, bitvalue) (bitvalue ? bitSet(value, bit) : bitClear(value, bit))
+#define bitWrite(value, bit, bitvalue) ((bitvalue) ? bitSet((value), (bit)) : bitClear((value), (bit) ))
 
 #define bit(b) (1UL << (b))
 //macro added for compatibility


### PR DESCRIPTION
Current version does not wrap arguments in "()", so works incorrectly when used like this:
```
bitWrite(var, bit, cond?1:0);
```


Same as in here: https://github.com/espressif/arduino-esp32/issues/4466

