### PR TITLE
cores(U5): support USB Type-C on U5

### DIFF
--- a/cores/arduino/stm32/usb/usbd_conf.c
+++ b/cores/arduino/stm32/usb/usbd_conf.c
@@ -51,6 +51,13 @@ PCD_HandleTypeDef g_hpcd;
 void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
 {
   const PinMap *map = NULL;
+
+#if defined(PIN_UCPD_TCPP)
+  /* Set TCPP default state: Type-C legacy */
+  pinMode(PIN_UCPD_TCPP, OUTPUT_OPEN_DRAIN);
+  digitalWriteFast(digitalPinToPinName(PIN_UCPD_TCPP), LOW);
+#endif
+
 #if defined(PWR_CR2_USV) || defined(PWR_SVMCR_USV)
   /* Enable VDDUSB on Pwrctrl CR2 register*/
   HAL_PWREx_EnableVddUSB();

--- a/cores/arduino/stm32/usb/usbd_conf.h
+++ b/cores/arduino/stm32/usb/usbd_conf.h
@@ -70,6 +70,9 @@ extern "C" {
 #elif defined(STM32G0xx)
 #define USB_IRQn USB_UCPD1_2_IRQn
 #define USB_IRQHandler USB_UCPD1_2_IRQHandler
+#elif defined(STM32U5xx)
+#define USB_IRQn OTG_FS_IRQn
+#define USB_IRQHandler OTG_FS_IRQHandler
 #elif defined(STM32L5xx)
 #define USB_IRQn            USB_FS_IRQn
 #define USB_IRQHandler      USB_FS_IRQHandler

--- a/variants/STM32L5xx/L552Z(C-E)TxQ_L562ZETxQ/variant_NUCLEO_L552ZE_Q.h
+++ b/variants/STM32L5xx/L552Z(C-E)TxQ_L562ZETxQ/variant_NUCLEO_L552ZE_Q.h
@@ -39,7 +39,7 @@
 #define PD12                    19
 #define PA4                     PIN_A9
 #define PB4                     21
-#define PB5                     22
+#define PB5                     22      // UCPD TCPP
 #define PB3                     23
 // 24 is PA4                   (20)
 // 25 is PB4                   (21)
@@ -232,6 +232,9 @@
 #ifndef PIN_SERIAL_TX
   #define PIN_SERIAL_TX         PG7
 #endif
+
+// Pin UCPD to configure TCPP in default Type-C legacy state (UCPD_DBn for TCPP01)
+#define PIN_UCPD_TCPP           PB5
 
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)

--- a/variants/STM32U5xx/U575A(G-I)IxQ_U585AIIxQ/variant_B_U585I_IOT02A.h
+++ b/variants/STM32U5xx/U575A(G-I)IxQ_U585AIIxQ/variant_B_U585I_IOT02A.h
@@ -301,6 +301,9 @@
   #define PIN_SERIAL_TX         PA9
 #endif
 
+// Pin UCPD to configure TCPP in default Type-C legacy state (UCPD_PWR for TCPP03)
+#define PIN_UCPD_TCPP           PB5
+
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED

--- a/variants/STM32U5xx/U575Z(G-I)TxQ_U585ZETxQ/variant_NUCLEO_U575ZI_Q.h
+++ b/variants/STM32U5xx/U575Z(G-I)TxQ_U585ZETxQ/variant_NUCLEO_U575ZI_Q.h
@@ -37,7 +37,7 @@
 #define PD12                    PIN_A15
 #define PA4                     PIN_A16 // SB35 ON
 #define PB4                     21      // SB36 ON
-#define PB5                     22
+#define PB5                     22      // UCPD TCPP
 #define PB3                     23
 // 24 is PA4 (20) as default SB38 ON
 // 25 is PB4 (21) as default SB43 ON
@@ -235,6 +235,9 @@
 #ifndef PIN_SERIAL_TX
   #define PIN_SERIAL_TX         PA9
 #endif
+
+// Pin UCPD to configure TCPP in default Type-C legacy state (UCPD_DBn for TCPP01)
+#define PIN_UCPD_TCPP           PB5
 
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)


### PR DESCRIPTION
**Summary**
cores(U5): support USB Type-C on U5

Only USB legacy on Type-C, no UCPD.
Hardening of TCPP default legacy state,
which applies to U5 as well as L5 series.

Tested:
* AnalogReadSerial with "USB support CDC (generic Serial supersede USART)
* Both Nucleo-U575zi-Q and B-U585I-IOT02A boards
* Both TypeC <--> TypeC  and  TypeC <-->TypeA  cables

Note: #1639 is needed