### PR TITLE
Wire: implement STOP sequence to recover I2C bus.

### DIFF
--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -66,6 +66,7 @@ class TwoWire : public Stream {
 
     void resetRxBuffer(void);
     void resetTxBuffer(void);
+    void recoverBus(void);
 
   public:
     TwoWire();


### PR DESCRIPTION
**Summary**
Wire: implement STOP sequence to recover I2C bus.

Useful in case of bus stuck after a reset for example
Fixes #1661

