### PR TITLE
feat: `BUTTON_BUILTIN` alias for `USER_BTN`

### DIFF
--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -40,6 +40,11 @@ _Static_assert(LastPort <= 0x0F, "PortName must be less than 16");
 _Static_assert(NUM_ANALOG_INPUTS <= MAX_ANALOG_INPUTS,
                "Core NUM_ANALOG_INPUTS limited to MAX_ANALOG_INPUTS");
 
+/* Alias USER_BTN when available */
+#if defined(USER_BTN) && !defined(BUTTON_BUILTIN)
+  #define BUTTON_BUILTIN            USER_BTN
+#endif
+
 /* Default for Arduino connector compatibility */
 /* SPI Definitions */
 #ifndef PIN_SPI_SS


### PR DESCRIPTION
Create an alias for those new to STM32duino environment.

`USER_BTN` is commonplace in STM32duino, however there are several instances of `BUTTON_BUILTIN` across other Arduino BSPs. The naming convention of `BUTTON_BUILTIN` is more closely aligned to `LED_BUILTIN`, and there appears to be some precedent.

Examples:
- https://github.com/espressif/arduino-esp32/blob/master/variants/micro_s2/pins_arduino.h#L75
- https://github.com/esp8266/Arduino/blob/master/variants/espectro/pins_arduino.h#L40
- https://github.com/f32c/arduino/blob/master/hardware/fpga/f32c/variants/FleaFPGA-Uno/variant.h#L17
_... as well as several other examples that can be discovered by Googling, `"BUTTON_BUILTIN" arduino`._

Since ST is the clear leader in boards having a built-in button, it has a unique opportunity to help reinforce the semi-standardized precedent `BUTTON_BUILTIN` by providing an alias for all boards that support a `USER_BTN`.