### PR TITLE
Move Swan board to dedicated menu and add a workaround for SWD upload method

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
  - [Generic STM32WB boards](#generic-stm32wb-boards)
  - [Generic STM32WL boards](#generic-stm32wb-boards)
  - [3D printer boards](#3d-printer-boards)
+ - [Blues Wireless boards](#blues-wireless-boards)
  - [Elecgator boards](#elecgator-boards)
  - [Electronic Speed Controller boards](#electronic-speed-controller-boards)
  - [Garatronics boards](#Garatronic/McHobby-boards)
@@ -407,7 +408,6 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart:  | STM32L4S7ZITx | Generic Board | *2.0.0* |  |
 | :green_heart:  | STM32L4S9ZIJx | Generic Board | *2.0.0* |  |
 | :yellow_heart:  | STM32L4S9ZIYx | Generic Board | **2.1.0** |  |
-| :yellow_heart:  | STM32L4R5ZIYx | Swan R5 | **2.1.0** | [Blues Wireless](https://blues.io/) |
 
 ### Generic STM32L5 boards
 
@@ -460,14 +460,11 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart:  | STM32F446RE | [VAkE v1.0](https://www.facebook.com/pages/category/Product-Service/VAkE-Board-2290066274575218/) | *1.6.0* |  |
 | :green_heart:  | STM32F446VE | [FYSETC_S6](https://wiki.fysetc.com/FYSETC_S6/) | *1.9.0* | |
 
-### [Garatronic](https://www.garatronic.fr)/[McHobby](https://shop.mchobby.be) boards
+### [Blues Wireless](https://blues.io/) boards
 
 | Status | Device(s) | Name | Release | Notes |
 | :----: | :-------: | ---- | :-----: | :---- |
-| :green_heart:  | STM32F072RB | [PYBStick 26 Duino](https://shop.mchobby.be/fr/compatibles-arduino/1851-pybstick-duino-arduino-uniquement-3232100018518-garatronic.html) | *1.9.0* | [More info](https://github.com/mchobby/pyboard-driver/tree/master/PYBStick) |
-| :green_heart:  | STM32F401CE | [PYBStick 26 Lite](https://shop.mchobby.be/fr/micropython/1830-pybstick-lite-26-micropython-et-arduino-3232100018303-garatronic.html) | *1.9.0* | [More info](https://github.com/mchobby/pyboard-driver/tree/master/PYBStick) |
-| :green_heart:  | STM32F411RE | [PYBStick 26 Standard](https://shop.mchobby.be/fr/micropython/1844-pybstick-standard-26-micropython-et-arduino-3232100018440-garatronic.html) | *1.9.0* | [More info](https://github.com/mchobby/pyboard-driver/tree/master/PYBStick) |
-| :green_heart:  | STM32F412RE | [PYBStick 26 Pro](https://shop.mchobby.be/fr/micropython/1850-pybstick-pro-26-micropython-et-arduino-3232100018501-garatronic.html) | *1.9.0* | [More info](https://github.com/mchobby/pyboard-driver/tree/master/PYBStick) |
+| :yellow_heart:  | STM32L4R5ZIYx | Swan R5 | **2.1.0** |  |
 
 ### [Elecgator](https://www.elecgator.com/) boards
 
@@ -481,6 +478,15 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :----: | :-------: | ---- | :-----: | :---- |
 | :green_heart:  | STM32F051K6U | [Wraith V1 ESC](https://www.readytoflyquads.com/35a-wraith32-v11-32bit-blheli-esc) | *1.8.0* |  |
 | :yellow_heart:  | STM32F103RCT | [STorM32 V1.31 RC](http://www.olliw.eu/storm32bgc-wiki/STorM32_Boards#STorM32-BGC_v1.3) | **2.1.0** |  |
+
+### [Garatronic](https://www.garatronic.fr)/[McHobby](https://shop.mchobby.be) boards
+
+| Status | Device(s) | Name | Release | Notes |
+| :----: | :-------: | ---- | :-----: | :---- |
+| :green_heart:  | STM32F072RB | [PYBStick 26 Duino](https://shop.mchobby.be/fr/compatibles-arduino/1851-pybstick-duino-arduino-uniquement-3232100018518-garatronic.html) | *1.9.0* | [More info](https://github.com/mchobby/pyboard-driver/tree/master/PYBStick) |
+| :green_heart:  | STM32F401CE | [PYBStick 26 Lite](https://shop.mchobby.be/fr/micropython/1830-pybstick-lite-26-micropython-et-arduino-3232100018303-garatronic.html) | *1.9.0* | [More info](https://github.com/mchobby/pyboard-driver/tree/master/PYBStick) |
+| :green_heart:  | STM32F411RE | [PYBStick 26 Standard](https://shop.mchobby.be/fr/micropython/1844-pybstick-standard-26-micropython-et-arduino-3232100018440-garatronic.html) | *1.9.0* | [More info](https://github.com/mchobby/pyboard-driver/tree/master/PYBStick) |
+| :green_heart:  | STM32F412RE | [PYBStick 26 Pro](https://shop.mchobby.be/fr/micropython/1850-pybstick-pro-26-micropython-et-arduino-3232100018501-garatronic.html) | *1.9.0* | [More info](https://github.com/mchobby/pyboard-driver/tree/master/PYBStick) |
 
 ### Generic flight controllers
 

--- a/boards.txt
+++ b/boards.txt
@@ -4563,16 +4563,6 @@ GenL4.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 GenL4.build.series=STM32L4xx
 GenL4.build.cmsis_lib_gcc=arm_cortexM4lf_math
 
-# Swan R5
-GenL4.menu.pnum.SWAN_R5=Swan R5
-GenL4.menu.pnum.SWAN_R5.upload.maximum_size=2097152
-GenL4.menu.pnum.SWAN_R5.upload.maximum_data_size=655360
-GenL4.menu.pnum.SWAN_R5.build.board=SWAN_R5
-GenL4.menu.pnum.SWAN_R5.build.product_line=STM32L4R5xx
-GenL4.menu.pnum.SWAN_R5.build.variant=STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY
-GenL4.menu.pnum.SWAN_R5.build.variant_h=variant_{build.board}.h
-GenL4.menu.pnum.SWAN_R5.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-
 # Generic L412K8Tx
 GenL4.menu.pnum.GENERIC_L412K8TX=Generic L412K8Tx
 GenL4.menu.pnum.GENERIC_L412K8TX.upload.maximum_size=65536
@@ -5680,6 +5670,45 @@ GenWL.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 
 ################################################################################
+# Blues Wireless boards
+
+BluesW.name= Blues Wireless boards
+
+BluesW.build.core=arduino
+BluesW.build.board=BluesWireless
+BluesW.build.variant_h=variant_{build.board}.h
+BluesW.build.extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+
+# Swan R5 board
+BluesW.menu.pnum.SWAN_R5=Swan R5
+BluesW.menu.pnum.SWAN_R5.upload.maximum_size=2097152
+BluesW.menu.pnum.SWAN_R5.upload.maximum_data_size=655360
+BluesW.menu.pnum.SWAN_R5.build.mcu=cortex-m4
+BluesW.menu.pnum.SWAN_R5.build.cmsis_lib_gcc=arm_cortexM4lf_math
+BluesW.menu.pnum.SWAN_R5.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
+BluesW.menu.pnum.SWAN_R5.build.board=SWAN_R5
+BluesW.menu.pnum.SWAN_R5.build.series=STM32L4xx
+BluesW.menu.pnum.SWAN_R5.build.product_line=STM32L4R5xx
+BluesW.menu.pnum.SWAN_R5.build.variant=STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY
+BluesW.menu.pnum.SWAN_R5.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+
+# Upload menu
+BluesW.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
+BluesW.menu.upload_method.swdMethod.upload.protocol=0
+BluesW.menu.upload_method.swdMethod.upload.options=-g
+BluesW.menu.upload_method.swdMethod.upload.tool=stm32CubeProg
+
+BluesW.menu.upload_method.serialMethod=STM32CubeProgrammer (Serial)
+BluesW.menu.upload_method.serialMethod.upload.protocol=1
+BluesW.menu.upload_method.serialMethod.upload.options={serial.port.file} -s
+BluesW.menu.upload_method.serialMethod.upload.tool=stm32CubeProg
+
+BluesW.menu.upload_method.dfuMethod=STM32CubeProgrammer (DFU)
+BluesW.menu.upload_method.dfuMethod.upload.protocol=2
+BluesW.menu.upload_method.dfuMethod.upload.options=-g
+BluesW.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
+
+################################################################################
 # Elecgator boards
 
 Elecgator.name=Elecgator boards
@@ -6199,6 +6228,12 @@ GenWL.menu.xserial.disabled.build.xSerial=
 3dprinter.menu.xserial.disabled=Disabled (no Serial support)
 3dprinter.menu.xserial.disabled.build.xSerial=
 
+BluesW.menu.xserial.generic=Enabled (generic 'Serial')
+BluesW.menu.xserial.none=Enabled (no generic 'Serial')
+BluesW.menu.xserial.none.build.xSerial=-DHAL_UART_MODULE_ENABLED -DHWSERIAL_NONE
+BluesW.menu.xserial.disabled=Disabled (no Serial support)
+BluesW.menu.xserial.disabled.build.xSerial=
+
 Elecgator.menu.xserial.generic=Enabled (generic 'Serial')
 Elecgator.menu.xserial.none=Enabled (no generic 'Serial')
 Elecgator.menu.xserial.none.build.xSerial=-DHAL_UART_MODULE_ENABLED -DHWSERIAL_NONE
@@ -6484,6 +6519,19 @@ GenWB.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 3dprinter.menu.xusb.HS.build.usb_speed=-DUSE_USB_HS
 3dprinter.menu.xusb.HSFS=High Speed in Full Speed mode
 3dprinter.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
+
+BluesW.menu.usb.none=None
+BluesW.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
+BluesW.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
+BluesW.menu.usb.CDC=CDC (no generic 'Serial')
+BluesW.menu.usb.CDC.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC -DDISABLE_GENERIC_SERIALUSB
+BluesW.menu.usb.HID=HID (keyboard and mouse)
+BluesW.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
+BluesW.menu.xusb.FS=Low/Full Speed
+BluesW.menu.xusb.HS=High Speed
+BluesW.menu.xusb.HS.build.usb_speed=-DUSE_USB_HS
+BluesW.menu.xusb.HSFS=High Speed in Full Speed mode
+BluesW.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 
 Elecgator.menu.usb.none=None
 Elecgator.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
@@ -6959,6 +7007,24 @@ GenWL.menu.opt.ogstd.build.flags.optimize=-Og
 3dprinter.menu.opt.ogstd=Debug (-Og)
 3dprinter.menu.opt.ogstd.build.flags.optimize=-Og
 
+BluesW.menu.opt.osstd=Smallest (-Os default)
+BluesW.menu.opt.oslto=Smallest (-Os) with LTO
+BluesW.menu.opt.oslto.build.flags.optimize=-Os -flto
+BluesW.menu.opt.o1std=Fast (-O1)
+BluesW.menu.opt.o1std.build.flags.optimize=-O1
+BluesW.menu.opt.o1lto=Fast (-O1) with LTO
+BluesW.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+BluesW.menu.opt.o2std=Faster (-O2)
+BluesW.menu.opt.o2std.build.flags.optimize=-O2
+BluesW.menu.opt.o2lto=Faster (-O2) with LTO
+BluesW.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+BluesW.menu.opt.o3std=Fastest (-O3)
+BluesW.menu.opt.o3std.build.flags.optimize=-O3
+BluesW.menu.opt.o3lto=Fastest (-O3) with LTO
+BluesW.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+BluesW.menu.opt.ogstd=Debug (-Og)
+BluesW.menu.opt.ogstd.build.flags.optimize=-Og
+
 Elecgator.menu.opt.osstd=Smallest (-Os default)
 Elecgator.menu.opt.oslto=Smallest (-Os) with LTO
 Elecgator.menu.opt.oslto.build.flags.optimize=-Os -flto
@@ -7155,6 +7221,10 @@ GenWL.menu.dbg.enable.build.flags.debug=-g
 3dprinter.menu.dbg.none=None
 3dprinter.menu.dbg.enable=Enabled (-g)
 3dprinter.menu.dbg.enable.build.flags.debug=-g
+
+BluesW.menu.dbg.none=None
+BluesW.menu.dbg.enable=Enabled (-g)
+BluesW.menu.dbg.enable.build.flags.debug=-g
 
 Elecgator.menu.dbg.none=None
 Elecgator.menu.dbg.enable=Enabled (-g)
@@ -7410,6 +7480,16 @@ GenWL.menu.rtlib.full.build.flags.ldspecs=
 3dprinter.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 3dprinter.menu.rtlib.full=Newlib Standard
 3dprinter.menu.rtlib.full.build.flags.ldspecs=
+
+BluesW.menu.rtlib.nano=Newlib Nano (default)
+BluesW.menu.rtlib.nanofp=Newlib Nano + Float Printf
+BluesW.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+BluesW.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+BluesW.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+BluesW.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+BluesW.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+BluesW.menu.rtlib.full=Newlib Standard
+BluesW.menu.rtlib.full.build.flags.ldspecs=
 
 Elecgator.menu.rtlib.nano=Newlib Nano (default)
 Elecgator.menu.rtlib.nanofp=Newlib Nano + Float Printf

--- a/boards.txt
+++ b/boards.txt
@@ -5695,7 +5695,7 @@ BluesW.menu.pnum.SWAN_R5.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 # Upload menu
 BluesW.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
 BluesW.menu.upload_method.swdMethod.upload.protocol=0
-BluesW.menu.upload_method.swdMethod.upload.options=-g
+BluesW.menu.upload_method.swdMethod.upload.options=-g -ob nBOOT0=0 -ob nBOOT0=1
 BluesW.menu.upload_method.swdMethod.upload.tool=stm32CubeProg
 
 BluesW.menu.upload_method.serialMethod=STM32CubeProgrammer (Serial)


### PR DESCRIPTION
This PR is a workaround to allow flashing the Swan board at once. An issue is under investigations by ST BL team.
While waiting to have their return adding `-ob nBOOT0=0 -ob nBOOT0=1` to the upload options allows to properly flash and run the application.

Fixes #1495

During the test I found an issue with the STM32cubeProgrammer script due to the use of '=' in option.
I've push a fix in the [stm32duino/Arduino_Tools](https://github.com/stm32duino/Arduino_Tools) repo: https://github.com/stm32duino/Arduino_Tools/commit/1bce38f76f453adcc90ee4c21b51d498b22c3756
It will be available with the 2.1.0 version.

/CC @zfields @bsatrom 

