### PR TITLE
library: enhance peripheral clock frequency management

### DIFF
--- a/libraries/SPI/src/utility/spi_com.c
+++ b/libraries/SPI/src/utility/spi_com.c
@@ -55,95 +55,111 @@ extern "C" {
 uint32_t spi_getClkFreqInst(SPI_TypeDef *spi_inst)
 {
   uint32_t spi_freq = SystemCoreClock;
-
+  if (spi_inst != NP) {
 #if defined(STM32F0xx) || defined(STM32G0xx)
-  UNUSED(spi_inst);
-  /* SPIx source CLK is PCKL1 */
-  spi_freq = HAL_RCC_GetPCLK1Freq();
-#elif defined(STM32H7xx)
-  /* Get source clock depending on SPI instance */
-  if (spi_inst != NP) {
-    switch ((uint32_t)spi_inst) {
-      case (uint32_t)SPI1:
-      case (uint32_t)SPI2:
-      case (uint32_t)SPI3:
-        spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI123);
-        break;
-      case (uint32_t)SPI4:
-      case (uint32_t)SPI5:
-        spi_freq = HAL_RCC_GetPCLK2Freq();
-        break;
-      case (uint32_t)SPI6:
-        spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI6);
-        break;
-      default:
-        core_debug("CLK: SPI instance not set");
-        break;
-    }
-  }
-#elif defined(STM32MP1xx)
-  /* Get source clock depending on SPI instance */
-  if (spi_inst != NP) {
-    switch ((uint32_t)spi_inst) {
-      case (uint32_t)SPI1:
-        spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
-        break;
-      case (uint32_t)SPI2:
-      case (uint32_t)SPI3:
-        spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI23);
-        break;
-      case (uint32_t)SPI4:
-      case (uint32_t)SPI5:
-        spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI45);
-        break;
-      case (uint32_t)SPI6:
-        spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI6);
-        break;
-      default:
-        core_debug("CLK: SPI instance not set");
-        break;
-    }
-  }
+    /* SPIx source CLK is PCKL1 */
+    spi_freq = HAL_RCC_GetPCLK1Freq();
 #else
-  if (spi_inst != NP) {
-    /* Get source clock depending on SPI instance */
-    switch ((uint32_t)spi_inst) {
-#if defined(SPI1_BASE) || defined(SPI4_BASE) || defined(SPI5_BASE) || defined(SPI6_BASE)
-        /* Some STM32's (eg. STM32F302x8) have no SPI1, but do have SPI2/3. */
-#if defined SPI1_BASE
-      case (uint32_t)SPI1:
+#if defined(SPI1_BASE)
+    if (spi_inst == SPI1) {
+#if defined(RCC_PERIPHCLK_SPI1) || defined(RCC_PERIPHCLK_SPI123)
+#ifdef RCC_PERIPHCLK_SPI1
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
+#else
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI123);
 #endif
-#if defined SPI4_BASE
-      case (uint32_t)SPI4:
+      if (spi_freq == 0)
 #endif
-#if defined SPI5_BASE
-      case (uint32_t)SPI5:
-#endif
-#if defined SPI6_BASE
-      case (uint32_t)SPI6:
-#endif
+      {
         /* SPI1, SPI4, SPI5 and SPI6. Source CLK is PCKL2 */
         spi_freq = HAL_RCC_GetPCLK2Freq();
-        break;
-#endif  /* SPI[1456]_BASE */
-
-#if defined(SPI2_BASE) || defined (SPI3_BASE)
-#if defined SPI2_BASE
-      case (uint32_t)SPI2:
+      }
+    }
+#endif // SPI1_BASE
+#if defined(SPI2_BASE)
+    if (spi_inst == SPI2) {
+#if defined(RCC_PERIPHCLK_SPI2) || defined(RCC_PERIPHCLK_SPI123) ||\
+    defined(RCC_PERIPHCLK_SPI23)
+#ifdef RCC_PERIPHCLK_SPI2
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI2);
+#elif defined(RCC_PERIPHCLK_SPI123)
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI123);
+#else
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI23);
 #endif
-#if defined SPI3_BASE
-      case (uint32_t)SPI3:
+      if (spi_freq == 0)
 #endif
+      {
         /* SPI_2 and SPI_3. Source CLK is PCKL1 */
         spi_freq = HAL_RCC_GetPCLK1Freq();
-        break;
-#endif
-      default:
-        core_debug("CLK: SPI instance not set");
-        break;
+      }
     }
-  }
+#endif // SPI2_BASE
+#if defined(SPI3_BASE)
+    if (spi_inst == SPI3) {
+#if defined(RCC_PERIPHCLK_SPI3) || defined(RCC_PERIPHCLK_SPI123) ||\
+    defined(RCC_PERIPHCLK_SPI23)
+#ifdef RCC_PERIPHCLK_SPI3
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI3);
+#elif defined(RCC_PERIPHCLK_SPI123)
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI123);
+#else
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI23);
 #endif
+      if (spi_freq == 0)
+#endif
+      {
+        /* SPI_2 and SPI_3. Source CLK is PCKL1 */
+        spi_freq = HAL_RCC_GetPCLK1Freq();
+      }
+    }
+#endif // SPI3_BASE
+#if defined(SPI4_BASE)
+    if (spi_inst == SPI4) {
+#if defined(RCC_PERIPHCLK_SPI4) || defined(RCC_PERIPHCLK_SPI45)
+#ifdef RCC_PERIPHCLK_SPI4
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI4);
+#else
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI45);
+#endif
+      if (spi_freq == 0)
+#endif
+      {
+        /* SPI1, SPI4, SPI5 and SPI6. Source CLK is PCKL2 */
+        spi_freq = HAL_RCC_GetPCLK2Freq();
+      }
+    }
+#endif // SPI4_BASE
+#if defined(SPI5_BASE)
+    if (spi_inst == SPI5) {
+#if defined(RCC_PERIPHCLK_SPI5) || defined(RCC_PERIPHCLK_SPI45)
+#ifdef RCC_PERIPHCLK_SPI5
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI5);
+#else
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI45);
+#endif
+      if (spi_freq == 0)
+#endif
+      {
+        /* SPI1, SPI4, SPI5 and SPI6. Source CLK is PCKL2 */
+        spi_freq = HAL_RCC_GetPCLK2Freq();
+      }
+    }
+#endif // SPI5_BASE
+#if defined(SPI6_BASE)
+    if (spi_inst == SPI6) {
+#if defined(RCC_PERIPHCLK_SPI6)
+      spi_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI6);
+      if (spi_freq == 0)
+#endif
+      {
+        /* SPI1, SPI4, SPI5 and SPI6. Source CLK is PCKL2 */
+        spi_freq = HAL_RCC_GetPCLK2Freq();
+      }
+    }
+#endif // SPI6_BASE
+#endif
+  }
   return spi_freq;
 }
 

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -189,192 +189,243 @@ static I2C_HandleTypeDef *i2c_handles[I2C_NUM];
 static uint32_t i2c_getClkFreq(I2C_TypeDef *i2c)
 {
   uint32_t clkSrcFreq = 0;
-#if !defined(STM32MP1xx)
 #ifdef STM32H7xx
   PLL3_ClocksTypeDef PLL3_Clocks;
 #endif
-#if defined I2C1_BASE
+#if defined(I2C1_BASE)
   if (i2c == I2C1) {
-    switch (__HAL_RCC_GET_I2C1_SOURCE()) {
-      case RCC_I2C1CLKSOURCE_HSI:
-        clkSrcFreq = HSI_VALUE;
-        break;
+#if defined(RCC_PERIPHCLK_I2C1) || defined(RCC_PERIPHCLK_I2C12)
+#ifdef RCC_PERIPHCLK_I2C1
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C1);
+#else
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C12);
+#endif
+    if (clkSrcFreq == 0)
+#endif
+    {
+#ifdef __HAL_RCC_GET_I2C1_SOURCE
+      switch (__HAL_RCC_GET_I2C1_SOURCE()) {
+#ifdef RCC_I2C1CLKSOURCE_HSI
+        case RCC_I2C1CLKSOURCE_HSI:
+          clkSrcFreq = HSI_VALUE;
+          break;
+#endif
 #ifdef RCC_I2C1CLKSOURCE_SYSCLK
-      case RCC_I2C1CLKSOURCE_SYSCLK:
-        clkSrcFreq = SystemCoreClock;
-        break;
+        case RCC_I2C1CLKSOURCE_SYSCLK:
+          clkSrcFreq = SystemCoreClock;
+          break;
 #endif
 #if defined(RCC_I2C1CLKSOURCE_PCLK1) || defined(RCC_I2C1CLKSOURCE_D2PCLK1)
 #ifdef RCC_I2C1CLKSOURCE_PCLK1
-      case RCC_I2C1CLKSOURCE_PCLK1:
+        case RCC_I2C1CLKSOURCE_PCLK1:
 #endif
 #ifdef RCC_I2C1CLKSOURCE_D2PCLK1
-      case RCC_I2C1CLKSOURCE_D2PCLK1:
+        case RCC_I2C1CLKSOURCE_D2PCLK1:
 #endif
-        clkSrcFreq = HAL_RCC_GetPCLK1Freq();
-        break;
+          clkSrcFreq = HAL_RCC_GetPCLK1Freq();
+          break;
 #endif
 #ifdef RCC_I2C1CLKSOURCE_CSI
-      case RCC_I2C1CLKSOURCE_CSI:
-        clkSrcFreq = CSI_VALUE;
-        break;
+        case RCC_I2C1CLKSOURCE_CSI:
+          clkSrcFreq = CSI_VALUE;
+          break;
 #endif
 #ifdef RCC_I2C1CLKSOURCE_PLL3
-      case RCC_I2C1CLKSOURCE_PLL3:
-        HAL_RCCEx_GetPLL3ClockFreq(&PLL3_Clocks);
-        clkSrcFreq = PLL3_Clocks.PLL3_R_Frequency;
-        break;
+        case RCC_I2C1CLKSOURCE_PLL3:
+          HAL_RCCEx_GetPLL3ClockFreq(&PLL3_Clocks);
+          clkSrcFreq = PLL3_Clocks.PLL3_R_Frequency;
+          break;
 #endif
-      default:
-        Error_Handler();
+        default:
+          Error_Handler();
+      }
+#else
+      Error_Handler();
+#endif
     }
   }
 #endif // I2C1_BASE
-#if defined I2C2_BASE
+#if defined(I2C2_BASE)
   if (i2c == I2C2) {
+#if defined(RCC_PERIPHCLK_I2C2) || defined(RCC_PERIPHCLK_I2C12)
+#ifdef RCC_PERIPHCLK_I2C2
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C2);
+#else
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C12);
+#endif
+    if (clkSrcFreq == 0)
+#endif
+    {
 #ifdef __HAL_RCC_GET_I2C2_SOURCE
-    switch (__HAL_RCC_GET_I2C2_SOURCE()) {
-      case RCC_I2C2CLKSOURCE_HSI:
-        clkSrcFreq = HSI_VALUE;
-        break;
+      switch (__HAL_RCC_GET_I2C2_SOURCE()) {
+        case RCC_I2C2CLKSOURCE_HSI:
+          clkSrcFreq = HSI_VALUE;
+          break;
 #ifdef RCC_I2C2CLKSOURCE_SYSCLK
-      case RCC_I2C2CLKSOURCE_SYSCLK:
-        clkSrcFreq = SystemCoreClock;
-        break;
+        case RCC_I2C2CLKSOURCE_SYSCLK:
+          clkSrcFreq = SystemCoreClock;
+          break;
 #endif
 #if defined(RCC_I2C2CLKSOURCE_PCLK1) || defined(RCC_I2C2CLKSOURCE_D2PCLK1)
 #ifdef RCC_I2C2CLKSOURCE_PCLK1
-      case RCC_I2C2CLKSOURCE_PCLK1:
+        case RCC_I2C2CLKSOURCE_PCLK1:
 #endif
 #ifdef RCC_I2C2CLKSOURCE_D2PCLK1
-      case RCC_I2C2CLKSOURCE_D2PCLK1:
+        case RCC_I2C2CLKSOURCE_D2PCLK1:
 #endif
-        clkSrcFreq = HAL_RCC_GetPCLK1Freq();
-        break;
+          clkSrcFreq = HAL_RCC_GetPCLK1Freq();
+          break;
 #endif
 #ifdef RCC_I2C2CLKSOURCE_CSI
-      case RCC_I2C2CLKSOURCE_CSI:
-        clkSrcFreq = CSI_VALUE;
-        break;
+        case RCC_I2C2CLKSOURCE_CSI:
+          clkSrcFreq = CSI_VALUE;
+          break;
 #endif
 #ifdef RCC_I2C2CLKSOURCE_PLL3
-      case RCC_I2C2CLKSOURCE_PLL3:
-        HAL_RCCEx_GetPLL3ClockFreq(&PLL3_Clocks);
-        clkSrcFreq = PLL3_Clocks.PLL3_R_Frequency;
-        break;
+        case RCC_I2C2CLKSOURCE_PLL3:
+          HAL_RCCEx_GetPLL3ClockFreq(&PLL3_Clocks);
+          clkSrcFreq = PLL3_Clocks.PLL3_R_Frequency;
+          break;
 #endif
-      default:
-        Error_Handler();
-    }
+        default:
+          Error_Handler();
+      }
 #else
-    /* STM32 L0/G0 I2C2 has no independent clock */
-    clkSrcFreq = HAL_RCC_GetPCLK1Freq();
+      /* STM32 L0/G0 I2C2 has no independent clock */
+      clkSrcFreq = HAL_RCC_GetPCLK1Freq();
 #endif
+    }
   }
 #endif // I2C2_BASE
-#if defined I2C3_BASE
+#if defined(I2C3_BASE)
   if (i2c == I2C3) {
+#if defined(RCC_PERIPHCLK_I2C3) || defined(RCC_PERIPHCLK_I2C35)
+#ifdef RCC_PERIPHCLK_I2C3
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C3);
+#else
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C35);
+#endif
+    if (clkSrcFreq == 0)
+#endif
+    {
 #if defined(__HAL_RCC_GET_I2C3_SOURCE)
-    switch (__HAL_RCC_GET_I2C3_SOURCE()) {
-      case RCC_I2C3CLKSOURCE_HSI:
-        clkSrcFreq = HSI_VALUE;
-        break;
+      switch (__HAL_RCC_GET_I2C3_SOURCE()) {
+        case RCC_I2C3CLKSOURCE_HSI:
+          clkSrcFreq = HSI_VALUE;
+          break;
 #ifdef RCC_I2C3CLKSOURCE_SYSCLK
-      case RCC_I2C3CLKSOURCE_SYSCLK:
-        clkSrcFreq = SystemCoreClock;
-        break;
+        case RCC_I2C3CLKSOURCE_SYSCLK:
+          clkSrcFreq = SystemCoreClock;
+          break;
 #endif
 #if defined(RCC_I2C3CLKSOURCE_PCLK1) || defined(RCC_I2C3CLKSOURCE_D2PCLK1)
 #ifdef RCC_I2C3CLKSOURCE_PCLK1
-      case RCC_I2C3CLKSOURCE_PCLK1:
+        case RCC_I2C3CLKSOURCE_PCLK1:
 #endif
 #ifdef RCC_I2C3CLKSOURCE_D2PCLK1
-      case RCC_I2C3CLKSOURCE_D2PCLK1:
+        case RCC_I2C3CLKSOURCE_D2PCLK1:
 #endif
-        clkSrcFreq = HAL_RCC_GetPCLK1Freq();
-        break;
+          clkSrcFreq = HAL_RCC_GetPCLK1Freq();
+          break;
 #endif
 #ifdef RCC_I2C3CLKSOURCE_CSI
-      case RCC_I2C3CLKSOURCE_CSI:
-        clkSrcFreq = CSI_VALUE;
-        break;
+        case RCC_I2C3CLKSOURCE_CSI:
+          clkSrcFreq = CSI_VALUE;
+          break;
 #endif
 #ifdef RCC_I2C3CLKSOURCE_PLL3
-      case RCC_I2C3CLKSOURCE_PLL3:
-        HAL_RCCEx_GetPLL3ClockFreq(&PLL3_Clocks);
-        clkSrcFreq = PLL3_Clocks.PLL3_R_Frequency;
-        break;
+        case RCC_I2C3CLKSOURCE_PLL3:
+          HAL_RCCEx_GetPLL3ClockFreq(&PLL3_Clocks);
+          clkSrcFreq = PLL3_Clocks.PLL3_R_Frequency;
+          break;
 #endif
-      default:
-        Error_Handler();
-    }
+        default:
+          Error_Handler();
+      }
 #else
-    /* STM32 G0 I2C3 has no independent clock */
-    clkSrcFreq = HAL_RCC_GetPCLK1Freq();
+      /* STM32 G0 I2C3 has no independent clock */
+      clkSrcFreq = HAL_RCC_GetPCLK1Freq();
 #endif
+    }
   }
 #endif // I2C3_BASE
-#if defined I2C4_BASE
+#if defined(I2C4_BASE)
   if (i2c == I2C4) {
-    switch (__HAL_RCC_GET_I2C4_SOURCE()) {
-      case RCC_I2C4CLKSOURCE_HSI:
-        clkSrcFreq = HSI_VALUE;
-        break;
+#if defined(RCC_PERIPHCLK_I2C4) || defined(RCC_PERIPHCLK_I2C46)
+#ifdef RCC_PERIPHCLK_I2C4
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C4);
+#else
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C46);
+#endif
+    if (clkSrcFreq == 0)
+#endif
+    {
+#if defined(__HAL_RCC_GET_I2C4_SOURCE)
+      switch (__HAL_RCC_GET_I2C4_SOURCE()) {
+#ifdef RCC_I2C4CLKSOURCE_HSI
+        case RCC_I2C4CLKSOURCE_HSI:
+          clkSrcFreq = HSI_VALUE;
+          break;
+#endif
 #ifdef RCC_I2C4CLKSOURCE_SYSCLK
-      case RCC_I2C4CLKSOURCE_SYSCLK:
-        clkSrcFreq = SystemCoreClock;
-        break;
+        case RCC_I2C4CLKSOURCE_SYSCLK:
+          clkSrcFreq = SystemCoreClock;
+          break;
 #endif
 #ifdef RCC_I2C4CLKSOURCE_PCLK1
-      case RCC_I2C4CLKSOURCE_PCLK1:
-        clkSrcFreq = HAL_RCC_GetPCLK1Freq();
-        break;
+        case RCC_I2C4CLKSOURCE_PCLK1:
+          clkSrcFreq = HAL_RCC_GetPCLK1Freq();
+          break;
 #endif
 #ifdef RCC_I2C4CLKSOURCE_D3PCLK1
-      case RCC_I2C4CLKSOURCE_D3PCLK1:
-        clkSrcFreq = HAL_RCCEx_GetD3PCLK1Freq();
-        break;
+        case RCC_I2C4CLKSOURCE_D3PCLK1:
+          clkSrcFreq = HAL_RCCEx_GetD3PCLK1Freq();
+          break;
 #endif
 #ifdef RCC_I2C4CLKSOURCE_CSI
-      case RCC_I2C4CLKSOURCE_CSI:
-        clkSrcFreq = CSI_VALUE;
-        break;
+        case RCC_I2C4CLKSOURCE_CSI:
+          clkSrcFreq = CSI_VALUE;
+          break;
 #endif
 #ifdef RCC_I2C4CLKSOURCE_PLL3
-      case RCC_I2C4CLKSOURCE_PLL3:
-        HAL_RCCEx_GetPLL3ClockFreq(&PLL3_Clocks);
-        clkSrcFreq = PLL3_Clocks.PLL3_R_Frequency;
-        break;
+        case RCC_I2C4CLKSOURCE_PLL3:
+          HAL_RCCEx_GetPLL3ClockFreq(&PLL3_Clocks);
+          clkSrcFreq = PLL3_Clocks.PLL3_R_Frequency;
+          break;
 #endif
-      default:
-        Error_Handler();
+        default:
+          Error_Handler();
+      }
+#else
+      Error_Handler();
+#endif
     }
   }
 #endif // I2C4_BASE
-
-#elif defined(STM32MP1xx)
-  if (i2c == I2C1) {
-    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C12);
-  }
-  if (i2c == I2C2) {
-    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C12);
-  }
-  if (i2c == I2C3) {
-    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C35);
-  }
-  if (i2c == I2C4) {
-    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C46);
-  }
-#endif // STM32MP1xx
-
-#if defined I2C5_BASE
+#if defined(I2C5_BASE)
   if (i2c == I2C5) {
+#if defined(RCC_PERIPHCLK_I2C5) || defined(RCC_PERIPHCLK_I2C35)
+#ifdef RCC_PERIPHCLK_I2C5
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C5);
+#else
     clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C35);
+#endif
+    if (clkSrcFreq == 0)
+#endif
+    {
+      clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C35);
+    }
   }
 #endif // I2C5_BASE
-#if defined I2C6_BASE
+#if defined(I2C6_BASE)
   if (i2c == I2C6) {
+#if defined(RCC_PERIPHCLK_I2C6) || defined(RCC_PERIPHCLK_I2C46)
+#ifdef RCC_PERIPHCLK_I2C6
+    clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C6);
+#else
     clkSrcFreq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C46);
+#endif
+#endif
   }
 #endif // I2C6_BASE
   return clkSrcFreq;


### PR DESCRIPTION
Some series provides the `HAL_RCCEx_GetPeriphCLKFreq()` which returns the peripheral clock frequency based on Peripheral clock identifier.

