### PR TITLE
HardwareTimer: Add API to check whether timer/channels are running

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -1159,6 +1159,42 @@ void HardwareTimer::captureCompareCallback(TIM_HandleTypeDef *htim)
 }
 
 /**
+  * @brief  Check whether HardwareTimer is running (paused or resumed).
+  * @retval return true if the HardwareTimer is running
+  */
+bool HardwareTimer::isRunning()
+{
+  return LL_TIM_IsEnabledCounter(_timerObj.handle.Instance);
+}
+
+/**
+  * @brief  Check whether channel is running (paused or resumed).
+  * @param  channel: Arduino channel [1..4]
+  * @retval return true if HardwareTimer is running and the channel is enabled
+  */
+bool HardwareTimer::isRunningChannel(uint32_t channel)
+{
+  int timAssociatedInputChannel;
+  int LLChannel = getLLChannel(channel);
+  int interrupt = getIT(channel);
+  bool ret;
+
+  if (LLChannel == -1) {
+    Error_Handler();
+  }
+
+  if (interrupt == -1) {
+    Error_Handler();
+  }
+
+  // channel is runnning if: timer is running, and either output channel is
+  // enabled or interrupt is set
+  ret = LL_TIM_CC_IsEnabledChannel(_timerObj.handle.Instance, LLChannel)
+        || (__HAL_TIM_GET_IT_SOURCE(&(_timerObj.handle), interrupt) == SET);
+  return (isRunning() && ret);
+}
+
+/**
   * @brief  HardwareTimer destructor
   * @retval None
   */

--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -148,8 +148,11 @@ class HardwareTimer {
 
     uint32_t getTimerClkFreq();  // return timer clock frequency in Hz.
 
-    static void captureCompareCallback(TIM_HandleTypeDef *htim); // Generic Caputre and Compare callback which will call user callback
+    static void captureCompareCallback(TIM_HandleTypeDef *htim); // Generic Capture and Compare callback which will call user callback
     static void updateCallback(TIM_HandleTypeDef *htim);  // Generic Update (rollover) callback which will call user callback
+
+    bool isRunning(); // return true if HardwareTimer is running
+    bool isRunningChannel(uint32_t channel); // return true if channel is running
 
     // The following function(s) are available for more advanced timer options
     TIM_HandleTypeDef *getHandle();  // return the handle address for HAL related configuration


### PR DESCRIPTION
**Summary**
HardwareTimer: Add API to check whether timer/channels are running

* bool isRunning(); //returns true if HardwareTimer is running
* bool isRunningChannel(channel); //returns true if channel is running

Fixes #1525