### PR TITLE
chore: update SPI pins for Swan_R5

### DIFF
--- a/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/variant_SWAN_R5.h
+++ b/variants/STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY/variant_SWAN_R5.h
@@ -181,9 +181,23 @@
   #define USER_BTN              PC13
 #endif
 
-// On-board user button
+// Power switch EN pin
 #ifndef ENABLE_3V3
-  #define ENABLE_3V3          PE4
+  #define ENABLE_3V3            PE4
+#endif
+
+// SPI definitions
+#ifndef PIN_SPI_SS
+  #define PIN_SPI_SS            PD0
+#endif
+#ifndef PIN_SPI_MOSI
+  #define PIN_SPI_MOSI          PB15
+#endif
+#ifndef PIN_SPI_MISO
+  #define PIN_SPI_MISO          PB14
+#endif
+#ifndef PIN_SPI_SCK
+  #define PIN_SPI_SCK           PD1
 #endif
 
 // I2C definitions


### PR DESCRIPTION
**Summary**

update SPI pins (MOSI, MISO, SCK, SS) for Swan_R5

This PR fixes/implements the following **bugs/features**

[Bug] SPI does not trigger the appropriate pins.

I work at Blues Wireless. During preparation and testing of the Swan, I discovered the SPI pins were not functional through the Feather pinouts.

**Validation**

* I have used the code to drive an MCP23S17 from the Swan.

**Code formatting**

It's all in the preprocessor, and it was copied from the existing pattern.

**Closing issues**