### PR TITLE
fix(cli): optional column number in error pattern

### DIFF
--- a/CI/build/arduino-cli.py
+++ b/CI/build/arduino-cli.py
@@ -90,7 +90,7 @@ skip_count = 0
 
 # error or fatal error
 fork_pattern = re.compile(r"^Error during build: fork/exec")
-error_pattern = re.compile(r":\d+:\d+:\s.*error:\s|^Error:")
+error_pattern = re.compile(r":\d+:\d*:?\s.*error:\s|^Error:")
 ld_pattern = re.compile("arm-none-eabi/bin/ld:")
 overflow_pattern = re.compile(
     r"(will not fit in |section .+ is not within )?region( .+ overflowed by [\d]+ bytes)?"


### PR DESCRIPTION
If error comes from the full line of code column number is not available.
Ex:
```
system/STM32H7xx/system_stm32h7xx.c:68: error: unterminated #if
   68 | #if defined(DUAL_CORE) && defined(CORE_CM4)
      |

```