### PR TITLE
gpio: Enable PWR CLK when enabling VddIO2 for GPIOG

### DIFF
--- a/libraries/SrcWrapper/src/stm32/PortNames.c
+++ b/libraries/SrcWrapper/src/stm32/PortNames.c
@@ -105,6 +105,7 @@ GPIO_TypeDef *set_GPIO_Port_Clock(uint32_t port_idx)
     case PortG:
 #if defined(PWR_CR2_IOSV) || defined(PWR_SVMCR_IO2VMEN)
       // Enable VDDIO2 supply for 14 I/Os (Port G[15:2])
+      __HAL_RCC_PWR_CLK_ENABLE();
       HAL_PWREx_EnableVddIO2();
 #endif
       gpioPort = (GPIO_TypeDef *)GPIOG_BASE;


### PR DESCRIPTION
**Summary**
gpio: Enable PWR CLK when enabling VddIO2 for GPIOG

