### PR TITLE
spi: Add delay before disabling SPI to avoid truncated clock/data signals

### DIFF
--- a/libraries/SPI/src/utility/spi_com.h
+++ b/libraries/SPI/src/utility/spi_com.h
@@ -56,6 +56,11 @@ struct spi_s {
   PinName pin_mosi;
   PinName pin_sclk;
   PinName pin_ssel;
+#if defined(STM32H7xx) || defined(STM32MP1xx)
+  // Delay before disabling SPI.
+  // See https://github.com/stm32duino/Arduino_Core_STM32/issues/1294
+  uint32_t disable_delay;
+#endif
 };
 
 typedef struct spi_s spi_t;


### PR DESCRIPTION
**Summary**
spi: Add delay before disabling SPI to avoid truncated clock/data signals

Add a delay before disabling SPI otherwise last-bit/last-clock
may be truncated.
See https://github.com/stm32duino/Arduino_Core_STM32/issues/1294
Computed delay is half SPI clock.

Fixes #1294
