### PR TITLE
fix variant WeActMiniH7xx, DevEBoxH7xx: ena peripheral pll clks

### DIFF
--- a/variants/STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)/variant_DevEBoxH7xx.cpp
+++ b/variants/STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)/variant_DevEBoxH7xx.cpp
@@ -235,29 +235,23 @@ WEAK void SystemClock_Config(void)
   // QSPI from PLL1 qclk
   PeriphClkInitStruct.QspiClockSelection = RCC_QSPICLKSOURCE_PLL;
   // SDMMC from PLL1 qclk
-  PeriphClkInitStruct.SdmmcClockSelection = 0;
-  //PeriphClkInitStruct.SdmmcClockSelection = RCC_SDMMCCLKSOURCE_PLL;
+  PeriphClkInitStruct.SdmmcClockSelection = RCC_SDMMCCLKSOURCE_PLL;
   // LPUART from PLL2 qclk
-  PeriphClkInitStruct.Lpuart1ClockSelection = 0;
-  //PeriphClkInitStruct.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_PLL2;
+  PeriphClkInitStruct.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_PLL2;
   // USART from PLL2 qclk
   PeriphClkInitStruct.Usart16ClockSelection = RCC_USART16CLKSOURCE_PLL2;
   // USART from PLL2 qclk
-  PeriphClkInitStruct.Usart234578ClockSelection = 0;
-  //PeriphClkInitStruct.Usart234578ClockSelection = RCC_USART234578CLKSOURCE_PLL2;
+  PeriphClkInitStruct.Usart234578ClockSelection = RCC_USART234578CLKSOURCE_PLL2;
   // I2C123 from PLL3 rclk
   PeriphClkInitStruct.I2c123ClockSelection = RCC_I2C123CLKSOURCE_PLL3;
   // I2C4 from PLL3 rclk
-  PeriphClkInitStruct.I2c4ClockSelection = 0;
-  //PeriphClkInitStruct.I2c4ClockSelection = RCC_I2C4CLKSOURCE_PLL3;
+  PeriphClkInitStruct.I2c4ClockSelection = RCC_I2C4CLKSOURCE_PLL3;
   // SPI123 from PLL2 pclk
   PeriphClkInitStruct.Spi123ClockSelection = RCC_SPI123CLKSOURCE_PLL2;
   // SPI45 from PLL2 qclk
-  PeriphClkInitStruct.Spi45ClockSelection = 0;
-  //PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_PLL2;
+  PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_PLL2;
   // SPI6 from PLL2 qclk
-  PeriphClkInitStruct.Spi6ClockSelection = 0;
-  //PeriphClkInitStruct.Spi6ClockSelection = RCC_SPI6CLKSOURCE_PLL2;
+  PeriphClkInitStruct.Spi6ClockSelection = RCC_SPI6CLKSOURCE_PLL2;
 
 
   if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {

--- a/variants/STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)/variant_WeActMiniH7xx.cpp
+++ b/variants/STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)/variant_WeActMiniH7xx.cpp
@@ -235,29 +235,23 @@ WEAK void SystemClock_Config(void)
   // QSPI from PLL1 qclk
   PeriphClkInitStruct.QspiClockSelection = RCC_QSPICLKSOURCE_PLL;
   // SDMMC from PLL1 qclk
-  PeriphClkInitStruct.SdmmcClockSelection = 0;
-  //PeriphClkInitStruct.SdmmcClockSelection = RCC_SDMMCCLKSOURCE_PLL;
+  PeriphClkInitStruct.SdmmcClockSelection = RCC_SDMMCCLKSOURCE_PLL;
   // LPUART from PLL2 qclk
-  PeriphClkInitStruct.Lpuart1ClockSelection = 0;
-  //PeriphClkInitStruct.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_PLL2;
+  PeriphClkInitStruct.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_PLL2;
   // USART from PLL2 qclk
   PeriphClkInitStruct.Usart16ClockSelection = RCC_USART16CLKSOURCE_PLL2;
   // USART from PLL2 qclk
-  PeriphClkInitStruct.Usart234578ClockSelection = 0;
-  //PeriphClkInitStruct.Usart234578ClockSelection = RCC_USART234578CLKSOURCE_PLL2;
+  PeriphClkInitStruct.Usart234578ClockSelection = RCC_USART234578CLKSOURCE_PLL2;
   // I2C123 from PLL3 rclk
   PeriphClkInitStruct.I2c123ClockSelection = RCC_I2C123CLKSOURCE_PLL3;
   // I2C4 from PLL3 rclk
-  PeriphClkInitStruct.I2c4ClockSelection = 0;
-  //PeriphClkInitStruct.I2c4ClockSelection = RCC_I2C4CLKSOURCE_PLL3;
+  PeriphClkInitStruct.I2c4ClockSelection = RCC_I2C4CLKSOURCE_PLL3;
   // SPI123 from PLL2 pclk
   PeriphClkInitStruct.Spi123ClockSelection = RCC_SPI123CLKSOURCE_PLL2;
   // SPI45 from PLL2 qclk
-  PeriphClkInitStruct.Spi45ClockSelection = 0;
-  //PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_PLL2;
+  PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_PLL2;
   // SPI6 from PLL2 qclk
-  PeriphClkInitStruct.Spi6ClockSelection = 0;
-  //PeriphClkInitStruct.Spi6ClockSelection = RCC_SPI6CLKSOURCE_PLL2;
+  PeriphClkInitStruct.Spi6ClockSelection = RCC_SPI6CLKSOURCE_PLL2;
 
 
   if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {


### PR DESCRIPTION
* fix variant WeActMiniH7xx: ena peripheral pll clks 

in previous commit  https://github.com/stm32duino/Arduino_Core_STM32/pull/1552 some clocks from PLL2, PLL3
are not distributed to some peripherals

originally to save some power. However, users using those
pheriperials may mistake that it is not working

this fix distributes the missed out PLL clocks to all pheripherals
those clocks are at 80 Mhz

* made the same fixes for DevEBoxH7xx

## Pull Request template

Please, Make sure that your PR is not a duplicate.
Search among the [Pull request](https://github.com/stm32duino/Arduino_Core_STM32/pulls) before creating one.

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

Thanks for submitting a pull request.
Please provide enough information so that others can review your pull request:

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Bug 1
distribute missed out PLL clocks to all peripherals (previously commented out)
* [ ] 

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

bug fix

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Validation**

* Ensure CI build is passed.
* Demonstrate the code is solid. [e.g. Provide a sketch]

updated files in installed core and re-ran previous test in original commit.
https://github.com/stm32duino/Arduino_Core_STM32/pull/1552
compile, Arduino IDE 1.8.16:
Sketch uses 56148 bytes (2%) of program storage space. Maximum is 2097152 bytes.
Global variables use 4112 bytes (0%) of dynamic memory, leaving 520176 bytes for local variables. Maximum is 524288 bytes.

sample results:
```
p - print/stop print
C - cpu full speed
c - cpu half speed
w - run whetstone
Vref int (1.21v):374
temp sensor:204
mvolt:660
temp:50.00
Beginning Whetstone benchmark at 480 MHz ...

Loops:10000, Iterations:1, Duration:1627.54 millisec
C Converted Single Precision Whetstones:614.42 Mflops
Vref int (1.21v):375
temp sensor:205
mvolt:661
temp:50.50
Vref int (1.21v):376
temp sensor:205
mvolt:659
temp:49.50
Beginning Whetstone benchmark at 480 MHz ...

Loops:10000, Iterations:1, Duration:1627.53 millisec
C Converted Single Precision Whetstones:614.43 Mflops
Vref int (1.21v):374
temp sensor:204
mvolt:660
```
led blinking per normal

<!-- Make sure tests pass on both CI. -->

**Code formatting**

* Ensure AStyle check is passed thanks CI

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #xxx
