### PR TITLE
feat: Add STM32Cube HAL getter to SPI, Wire and HardwareSerial

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -174,6 +174,13 @@ class HardwareSerial : public Stream {
     // Interrupt handlers
     static void _rx_complete_irq(serial_t *obj);
     static int _tx_complete_irq(serial_t *obj);
+
+    // Could be used to mix Arduino API and STM32Cube HAL API (ex: DMA). Use at your own risk.
+    UART_HandleTypeDef *getHandle(void)
+    {
+      return &(_serial.handle);
+    }
+
   private:
     bool _rx_enabled;
     uint8_t _config;

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -227,6 +227,12 @@ class SPIClass {
     void attachInterrupt(void);
     void detachInterrupt(void);
 
+    // Could be used to mix Arduino API and STM32Cube HAL API (ex: DMA). Use at your own risk.
+    SPI_HandleTypeDef *getHandle(void)
+    {
+      return &(_spi.handle);
+    }
+
   private:
     /* Contains various spiSettings for the same spi instance. Each spi spiSettings
     is associated to a CS pin. */

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -130,6 +130,12 @@ class TwoWire : public Stream {
       return write((uint8_t)n);
     }
     using Print::write;
+
+    // Could be used to mix Arduino API and STM32Cube HAL API (ex: DMA). Use at your own risk.
+    I2C_HandleTypeDef *getHandle(void)
+    {
+      return &(_i2c.handle);
+    }
 };
 
 


### PR DESCRIPTION
**Summary**
feat: Add STM32Cube HAL getter to SPI, Wire and HardwareSerial

Could be used for example to mix Arduino API and STM32Cube HAL API.
For example to configure DMA.
Warning: Use at your own risk

Fixes #1035