### PR TITLE
Interrupts: remove C prototype and keep only C++ prototypes

### DIFF
--- a/cores/arduino/WInterrupts.h
+++ b/cores/arduino/WInterrupts.h
@@ -20,17 +20,10 @@
 #define _WIRING_INTERRUPTS_
 
 #include <stdint.h>
+#include <functional>
 
-#ifdef __cplusplus
-  #include <functional>
-
-  typedef std::function<void(void)> callback_function_t;
-  void attachInterrupt(uint32_t pin, callback_function_t callback, uint32_t mode);
-
-#endif
-
-void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode);
-
+typedef std::function<void(void)> callback_function_t;
+void attachInterrupt(uint32_t pin, callback_function_t callback, uint32_t mode);
 void detachInterrupt(uint32_t pin);
 
 #endif /* _WIRING_INTERRUPTS_ */

--- a/cores/arduino/wiring.h
+++ b/cores/arduino/wiring.h
@@ -36,7 +36,6 @@
 #include "wiring_pulse.h"
 #include "wiring_shift.h"
 #include "wiring_time.h"
-#include "WInterrupts.h"
 
 #include <board.h>
 
@@ -44,8 +43,9 @@
   #include "HardwareTimer.h"
   #include "Tone.h"
   #include "WCharacter.h"
-  #include "WSerial.h"
+  #include "WInterrupts.h"
   #include "WMath.h"
+  #include "WSerial.h"
   #include "WString.h"
 #endif // __cplusplus
 


### PR DESCRIPTION
**Summary**
Interrupts: remove C prototype and keep only C++ prototypes

attachInterrupt() C prototypes was not usable from C source file
(inheritance of former pure C implementation), and causes ambiguity
when used with lambda function as callback
Fixes #1601
