### PR TITLE
Bootloader jump to application

### DIFF
--- a/system/STM32F0xx/system_stm32f0xx.c
+++ b/system/STM32F0xx/system_stm32f0xx.c
@@ -184,10 +184,10 @@ void SystemInit(void)
 #endif
 
   /* Reset HSI14 bit */
-  RCC->CR2 &= (uint32_t)0xFFFFFFFEU;
+  RCC->CR2 &= (uint32_t)0xFFFFFFFE;
 
-  /* Disable all interrupts */
-  RCC->CIR = 0x00000000U;
+  /* Disable all interrupts and clear pending bits  */
+  RCC->CIR = (uint32_t)0x00BF0000;
 
 }
 

--- a/system/STM32F1xx/system_stm32f1xx.c
+++ b/system/STM32F1xx/system_stm32f1xx.c
@@ -79,13 +79,32 @@
 /* #define DATA_IN_ExtSRAM */
 #endif /* STM32F100xE || STM32F101xE || STM32F101xG || STM32F103xE || STM32F103xG */
 
-/*!< Uncomment the following line if you need to relocate your vector Table in
-     Internal SRAM. */
+
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
 /* #define VECT_TAB_SRAM */
+
 #ifndef VECT_TAB_OFFSET
-#define VECT_TAB_OFFSET  0x00000000U /*!< Vector Table base offset field.
-                                  This value must be a multiple of 0x200. */
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
 #endif
+
+#ifndef VECT_TAB_BASE_ADDRESS
+#if defined(VECT_TAB_SRAM)
+#define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#else
+#define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#endif /* VECT_TAB_SRAM */
+#endif /* VECT_TAB_BASE_ADDRESS */
 
 
 /**
@@ -195,11 +214,8 @@ void SystemInit (void)
   #endif /* DATA_IN_ExtSRAM */
 #endif
 
-#ifdef VECT_TAB_SRAM
-  SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM. */
-#else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH. */
-#endif
+  /* Configure the Vector Table location add offset address ------------------*/
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32F2xx/system_stm32f2xx.c
+++ b/system/STM32F2xx/system_stm32f2xx.c
@@ -136,19 +136,19 @@ void SystemInit(void)
   RCC->CR |= (uint32_t)0x00000001;
 
   /* Reset CFGR register */
-  RCC->CFGR = 0x00000000;
+  RCC->CFGR = (uint32_t)0x00000000;
 
   /* Reset HSEON, CSSON and PLLON bits */
   RCC->CR &= (uint32_t)0xFEF6FFFF;
 
   /* Reset PLLCFGR register */
-  RCC->PLLCFGR = 0x24003010;
+  RCC->PLLCFGR = (uint32_t)0x24003010;
 
   /* Reset HSEBYP bit */
   RCC->CR &= (uint32_t)0xFFFBFFFF;
 
-  /* Disable all interrupts */
-  RCC->CIR = 0x00000000;
+  /* Disable all interrupts and clear pending bits  */
+  RCC->CIR = (uint32_t)0x00BF0000;
 
 #ifdef DATA_IN_ExtSRAM
   SystemInit_ExtMemCtl();

--- a/system/STM32F2xx/system_stm32f2xx.c
+++ b/system/STM32F2xx/system_stm32f2xx.c
@@ -66,13 +66,32 @@
      on STM322xG_EVAL board as data memory  */
 /* #define DATA_IN_ExtSRAM */
 
-/*!< Uncomment the following line if you need to relocate your vector Table in
-     Internal SRAM. */
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
 /* #define VECT_TAB_SRAM */
+
 #ifndef VECT_TAB_OFFSET
-#define VECT_TAB_OFFSET  0x00 /*!< Vector Table base offset field.
-                                   This value must be a multiple of 0x200. */
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
 #endif
+
+#ifndef VECT_TAB_BASE_ADDRESS
+#if defined(VECT_TAB_SRAM)
+#define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#else
+#define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#endif /* VECT_TAB_SRAM */
+#endif /* VECT_TAB_BASE_ADDRESS */
+
 /******************************************************************************/
 
 /**
@@ -155,11 +174,7 @@ void SystemInit(void)
 #endif /* DATA_IN_ExtSRAM */
 
   /* Configure the Vector Table location add offset address ------------------*/
-#ifdef VECT_TAB_SRAM
-  SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
-#else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
-#endif
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32F3xx/system_stm32f3xx.c
+++ b/system/STM32F3xx/system_stm32f3xx.c
@@ -190,8 +190,8 @@ void SystemInit(void)
   /* Reset USARTSW[1:0], I2CSW and TIMs bits */
   RCC->CFGR3 &= 0xFF00FCCCU;
 
-  /* Disable all interrupts */
-  RCC->CIR = 0x00000000U;
+  /* Disable all interrupts and clear pending bits  */
+  RCC->CIR = 0x009F0000U;
 
   /* Configure the Vector Table location -------------------------------------*/
 #if defined(USER_VECT_TAB_ADDRESS)

--- a/system/STM32F3xx/system_stm32f3xx.c
+++ b/system/STM32F3xx/system_stm32f3xx.c
@@ -84,24 +84,24 @@
 /** @addtogroup STM32F3xx_System_Private_Defines
   * @{
   */
-#ifndef VECT_TAB_OFFSET
-#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
-                                                     This value must be a multiple of 0x200. */
-#else
-#define USER_VECT_TAB_ADDRESS
-#endif
 
 /* Note: Following vector table addresses must be defined in line with linker
          configuration. */
-/*!< Uncomment the following line if you need to relocate the vector table
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
-     remap of boot address selected */
-/* #define USER_VECT_TAB_ADDRESS */
 
-#if defined(USER_VECT_TAB_ADDRESS)
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
 /*!< Uncomment the following line if you need to relocate your vector Table
-     in Sram else user remap will be done in Flash. */
+     in Sram else user remap will be done by default in Flash. */
 /* #define VECT_TAB_SRAM */
+
+#ifndef VECT_TAB_OFFSET
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
+#endif
+
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
@@ -109,7 +109,7 @@
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+#endif /* VECT_TAB_BASE_ADDRESS */
 
 /******************************************************************************/
 /**
@@ -194,9 +194,7 @@ void SystemInit(void)
   RCC->CIR = 0x009F0000U;
 
   /* Configure the Vector Table location -------------------------------------*/
-#if defined(USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation */
-#endif /* USER_VECT_TAB_ADDRESS */
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32F4xx/system_stm32f4xx.c
+++ b/system/STM32F4xx/system_stm32f4xx.c
@@ -79,24 +79,23 @@
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F446xx || STM32F469xx ||\
           STM32F479xx */
 
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
+/* #define VECT_TAB_SRAM */
+
 #ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
                                                      This value must be a multiple of 0x200. */
-#else
-#define USER_VECT_TAB_ADDRESS
 #endif
 
-/* Note: Following vector table addresses must be defined in line with linker
-         configuration. */
-/*!< Uncomment the following line if you need to relocate the vector table
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
-     remap of boot address selected */
-/* #define USER_VECT_TAB_ADDRESS */
-
-#if defined(USER_VECT_TAB_ADDRESS)
-/*!< Uncomment the following line if you need to relocate your vector Table
-     in Sram else user remap will be done in Flash. */
-/* #define VECT_TAB_SRAM */
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
@@ -104,7 +103,9 @@
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+#endif /* VECT_TAB_BASE_ADDRESS */
+
+
 /******************************************************************************/
 
 /**
@@ -193,9 +194,7 @@ void SystemInit(void)
 #endif /* DATA_IN_ExtSRAM || DATA_IN_ExtSDRAM */
 
   /* Configure the Vector Table location -------------------------------------*/
-#if defined(USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32F4xx/system_stm32f4xx.c
+++ b/system/STM32F4xx/system_stm32f4xx.c
@@ -171,19 +171,22 @@ void SystemInit(void)
   RCC->CR |= (uint32_t)0x00000001;
 
   /* Reset CFGR register */
-  RCC->CFGR = 0x00000000;
+  RCC->CFGR = (uint32_t)0x00000000;
 
   /* Reset HSEON, CSSON and PLLON bits */
   RCC->CR &= (uint32_t)0xFEF6FFFF;
 
   /* Reset PLLCFGR register */
-  RCC->PLLCFGR = 0x24003010;
+  RCC->PLLCFGR = (uint32_t)0x24003010;
 
   /* Reset HSEBYP bit */
   RCC->CR &= (uint32_t)0xFFFBFFFF;
 
-  /* Disable all interrupts */
-  RCC->CIR = 0x00000000;
+#if defined(RCC_CIR_PLLSAIRDYC)
+  RCC->CIR = (uint32_t)0x00FF0000;
+#else
+  RCC->CIR = (uint32_t)0x00BF0000;
+#endif
 
 #if defined (DATA_IN_ExtSRAM) || defined (DATA_IN_ExtSDRAM)
   SystemInit_ExtMemCtl();

--- a/system/STM32F7xx/system_stm32f7xx.c
+++ b/system/STM32F7xx/system_stm32f7xx.c
@@ -152,19 +152,19 @@ void SystemInit(void)
   RCC->CR |= (uint32_t)0x00000001;
 
   /* Reset CFGR register */
-  RCC->CFGR = 0x00000000;
+  RCC->CFGR = (uint32_t)0x00000000;
 
   /* Reset HSEON, CSSON and PLLON bits */
   RCC->CR &= (uint32_t)0xFEF6FFFF;
 
   /* Reset PLLCFGR register */
-  RCC->PLLCFGR = 0x24003010;
+  RCC->PLLCFGR = (uint32_t)0x24003010;
 
   /* Reset HSEBYP bit */
   RCC->CR &= (uint32_t)0xFFFBFFFF;
 
-  /* Disable all interrupts */
-  RCC->CIR = 0x00000000;
+  /* Disable all interrupts and clear pending bits  */
+  RCC->CIR = (uint32_t)0x00FF0000;
 
 
   /* Configure the Vector Table location -------------------------------------*/

--- a/system/STM32F7xx/system_stm32f7xx.c
+++ b/system/STM32F7xx/system_stm32f7xx.c
@@ -63,23 +63,23 @@
   */
 
 /************************* Miscellaneous Configuration ************************/
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
 
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
+/* #define VECT_TAB_SRAM */
 
 #ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
                                                      This value must be a multiple of 0x200. */
-#else
-#define USER_VECT_TAB_ADDRESS
 #endif
 
-/* Note: Following vector table addresses must be defined in line with linker
-         configuration. */
-/*!< Define USER_VECT_TAB_ADDRESS line if you need to relocate the vector table
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
-     remap of boot address selected */
-#if defined(USER_VECT_TAB_ADDRESS)
-/*!< Define VECT_TAB_SRAM if you need to relocate your vector Table
-     in Sram else user remap will be done in Flash. */
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   RAMDTCM_BASE    /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
@@ -87,7 +87,8 @@
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+#endif /* VECT_TAB_BASE_ADDRESS */
+
 /******************************************************************************/
 
 /**
@@ -168,9 +169,7 @@ void SystemInit(void)
 
 
   /* Configure the Vector Table location -------------------------------------*/
-#if defined(USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32G0xx/system_stm32g0xx.c
+++ b/system/STM32G0xx/system_stm32g0xx.c
@@ -93,32 +93,33 @@
   */
 
 /************************* Miscellaneous Configuration ************************/
-#ifndef VECT_TAB_OFFSET
-#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
-                                                     This value must be a multiple of 0x200. */
-#else
-#define USER_VECT_TAB_ADDRESS
-#endif
-
 /* Note: Following vector table addresses must be defined in line with linker
          configuration. */
-/*!< Uncomment the following line if you need to relocate the vector table
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
-     remap of boot address selected */
-/* #define USER_VECT_TAB_ADDRESS */
 
-#if defined(USER_VECT_TAB_ADDRESS)
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
 /*!< Uncomment the following line if you need to relocate your vector Table
-     in Sram else user remap will be done in Flash. */
+     in Sram else user remap will be done by default in Flash. */
 /* #define VECT_TAB_SRAM */
+
+#ifndef VECT_TAB_OFFSET
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x100. */
+#endif
+
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
-                                                     This value must be a multiple of 0x200. */
+                                                     This value must be a multiple of 0x100. */
 #else
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
-                                                     This value must be a multiple of 0x200. */
+                                                     This value must be a multiple of 0x100. */
 #endif /* VECT_TAB_SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+#endif /* VECT_TAB_BASE_ADDRESS */
+
+
 /******************************************************************************/
 /**
   * @}
@@ -197,9 +198,7 @@ void SystemInit(void)
 #endif
 
   /* Configure the Vector Table location -------------------------------------*/
-#if defined(USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation */
-#endif /* USER_VECT_TAB_ADDRESS */
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32G0xx/system_stm32g0xx.c
+++ b/system/STM32G0xx/system_stm32g0xx.c
@@ -171,6 +171,31 @@
   */
 void SystemInit(void)
 {
+  /* Reset the RCC clock configuration to the default reset state ------------*/
+  /* Set HSION bit */
+  RCC->CR |= 0x00000500U;
+
+  /* Reset CFGR register */
+  RCC->CFGR = 0x00000000U;
+
+  /* Reset HSEON, CSSON and PLLON bits */
+  RCC->CR &= 0xFEF6FFFFU;
+
+  /* Reset PLLCFGR register */
+  RCC->PLLCFGR = 0x00001000U;
+
+  /* Reset HSEBYP bit */
+  RCC->CR &= 0xFFFBFFFFU;
+
+  /* Disable all interrupts and clar flags */
+  RCC->CIER = 0x00000000U;
+
+#if defined(RCC_CICR_HSI48RDYC)
+  RCC->CICR = 0x0000033FU;
+#else
+  RCC->CICR = 0x0000033BU;
+#endif
+
   /* Configure the Vector Table location -------------------------------------*/
 #if defined(USER_VECT_TAB_ADDRESS)
   SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation */

--- a/system/STM32G4xx/system_stm32g4xx.c
+++ b/system/STM32G4xx/system_stm32g4xx.c
@@ -94,23 +94,23 @@
   */
 
 /************************* Miscellaneous Configuration ************************/
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
+/* #define VECT_TAB_SRAM */
+
 #ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
                                                      This value must be a multiple of 0x200. */
-#else
-#define USER_VECT_TAB_ADDRESS
 #endif
 
-/* Note: Following vector table addresses must be defined in line with linker
-         configuration. */
-/*!< Uncomment the following line if you need to relocate the vector table
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
-     remap of boot address selected */
-
-#if defined(USER_VECT_TAB_ADDRESS)
-/*!< Uncomment the following line if you need to relocate your vector Table
-     in Sram else user remap will be done in Flash. */
-/* #define VECT_TAB_SRAM */
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
@@ -118,7 +118,8 @@
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+#endif /* VECT_TAB_BASE_ADDRESS */
+
 /******************************************************************************/
 /**
   * @}
@@ -195,9 +196,7 @@ void SystemInit(void)
   RCC->CICR = 0x0000073BU;
 
   /* Configure the Vector Table location add offset address ------------------*/
-#if defined(USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32G4xx/system_stm32g4xx.c
+++ b/system/STM32G4xx/system_stm32g4xx.c
@@ -177,6 +177,23 @@ void SystemInit(void)
     SCB->CPACR |= ((3UL << (10*2))|(3UL << (11*2)));  /* set CP10 and CP11 Full Access */
   #endif
 
+  /* Reset the RCC clock configuration to the default reset state ------------*/
+  /* Set HSION bit */
+  RCC->CR |= 0x00000500U;
+
+  /* Reset CFGR register */
+  RCC->CFGR = 0x00000001U;
+
+  /* Reset CR register */
+  RCC->CR = 0x00000500U;
+
+  /* Reset PLLCFGR register */
+  RCC->PLLCFGR = 0x00001000U;
+
+  /* Disable all interrupts and clar flags */
+  RCC->CIER = 0x00000000U;
+  RCC->CICR = 0x0000073BU;
+
   /* Configure the Vector Table location add offset address ------------------*/
 #if defined(USER_VECT_TAB_ADDRESS)
   SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */

--- a/system/STM32H7xx/system_stm32h7xx.c
+++ b/system/STM32H7xx/system_stm32h7xx.c
@@ -187,7 +187,7 @@ void SystemInit (void)
   RCC->CR |= RCC_CR_HSION;
 
   /* Reset CFGR register */
-  RCC->CFGR = 0x00000000;
+  RCC->CFGR = 0x00000000U;
 
   /* Reset HSEON, HSECSSON, CSION, HSI48ON, CSIKERON, PLL1ON, PLL2ON and PLL3ON bits */
   RCC->CR &= 0xEAF6ED7FU;
@@ -201,50 +201,51 @@ void SystemInit (void)
 
 #if defined(D3_SRAM_BASE)
   /* Reset D1CFGR register */
-  RCC->D1CFGR = 0x00000000;
+  RCC->D1CFGR = 0x00000000U;
 
   /* Reset D2CFGR register */
-  RCC->D2CFGR = 0x00000000;
+  RCC->D2CFGR = 0x00000000U;
 
   /* Reset D3CFGR register */
-  RCC->D3CFGR = 0x00000000;
+  RCC->D3CFGR = 0x00000000U;
 #else
   /* Reset CDCFGR1 register */
-  RCC->CDCFGR1 = 0x00000000;
+  RCC->CDCFGR1 = 0x00000000U;
 
   /* Reset CDCFGR2 register */
-  RCC->CDCFGR2 = 0x00000000;
+  RCC->CDCFGR2 = 0x00000000U;
 
   /* Reset SRDCFGR register */
-  RCC->SRDCFGR = 0x00000000;
+  RCC->SRDCFGR = 0x00000000U;
 #endif
   /* Reset PLLCKSELR register */
-  RCC->PLLCKSELR = 0x02020200;
+  RCC->PLLCKSELR = 0x02020200U;
 
   /* Reset PLLCFGR register */
-  RCC->PLLCFGR = 0x01FF0000;
+  RCC->PLLCFGR = 0x01FF0000U;
   /* Reset PLL1DIVR register */
-  RCC->PLL1DIVR = 0x01010280;
+  RCC->PLL1DIVR = 0x01010280U;
   /* Reset PLL1FRACR register */
-  RCC->PLL1FRACR = 0x00000000;
+  RCC->PLL1FRACR = 0x00000000U;
 
   /* Reset PLL2DIVR register */
-  RCC->PLL2DIVR = 0x01010280;
+  RCC->PLL2DIVR = 0x01010280U;
 
   /* Reset PLL2FRACR register */
 
-  RCC->PLL2FRACR = 0x00000000;
+  RCC->PLL2FRACR = 0x00000000U;
   /* Reset PLL3DIVR register */
-  RCC->PLL3DIVR = 0x01010280;
+  RCC->PLL3DIVR = 0x01010280U;
 
   /* Reset PLL3FRACR register */
-  RCC->PLL3FRACR = 0x00000000;
+  RCC->PLL3FRACR = 0x00000000U;
 
   /* Reset HSEBYP bit */
   RCC->CR &= 0xFFFBFFFFU;
 
-  /* Disable all interrupts */
-  RCC->CIER = 0x00000000;
+  /* Disable all interrupts and clar flags */
+  RCC->CIER = 0x00000000U;
+  RCC->CICR = 0x000007FFU;
 
 #if (STM32H7_DEV_ID == 0x450UL)
   /* dual core CM7 or single core line */

--- a/system/STM32H7xx/system_stm32h7xx.c
+++ b/system/STM32H7xx/system_stm32h7xx.c
@@ -64,33 +64,24 @@
   */
 
 /************************* Miscellaneous Configuration ************************/
-/*!< Uncomment the following line if you need to use initialized data in D2 domain SRAM (AHB SRAM) */
-/* #define DATA_IN_D2_SRAM */
-
-/*!< Uncomment the following line if you need to relocate your vector Table in
-     Internal SRAM. */
-/* #define VECT_TAB_SRAM */
-#ifndef VECT_TAB_OFFSET
-#define VECT_TAB_OFFSET  0x00000000UL /*!< Vector Table base offset field.
-                                      This value must be a multiple of 0x200. */
-#else
-
-#define USER_VECT_TAB_ADDRESS
-
-#endif
 
 /* Note: Following vector table addresses must be defined in line with linker
          configuration. */
-/*!< Define USER_VECT_TAB_ADDRESS if you need to relocate the vector table
 
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
 
-     remap of boot address selected */
-#if defined(USER_VECT_TAB_ADDRESS)
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
+/* #define VECT_TAB_SRAM */
+
+#ifndef VECT_TAB_OFFSET
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
+#endif
+
 #if defined(DUAL_CORE) && defined(CORE_CM4)
-/*!< Define VECT_TAB_SRAM if you need to relocate your vector Table
-
-     in Sram else user remap will be done in Flash. */
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   D2_AXISRAM_BASE   /*!< Vector Table base address field.
                                                        This value must be a multiple of 0x200. */
@@ -98,10 +89,8 @@
 #define VECT_TAB_BASE_ADDRESS   FLASH_BANK2_BASE  /*!< Vector Table base address field.
                                                        This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
-#else
-/*!< Define VECT_TAB_SRAM if you need to relocate your vector Table
 
-     in Sram else user remap will be done in Flash. */
+#else
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   D1_AXISRAM_BASE   /*!< Vector Table base address field.
                                                        This value must be a multiple of 0x200. */
@@ -110,7 +99,8 @@
                                                        This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
 #endif /* DUAL_CORE && CORE_CM4 */
-#endif /* USER_VECT_TAB_ADDRESS */
+
+
 
 /******************************************************************************/
 
@@ -271,27 +261,17 @@ void SystemInit (void)
   (void) tmpreg;
 #endif /* DATA_IN_D2_SRAM */
 
-#if defined(DUAL_CORE) && defined(CORE_CM4)
-  /* Configure the Vector Table location add offset address for cortex-M4 ------------------*/
-#if defined(USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal D2 AXI-RAM or in Internal FLASH */
-#endif /* USER_VECT_TAB_ADDRESS */
-
-#else
-
+#if !defined(DUAL_CORE) || defined(CORE_CM7)
   /*
    * Disable the FMC bank1 (enabled after reset).
    * This, prevents CPU speculation access on this bank which blocks the use of FMC during
    * 24us. During this time the others FMC master (such as LTDC) cannot use it!
    */
   FMC_Bank1_R->BTCR[0] = 0x000030D2;
+#endif /* !DUAL_CORE || CORE_CM7 */
 
-  /* Configure the Vector Table location add offset address for cortex-M7 ------------------*/
-#if defined(USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal D1 AXI-RAM or in Internal FLASH */
-#endif /* USER_VECT_TAB_ADDRESS */
-
-#endif /*DUAL_CORE && CORE_CM4*/
+  /* Configure the Vector Table location add offset address for cortex-M7 or for cortex-M4 ------------------*/
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 
 }
 

--- a/system/STM32L0xx/system_stm32l0xx.c
+++ b/system/STM32L0xx/system_stm32l0xx.c
@@ -144,25 +144,32 @@ define USER_VECT_TAB_ADDRESS
 void SystemInit (void)
 {    
 /*!< Set MSION bit */
-  RCC->CR |= (uint32_t)0x00000100U;
+  RCC->CR |= 0x00000100U;
 
   /*!< Reset SW[1:0], HPRE[3:0], PPRE1[2:0], PPRE2[2:0], MCOSEL[2:0] and MCOPRE[2:0] bits */
-  RCC->CFGR &= (uint32_t) 0x88FF400CU;
+  RCC->CFGR =  0x00000000U;
  
   /*!< Reset HSION, HSIDIVEN, HSEON, CSSON and PLLON bits */
-  RCC->CR &= (uint32_t)0xFEF6FFF6U;
+  RCC->CR = 0x00000100U;
   
   /*!< Reset HSI48ON  bit */
-  RCC->CRRCR &= (uint32_t)0xFFFFFFFEU;
+  RCC->CRRCR &= 0xFFFFFFFEU;
   
   /*!< Reset HSEBYP bit */
-  RCC->CR &= (uint32_t)0xFFFBFFFFU;
+  RCC->CR &= 0xFFFBFFFFU;
 
   /*!< Reset PLLSRC, PLLMUL[3:0] and PLLDIV[1:0] bits */
-  RCC->CFGR &= (uint32_t)0xFF02FFFFU;
+  RCC->CFGR &= 0xFF02FFFFU;
 
-  /*!< Disable all interrupts */
+  /* Disable all interrupts and clar flags */
   RCC->CIER = 0x00000000U;
+#if defined(RCC_CICR_HSI48RDYC)
+  RCC->CICR = 0x000001FF;
+#elif (RCC_CICR_CSSHSEC)
+  RCC->CICR = 0x000001BFU;
+#else
+  RCC->CICR = 0x000000BFU;
+#endif
   
   /* Configure the Vector Table location add offset address ------------------*/
 #if defined (USER_VECT_TAB_ADDRESS)

--- a/system/STM32L0xx/system_stm32l0xx.c
+++ b/system/STM32L0xx/system_stm32l0xx.c
@@ -63,33 +63,32 @@
   * @{
   */
 /************************* Miscellaneous Configuration ************************/
-
-#ifndef VECT_TAB_OFFSET
-#define VECT_TAB_OFFSET  0x00U /*!< Vector Table base offset field. 
-                                   This value must be a multiple of 0x100. */
-#else
-define USER_VECT_TAB_ADDRESS
-#endif
-
 /* Note: Following vector table addresses must be defined in line with linker
          configuration. */
-/*!< Uncomment the following line if you need to relocate the vector table
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
-     remap of boot address selected */
-/* #define USER_VECT_TAB_ADDRESS */
 
-#if defined(USER_VECT_TAB_ADDRESS)
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
 /*!< Uncomment the following line if you need to relocate your vector Table
-     in Sram else user remap will be done in Flash. */
+     in Sram else user remap will be done by default in Flash. */
 /* #define VECT_TAB_SRAM */
+
+#ifndef VECT_TAB_OFFSET
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x100. */
+#endif
+
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
-                                                     This value must be a multiple of 0x200. */
+                                                     This value must be a multiple of 0x100. */
 #else
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
-                                                     This value must be a multiple of 0x200. */
+                                                     This value must be a multiple of 0x100. */
 #endif /* VECT_TAB_SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+#endif /* VECT_TAB_BASE_ADDRESS */
+
 
 /******************************************************************************/
 /**
@@ -172,9 +171,7 @@ void SystemInit (void)
 #endif
   
   /* Configure the Vector Table location add offset address ------------------*/
-#if defined (USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32L1xx/system_stm32l1xx.c
+++ b/system/STM32L1xx/system_stm32l1xx.c
@@ -169,8 +169,12 @@ void SystemInit (void)
   /*!< Reset PLLSRC, PLLMUL[3:0] and PLLDIV[1:0] bits */
   RCC->CFGR &= (uint32_t)0xFF02FFFF;
 
-  /*!< Disable all interrupts */
-  RCC->CIR = 0x00000000;
+  /* Disable all interrupts and clear pending bits  */
+#if defined(RCC_CIR_LSECSSF)
+  RCC->CIR = (uint32_t)0x00FF0000;
+#else
+  RCC->CIR = (uint32_t)0x00BF0000;
+#endif
 
 #ifdef DATA_IN_ExtSRAM
   SystemInit_ExtMemCtl();

--- a/system/STM32L1xx/system_stm32l1xx.c
+++ b/system/STM32L1xx/system_stm32l1xx.c
@@ -67,24 +67,23 @@
 /* #define DATA_IN_ExtSRAM */
 
 
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
+/* #define VECT_TAB_SRAM */
+
 #ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
                                                      This value must be a multiple of 0x200. */
-#else
-#define USER_VECT_TAB_ADDRESS
 #endif
 
-/* Note: Following vector table addresses must be defined in line with linker
-         configuration. */
-/*!< Uncomment the following line if you need to relocate the vector table
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
-     remap of boot address selected */
-/* #define USER_VECT_TAB_ADDRESS */
-
-#if defined(USER_VECT_TAB_ADDRESS)
-/*!< Uncomment the following line if you need to relocate your vector Table
-     in Sram else user remap will be done in Flash. */
-/* #define VECT_TAB_SRAM */
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM_BASE       /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
@@ -92,7 +91,7 @@
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+#endif /* VECT_TAB_BASE_ADDRESS */
 
 /******************************************************************************/
 /**
@@ -181,9 +180,7 @@ void SystemInit (void)
 #endif /* DATA_IN_ExtSRAM */
 
   /* Configure the Vector Table location -------------------------------------*/
-#if defined(USER_VECT_TAB_ADDRESS)
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH or SRAM. */
-#endif /* USER_VECT_TAB_ADDRESS */
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32L4xx/system_stm32l4xx.c
+++ b/system/STM32L4xx/system_stm32l4xx.c
@@ -107,21 +107,23 @@
   */
 
 /************************* Miscellaneous Configuration ************************/
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
+/* #define VECT_TAB_SRAM */
+
 #ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
                                                      This value must be a multiple of 0x200. */
-#else
-#define USER_VECT_TAB_ADDRESS
 #endif
 
-/* Note: Following vector table addresses must be defined in line with linker
-         configuration. */
-/*!< Define USER_VECT_TAB_ADDRESS if you need to relocate the vector table
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
-     remap of boot address selected */
-#if defined(USER_VECT_TAB_ADDRESS)
-/*!< Define VECT_TAB_SRAM if you need to relocate your vector Table
-     in Sram else user remap will be done in Flash. */
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM1_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
@@ -129,7 +131,7 @@
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+#endif /* VECT_TAB_BASE_ADDRESS */
 
 /******************************************************************************/
 /**
@@ -185,10 +187,8 @@
 
 void SystemInit(void)
 {
-#if defined(USER_VECT_TAB_ADDRESS)
   /* Configure the Vector Table location -------------------------------------*/
   SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
-#endif
 
   /* FPU settings ------------------------------------------------------------*/
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)

--- a/system/STM32L4xx/system_stm32l4xx.c
+++ b/system/STM32L4xx/system_stm32l4xx.c
@@ -211,8 +211,19 @@ void SystemInit(void)
   /* Reset HSEBYP bit */
   RCC->CR &= 0xFFFBFFFFU;
 
-  /* Disable all interrupts */
+  /* Disable all interrupts and clar flags */
   RCC->CIER = 0x00000000U;
+#if defined(RCC_CICR_PLLSAI2RDYC)
+#if defined(RCC_CICR_HSI48RDYC)
+  RCC->CICR = 0x000007FFU;
+#else
+  RCC->CICR = 0x000003FFU;
+#endif /* RCC_CICR_HSI48RDYC */
+#elif defined(RCC_CICR_PLLSAI1RDYC)
+  RCC->CICR = 0x0000077FU;
+#else
+  RCC->CICR = 0x0000073FU;
+#endif /* RCC_CICR_PLLSAI2RDYC */
 }
 
 /**

--- a/system/STM32L5xx/system_stm32l5xx_ns.c
+++ b/system/STM32L5xx/system_stm32l5xx_ns.c
@@ -157,6 +157,26 @@ void SystemInit(void)
   SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 #endif
 
+  /* Reset the RCC clock configuration to the default reset state ------------*/
+  /* Set MSION bit */
+  RCC->CR |= 0x00000001U;
+
+  /* Reset CFGR register */
+  RCC->CFGR = 0x00000000;
+
+  /* Reset CR register */
+  RCC->CR = 0x00000061U;
+
+  /* Reset PLLCFGR register */
+  RCC->PLLCFGR = 0x00001000U;
+
+  /* Reset HSEBYP bit */
+  RCC->CR &= 0xFFFBFFFFU;
+
+  /* Disable all interrupts and clar flags */
+  RCC->CIER = 0x00000000U;
+  RCC->CICR = 0x000005FFU;
+
   /* FPU settings ------------------------------------------------------------*/
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
   SCB->CPACR |= ((3UL << 20U)|(3UL << 22U));  /* set CP10 and CP11 Full Access */

--- a/system/STM32L5xx/system_stm32l5xx_ns.c
+++ b/system/STM32L5xx/system_stm32l5xx_ns.c
@@ -70,25 +70,23 @@
 /** @addtogroup STM32L5xx_System_Private_Defines
   * @{
   */
-#ifndef VECT_TAB_OFFSET
-#define VECT_TAB_OFFSET         0x00000000U /*!< Vector Table base offset field.
-                                                 This value must be a multiple of 0x200. */
-#else
-define USER_VECT_TAB_ADDRESS
-#endif
-
 /* Note: Following vector table addresses must be defined in line with linker
          configuration. */
-/*!< Uncomment the following line if you need to relocate the vector table
-     anywhere in Flash or Sram, else the vector table is kept at the automatic
-     remap of boot address selected */
-/* #define USER_VECT_TAB_ADDRESS */
 
-#if defined(USER_VECT_TAB_ADDRESS)
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
 /*!< Uncomment the following line if you need to relocate your vector Table
-     in Sram else user remap will be done in Flash. */
+     in Sram else user remap will be done by default in Flash. */
 /* #define VECT_TAB_SRAM */
 
+#ifndef VECT_TAB_OFFSET
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
+#endif
+
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM1_BASE_NS   /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
@@ -96,7 +94,7 @@ define USER_VECT_TAB_ADDRESS
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE_NS   /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
 #endif /* VECT_TAB_SRAM */
-#endif /* USER_VECT_TAB_ADDRESS */
+#endif /* VECT_TAB_BASE_ADDRESS */
 
 /******************************************************************************/
 /**
@@ -153,9 +151,7 @@ define USER_VECT_TAB_ADDRESS
 void SystemInit(void)
 {
   /* Configure the Vector Table location -------------------------------------*/
-#if defined(USER_VECT_TAB_ADDRESS)
   SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
-#endif
 
   /* Reset the RCC clock configuration to the default reset state ------------*/
   /* Set MSION bit */

--- a/system/STM32U5xx/system_stm32u5xx.c
+++ b/system/STM32U5xx/system_stm32u5xx.c
@@ -121,13 +121,32 @@
 
 
 /************************* Miscellaneous Configuration ************************/
-/*!< Uncomment the following line if you need to relocate your vector Table in
-     Internal SRAM. */
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
 /* #define VECT_TAB_SRAM */
+
 #ifndef VECT_TAB_OFFSET
-#define VECT_TAB_OFFSET  0x00000000UL /*!< Vector Table base offset field.
-                                   This value must be a multiple of 0x200. */
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
+                                                     This value must be a multiple of 0x200. */
 #endif
+
+#ifndef VECT_TAB_BASE_ADDRESS
+#if defined(VECT_TAB_SRAM)
+#define VECT_TAB_BASE_ADDRESS   SRAM1_BASE      /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#else
+#define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
+                                                     This value must be a multiple of 0x200. */
+#endif /* VECT_TAB_SRAM */
+#endif /* VECT_TAB_BASE_ADDRESS */
+
 /******************************************************************************/
 
 /**
@@ -211,11 +230,7 @@ void SystemInit(void)
   RCC->CICR = 0x00001DFFU;
 
   /* Configure the Vector Table location add offset address ------------------*/
-  #ifdef VECT_TAB_SRAM
-    SCB->VTOR = SRAM1_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
-  #else
-    SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
-  #endif
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
 }
 
 /**

--- a/system/STM32U5xx/system_stm32u5xx.c
+++ b/system/STM32U5xx/system_stm32u5xx.c
@@ -206,8 +206,9 @@ void SystemInit(void)
   /* Reset HSEBYP bit */
   RCC->CR &= ~(RCC_CR_HSEBYP);
 
-  /* Disable all interrupts */
-  RCC->CIER = 0U;
+  /* Disable all interrupts and clar flags */
+  RCC->CIER = 0x00000000U;
+  RCC->CICR = 0x00001DFFU;
 
   /* Configure the Vector Table location add offset address ------------------*/
   #ifdef VECT_TAB_SRAM

--- a/system/STM32WBxx/system_stm32wbxx.c
+++ b/system/STM32WBxx/system_stm32wbxx.c
@@ -101,29 +101,31 @@
   * @{
   */
 
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
+/* #define VECT_TAB_SRAM */
+
 #ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table base offset field.
                                                      This value must be a multiple of 0x200. */
-#else
-#define USER_VECT_TAB_ADDRESS
 #endif
 
-/* Note: Following vector table addresses must be defined in line with linker
-         configuration. */
-/*!< Define USER_VECT_TAB_ADDRESS if you need to relocate CPU1 CM4 and/or CPU2
-     CM0+ vector table anywhere in Sram or Flash. Else vector table will be kept
-     at address 0x00 which correspond to automatic remap of boot address selected */
-#if defined(USER_VECT_TAB_ADDRESS)
- /*!< Define VECT_TAB_SRAM for user vector table remap in Sram else user remap
-      will be done in Flash. */
+#ifndef VECT_TAB_BASE_ADDRESS
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM1_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
 #else
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
-#endif
-#endif
+#endif /* VECT_TAB_SRAM */
+#endif /* VECT_TAB_BASE_ADDRESS */
 
 /**
   * @}
@@ -187,10 +189,7 @@
   */
 void SystemInit(void)
 {
-#if defined(USER_VECT_TAB_ADDRESS)
-  /* Configure the Vector Table location add offset address ------------------*/
   SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
-#endif
 
   /* FPU settings ------------------------------------------------------------*/
   #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)

--- a/system/STM32WBxx/system_stm32wbxx.c
+++ b/system/STM32WBxx/system_stm32wbxx.c
@@ -205,13 +205,13 @@ void SystemInit(void)
   RCC->CFGR = 0x00070000U;
 
   /* Reset PLLSAI1ON, PLLON, HSECSSON, HSEON, HSION, and MSIPLLON bits */
-  RCC->CR &= (uint32_t)0xFAF6FEFBU;
+  RCC->CR &= 0xFAF6FEFBU;
 
   /*!< Reset LSI1 and LSI2 bits */
-  RCC->CSR &= (uint32_t)0xFFFFFFFAU;
+  RCC->CSR &= 0xFFFFFFFAU;
   
   /*!< Reset HSI48ON  bit */
-  RCC->CRRCR &= (uint32_t)0xFFFFFFFEU;
+  RCC->CRRCR &= 0xFFFFFFFEU;
     
   /* Reset PLLCFGR register */
   RCC->PLLCFGR = 0x22041000U;
@@ -224,8 +224,17 @@ void SystemInit(void)
   /* Reset HSEBYP bit */
   RCC->CR &= 0xFFFBFFFFU;
 
-  /* Disable all interrupts */
-  RCC->CIER = 0x00000000;
+  /* Disable all interrupts and clar flags */
+  RCC->CIER = 0x00000000U;
+#if defined(RCC_CICR_HSI48RDYC)
+#if defined(RCC_CICR_PLLSAI1RDYC)
+  RCC->CICR = 0x00000F7FU;
+#else
+  RCC->CICR = 0x00000F3FU;
+#endif /* RCC_CICR_PLLSAI1RDYC */
+#else
+  RCC->CICR = 0x00000B3FU;
+#endif /* RCC_CICR_HSI48RDYC */
 }
 
 /**

--- a/system/STM32WLxx/system_stm32wlxx.c
+++ b/system/STM32WLxx/system_stm32wlxx.c
@@ -101,44 +101,40 @@
   * @{
   */
 
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+
+/*!< Uncomment the following line and change the address
+     if you need to relocate your vector Table at a custom base address (+ VECT_TAB_OFFSET) */
+/* #define VECT_TAB_BASE_ADDRESS 0x08000000 */
+
+/*!< Uncomment the following line if you need to relocate your vector Table
+     in Sram else user remap will be done by default in Flash. */
+/* #define VECT_TAB_SRAM */
+
 #ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET         0x00008000U     /*!< Vector Table base offset field.
                                                      This value must be a multiple of 0x100. */
-#else
-#define USER_VECT_TAB_ADDRESS
 #endif
 
-/* Note: Following vector table addresses must be defined in line with linker
-         configuration. */
-/*!< Uncomment the following line if you need to relocate CPU1 CM4 and/or CPU2
-     CM0+ vector table anywhere in Sram or Flash. Else vector table will be kept
-     at address 0x00 which correspond to automatic remap of boot address selected */
-/* #define USER_VECT_TAB_ADDRESS */
-#if defined(USER_VECT_TAB_ADDRESS)
-#ifdef CORE_CM0PLUS
- /*!< Uncomment this line for user vector table remap in Sram else user remap
-      will be done in Flash. */
-/* #define VECT_TAB_SRAM */
+#if defined(CORE_CM0PLUS)
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM2_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x100. */
 #else
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x100. */
-#endif
+#endif /* VECT_TAB_SRAM */
+
 #else /* CORE_CM4 */
- /*!< Uncomment this line for user vector table remap in Sram else user remap
-      will be done in Flash. */
-/* #define VECT_TAB_SRAM */
 #if defined(VECT_TAB_SRAM)
 #define VECT_TAB_BASE_ADDRESS   SRAM1_BASE      /*!< Vector Table base address field.
-                                                     This value must be a multiple of 0x200. */
+                                                     This value must be a multiple of 0x100. */
 #else
 #define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
-                                                     This value must be a multiple of 0x200. */
-#endif
-#endif
-#endif
+                                                     This value must be a multiple of 0x100. */
+#endif /* VECT_TAB_SRAM */
+#endif /* CORE_CM0PLUS */
 
 /**
   * @}
@@ -208,10 +204,7 @@ void SystemInit(void)
   RCC->CIER = 0x00000000U;
   RCC->CICR = 0x0000033FU;
 
-#if defined(USER_VECT_TAB_ADDRESS)
-  /* Configure the Vector Table location add offset address ------------------*/
   SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
-#endif
 
   /* FPU settings ------------------------------------------------------------*/
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)

--- a/system/STM32WLxx/system_stm32wlxx.c
+++ b/system/STM32WLxx/system_stm32wlxx.c
@@ -190,6 +190,24 @@
   */
 void SystemInit(void)
 {
+
+  /* Reset the RCC clock configuration to the default reset state ------------*/
+  /* Set MSION bit */
+  RCC->CR |= 0x00000061U;
+
+  /* Reset CFGR register */
+  RCC->CFGR = 0x00070000U;
+
+  /* Reset CR register */
+  RCC->CR = 0x00000061U;
+
+  /* Reset PLLCFGR register */
+  RCC->PLLCFGR = 0x22040100U;
+
+  /* Disable all interrupts and clar flags */
+  RCC->CIER = 0x00000000U;
+  RCC->CICR = 0x0000033FU;
+
 #if defined(USER_VECT_TAB_ADDRESS)
   /* Configure the Vector Table location add offset address ------------------*/
   SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;


### PR DESCRIPTION
**Summary**
After UART Bootloader to jump to application, 2 issues prevent application to run properly:
* Bootloader changes VTOR register and did not restore it when jumping to application
It is necessary that application set VTOR unconditionally

* Bootloader set PLL as SystemClock and keep it when jumping to application
This prevent any further configuration of the PLL.
It is necessary change SystemClock source, for example revert to default SystemClock (HSI or MSI) before any further PLL configuration.

Fixes #1637
