### PR TITLE
Fix typos in variants/ subdirectory 

### DIFF
--- a/variants/STM32F0xx/F070CBT/MALYANMx00_F070CB.ld
+++ b/variants/STM32F0xx/F070CBT/MALYANMx00_F070CB.ld
@@ -106,7 +106,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/variants/STM32F0xx/F070CBT/startup_Mx00_f070xb.S
+++ b/variants/STM32F0xx/F070CBT/startup_Mx00_f070xb.S
@@ -100,7 +100,7 @@ LoopFillZerobss:
   cmp r2, r4
   bcc FillZerobss
 
-/* Call the clock system intitialization function.*/
+/* Call the clock system initialization function.*/
   bl  SystemInit
 
   cpsie i

--- a/variants/STM32F1xx/F103C4T_F103C6(T-U)/variant_BLUEPILL_F103C6.h
+++ b/variants/STM32F1xx/F103C4T_F103C6(T-U)/variant_BLUEPILL_F103C6.h
@@ -15,7 +15,7 @@
 /*----------------------------------------------------------------------------
  *        STM32 pins number
  *----------------------------------------------------------------------------*/
-// Bluepill USB connector on the top, MCU side (pins are reversed vertically for Arduino Ananlog pin correct sequence).
+// Bluepill USB connector on the top, MCU side (pins are reversed vertically for Arduino Analog pin correct sequence).
 // Left Side
 #define PB9                     0
 #define PB8                     1

--- a/variants/STM32F1xx/F103C8T_F103CB(T-U)/startup_M200_f103xb.S
+++ b/variants/STM32F1xx/F103C8T_F103CB(T-U)/startup_M200_f103xb.S
@@ -114,7 +114,7 @@ LoopFillZerobss:
   cmp r2, r3
   bcc FillZerobss
 
-/* Call the clock system intitialization function.*/
+/* Call the clock system initialization function.*/
     bl  SystemInit
 
 /* Re-enable handlers */

--- a/variants/STM32F1xx/F103C8T_F103CB(T-U)/variant_AFROFLIGHT_F103CB_XX.h
+++ b/variants/STM32F1xx/F103C8T_F103CB(T-U)/variant_AFROFLIGHT_F103CB_XX.h
@@ -162,7 +162,7 @@
  * TELEM_OUT                      PA13 // Warning, SWD access is lost when using this pin, bootloader via uart is required after
  *
  * BAT_ADC                        PA4 // Connected to 6 pin header Battery voltage in via resistor divider
- * ACC_INT                        PA5 // Connected to Intterupt pin of MMA84520 accelerometer I2C
+ * ACC_INT                        PA5 // Connected to Interrupt pin of MMA84520 accelerometer I2C
  *
  * MAG_DRD                        PB12 //Connected to HMC5883L compass I2C
  * BEEP                           PA12 //Connected to Beep out transistor on 6 pin header

--- a/variants/STM32F1xx/F103C8T_F103CB(T-U)/variant_MALYANM200_F103CB.h
+++ b/variants/STM32F1xx/F103C8T_F103CB(T-U)/variant_MALYANM200_F103CB.h
@@ -169,7 +169,7 @@
   #define RCC_PRIORITY            STM32_INT_PRIORITY
 #endif
 #ifndef EXTI_PRIORITY             /*f1 6~10,23,40*/
-  #define EXTI_PRIORITY           MAX_PRIORITY+1  //f1 6~9 botton  use 0x0f
+  #define EXTI_PRIORITY           MAX_PRIORITY+1  //f1 6~9 button use 0x0f
 #endif
 #ifndef DMA1_PRIORITY             /*f1 11~17*/
   #define DMA1_PRIORITY           STM32_INT_PRIORITY

--- a/variants/STM32F1xx/F103C8T_F103CB(T-U)/variant_PILL_F103Cx.h
+++ b/variants/STM32F1xx/F103C8T_F103CB(T-U)/variant_PILL_F103Cx.h
@@ -16,7 +16,7 @@
  *        STM32 pins number
  *----------------------------------------------------------------------------*/
 
-// Bluepill USB connector on the top, MCU side - Blackpill USB connector on bottom, MCU Side  (pins are reversed vertically for Arduino Ananlog pin correct sequence.
+// Bluepill USB connector on the top, MCU side - Blackpill USB connector on bottom, MCU Side  (pins are reversed vertically for Arduino Analog pin correct sequence.
 // Left Side
 #define PB9                     0
 #define PB8                     1

--- a/variants/STM32F3xx/F303R(B-C)T/variant_OLIMEXINO_STM32F3.h
+++ b/variants/STM32F3xx/F303R(B-C)T/variant_OLIMEXINO_STM32F3.h
@@ -46,7 +46,7 @@
 // Button
 #define PC9                     22
 
-// GPIO extention
+// GPIO extension
 #define PC15                    23
 #define PB9                     24
 #define PD2                     25
@@ -116,7 +116,7 @@
 #define PC10_ALT1               (PC10 | ALT1)
 #define PC11_ALT1               (PC11 | ALT1)
 
-// Alias GPIO1 extention
+// Alias GPIO1 extension
 #define EXT_GPIO1               PC15
 #define EXT_GPIO2               PB9
 #define EXT_GPIO3               PD2

--- a/variants/STM32F4xx/F413Z(G-H)(J-T)_F423ZH(J-T)/variant_DISCO_F413ZH.cpp
+++ b/variants/STM32F4xx/F413Z(G-H)(J-T)_F423ZH(J-T)/variant_DISCO_F413ZH.cpp
@@ -162,7 +162,7 @@ extern "C" {
 
 WEAK void initVariant(void)
 {
-  /* In DISCO_F413ZH board, Arduino connector and Wifi embeded module are sharing the same SPI pins */
+  /* In DISCO_F413ZH board, Arduino connector and Wifi embedded module are sharing the same SPI pins */
   /* We need to set the default SPI SS pin for the Wifi module to the inactive state i.e. 1 */
   /* See board User Manual: WIFI_SPI_CS = PG_11*/
   __HAL_RCC_GPIOG_CLK_ENABLE();

--- a/variants/STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)/ldscript.ld
+++ b/variants/STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)/ldscript.ld
@@ -138,7 +138,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/variants/STM32L0xx/L072R(B-Z)T_L073R(B-Z)T_L083R(B-Z)T/variant_PX_HER0.h
+++ b/variants/STM32L0xx/L072R(B-Z)T_L073R(B-Z)T_L083R(B-Z)T/variant_PX_HER0.h
@@ -195,7 +195,7 @@
 #endif
 
 // Optional PIN_SERIALn_RX and PIN_SERIALn_TX where 'n' is the U(S)ART number
-// Used when user instanciate a hardware Serial using its peripheral name.
+// Used when user instantiate a hardware Serial using its peripheral name.
 // Example: HardwareSerial mySerial(USART3);
 // will use PIN_SERIAL3_RX and PIN_SERIAL3_TX if defined.
 #define ENABLE_HWSERIAL1

--- a/variants/STM32MP1xx/MP153AAC_MP153CAC_MP153DAC_MP153FAC_MP157AAC_MP157CAC_MP157DAC_MP157FAC/ldscript.ld
+++ b/variants/STM32MP1xx/MP153AAC_MP153CAC_MP153DAC_MP153FAC_MP157AAC_MP157CAC_MP157DAC_MP157FAC/ldscript.ld
@@ -159,7 +159,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/variants/STM32MP1xx/MP153AAC_MP153CAC_MP153DAC_MP153FAC_MP157AAC_MP157CAC_MP157DAC_MP157FAC/variant_STM32MP157_DK.cpp
+++ b/variants/STM32MP1xx/MP153AAC_MP153CAC_MP153DAC_MP153FAC_MP157AAC_MP157CAC_MP157DAC_MP157FAC/variant_STM32MP157_DK.cpp
@@ -116,7 +116,7 @@ void SystemClock_Config(void)
 {
   /**
    * NOTE: Because of the limitation of STM32MP1xx, unlike other MCUs this is
-   * NOT a WEAK function, preventing being overriden.
+   * NOT a WEAK function, preventing being overridden.
    * In STM32MP1 series, SystemClock_Config()) is "done" by running the FSBL
    * (First Stage Boot Loader) on Cortex-A. This function call shall NOT be
    * executed in production mode. SystemClock_Config() shall be under

--- a/variants/STM32WBxx/WB55C(C-E-G)U/ldscript.ld
+++ b/variants/STM32WBxx/WB55C(C-E-G)U/ldscript.ld
@@ -136,7 +136,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/variants/STM32WBxx/WB55R(C-E-G)V/ldscript.ld
+++ b/variants/STM32WBxx/WB55R(C-E-G)V/ldscript.ld
@@ -136,7 +136,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/variants/STM32WBxx/WB5MMGH/ldscript.ld
+++ b/variants/STM32WBxx/WB5MMGH/ldscript.ld
@@ -136,7 +136,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)


### PR DESCRIPTION
Found via `codespell -q 3 -L aes,busses,cas,dout,exten,hsi,nd,pres,serie,sinc,te,ue`

Related to #1551