### PR TITLE
Daisy Seed 1.1 variant compatibility

### DIFF
--- a/variants/STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)/variant_DAISY_SEED.cpp
+++ b/variants/STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)/variant_DAISY_SEED.cpp
@@ -57,7 +57,8 @@ const PinName digitalPin[] = {
   // NC, 3v3D Out
   // NC, VIN
   // NC, DGND
-  PC_7   // LED_BUILTIN
+  PC_7,   // LED_BUILTIN
+  PD_3 // Version 1.1
 };
 
 const uint32_t analogInputPin[] = {

--- a/variants/STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)/variant_DAISY_SEED.h
+++ b/variants/STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)/variant_DAISY_SEED.h
@@ -47,6 +47,7 @@
 #define PB14                    29
 #define PB15                    30
 #define PC7                     31 // LED_BUILTIN
+#define PD3                     32
 
 // Alternate pins number
 #define PA0_ALT1                (PA0  | ALT1)
@@ -92,7 +93,7 @@
 #define PC10_ALT1               (PC10 | ALT1)
 #define PC11_ALT1               (PC11 | ALT1)
 
-#define NUM_DIGITAL_PINS        32
+#define NUM_DIGITAL_PINS        33
 #define NUM_ANALOG_INPUTS       12
 
 // On-board LED pin number


### PR DESCRIPTION
The Daisy Seed V1.1 uses PD3 as a version check pin. We'll need to add that pin to the Daisy Seed variant to allow for that check to occur.