### PR TITLE
Added new Agafia SG0 Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart: | STM32G030C6<br>STM32G030C8 | Generic Board | *2.2.0* |
 | :green_heart: | STM32G030F6<br>STM32G030F6 | Generic Board | *2.2.0* |
 | :green_heart: | STM32G030K8 | [Aurora One](https://www.bfy.kr/aurora-one/) | *2.0.0* |
+| :yellow_heart: | STM32G071CB | [AGAFIA SG0](https://www.sigmaic.com/agafia-sgo/) | *2.0.0* |
 | :green_heart: | STM32G030K6<br>STM32G030K8 | Generic Board | *2.0.0* |  |
 | :green_heart: | STM32G031J4<br>STM32G031J6 | Generic Board | *2.0.0* |  |
 | :yellow_heart: | STM32G031F4<br>STM32G031F6<br>STM32G031F8 | Generic Board | **2.3.0** |  |

--- a/boards.txt
+++ b/boards.txt
@@ -3189,7 +3189,7 @@ GenG0.menu.pnum.AURORA_ONE.build.board=AURORA_ONE
 GenG0.menu.pnum.AURORA_ONE.build.product_line=STM32G030xx
 GenG0.menu.pnum.AURORA_ONE.build.variant=STM32G0xx/G030K(6-8)T
 GenG0.menu.pnum.AURORA_ONE.build.variant_h=variant_{build.board}.h
-
+  
 # Generic G030C6Tx
 GenG0.menu.pnum.GENERIC_G030C6TX=Generic G030C6Tx
 GenG0.menu.pnum.GENERIC_G030C6TX.upload.maximum_size=32768
@@ -3413,6 +3413,15 @@ GenG0.menu.pnum.GENERIC_G070RBTX.upload.maximum_data_size=36864
 GenG0.menu.pnum.GENERIC_G070RBTX.build.board=GENERIC_G070RBTX
 GenG0.menu.pnum.GENERIC_G070RBTX.build.product_line=STM32G070xx
 GenG0.menu.pnum.GENERIC_G070RBTX.build.variant=STM32G0xx/G070RBT
+
+# AGAFIA SG0
+GenG0.menu.pnum.AGAFIA_SG0=AGAFIA SG0
+GenG0.menu.pnum.AGAFIA_SG0.upload.maximum_size=131072
+GenG0.menu.pnum.AGAFIA_SG0.upload.maximum_data_size=36864
+GenG0.menu.pnum.AGAFIA_SG0.build.board=AGAFIA_SG0
+GenG0.menu.pnum.AGAFIA_SG0.build.product_line=STM32G071xx
+GenG0.menu.pnum.AGAFIA_SG0.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
+GenG0.menu.pnum.AGAFIA_SG0.build.variant_h=variant_{build.board}.h
 
 # Generic G071R6Tx
 GenG0.menu.pnum.GENERIC_G071R6TX=Generic G071R6Tx

--- a/variants/STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)/variant_agafia_sg0.cpp
+++ b/variants/STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)/variant_agafia_sg0.cpp
@@ -1,0 +1,165 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+ 
+#if defined(ARDUINO_AGAFIA_SG0)
+#include "pins_arduino.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Pin number
+const PinName digitalPin[] = {
+  PA_10, //D0
+  PA_9 , //D1
+  PA_12, //D2
+  PC_6,  //D3  //SPI_CLK
+  PB_15, //D4
+  PB_14, //D5
+  PA_8,  //D6
+  PB_13, //D7
+  PC_7,  //D8
+  PB_3,  //D9
+  PB_0,  //D10 //SPI_CS
+  PA_7,  //D11 //SPI_MOSI
+  PA_6,  //D12 //SPI_MISO
+  PA_5,  //D13 //SPI_CLK
+  PB_9,  //D14
+  PB_8,  //D15
+   
+   
+  PA_3,  //D16
+  PA_2,  //D17
+  PA_0,  //D18 
+  PA_1,  //D19
+  
+  PA_11, //D20		
+  PA_15, //D21 
+  PD_0,	 //D22
+  PD_1,  //D23
+  PD_2,  //D24
+  PD_3,  //D25
+  PD_4,  //D26
+  PB_4,  //D27		
+  PB_5,  //D28
+  PB_6,  //D29
+  PB_7,  //D30
+  
+  PA_14, //D31
+  PA_13, //D32 
+  
+  PF_0,  //D33
+  PF_1,  //D34
+  PC_13, //D35
+  
+  PA_4,  //D36 //A0 //DAC1
+  PB_12, //D37 //A1
+  PB_11, //D38 //A2
+  PB_10, //D39 //A3
+  PB_2,  //D40 //A4 
+  PB_1   //D41 //A5
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInputPin[] = {
+  36, //A0
+  37, //A1
+  38, //A2
+  39, //A3
+  40, //A4
+  41, //A5
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+// ----------------------------------------------------------------------------
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief  System Clock Configuration
+  *         The system Clock is configured as follows :
+  *            System Clock source            = PLL (HSI)
+  *            SYSCLK(Hz)                     = 64000000
+  *            HCLK(Hz)                       = 64000000
+  *            AHB Prescaler                  = 1
+  *            APB1 Prescaler                 = 1
+  *            MSI Frequency(Hz)              = 16000000
+  *            PLL_M                          = 1
+  *            PLL_N                          = 8
+  *            PLL_R                          = 2
+  *            PLL_P                          = 2
+  *            PLL_Q                          = 2
+  *            Flash Latency(WS)              = 2
+  * @param  None
+  * @retval None
+  */
+WEAK void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {};
+
+  /* Configure the main internal regulator output voltage */
+  HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1);
+  /* Initializes the CPU, AHB and APB busses clocks */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.HSIDiv = RCC_HSI_DIV1;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+  RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV1;
+  RCC_OscInitStruct.PLL.PLLN = 8;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+  RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
+  RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+  /* Initializes the CPU, AHB and APB busses clocks */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK
+                                | RCC_CLOCKTYPE_PCLK1;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK) {
+    Error_Handler();
+  }
+}
+#ifdef __cplusplus
+}
+#endif
+#endif /* ARDUINO_AGAFIA_SG0 */

--- a/variants/STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)/variant_agafia_sg0.h
+++ b/variants/STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)/variant_agafia_sg0.h
@@ -1,0 +1,167 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+
+#pragma once
+
+/*----------------------------------------------------------------------------
+ *        Pins
+ *----------------------------------------------------------------------------*/
+
+#define PA10 0  // UART1_RX
+#define PA9  1  // UART1_TX
+#define PA12 2
+#define PC6  3	 
+#define PB15 4
+#define PB14 5
+#define PA8  6
+#define PB13 7
+#define PC7  8
+#define PB3  9  
+#define PB0  10 // SPI_CS 
+#define PA7  11 // SPI_MOSI
+#define PA6  12 // SPI_MISO
+#define PA5  13 // SPI_CLK
+#define PB9  14 // SDA
+#define PB8  15 // SCL
+
+//SERIAL PINS
+#define PA3  16
+#define PA2  17
+#define PA0  18
+#define PA1  19  
+
+//TOP PIN CONN
+#define PA11 20  
+#define PA15 21  
+#define PD0  22    
+#define PD1  23
+#define PD2  24
+#define PD3  25
+#define PD4  26 
+#define PB4	 27 	
+#define PB5  28
+#define PB6  29 
+#define PB7  30
+
+#define PA14 31 //SCK-BOOT0
+#define PA13 32 //SWDIO
+
+#define PF0  33 //LED3 
+#define PF1  34 //LED2
+#define PC13 35 //LED1
+
+#define PA4  36 // A0
+#define PB12 37 // A1
+#define PB11 38 // A2
+#define PB10 39 // A3
+#define PB2  40 // A4
+#define PB1  41 // A5
+
+// This must be a literal
+#define NUM_DIGITAL_PINS        42
+// This must be a literal with a value less than or equal to to MAX_ANALOG_INPUTS
+#define NUM_ANALOG_INPUTS       10
+ 
+
+// On-board LED pin number
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN           PC13
+#endif 
+#define LED1                    LED_BUILTIN
+#define LED2                    PF0  
+#define LED3                    PF1
+ 
+
+// SPI Definitions
+#define PIN_SPI_SS              PB0
+#define PIN_SPI_MOSI            PA7
+#define PIN_SPI_MISO            PA6
+#define PIN_SPI_SCK             PA5
+
+// I2C Definitions
+#define PIN_WIRE_SDA            PB9
+#define PIN_WIRE_SCL            PB8
+
+// Timer Definitions
+// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
+#ifndef TIMER_TONE
+  #define TIMER_TONE            TIM6
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO           TIM7
+#endif
+
+#define PIN_DAC1                PA4
+#define PIN_DAC2                PA5
+
+// UART Definitions
+#ifndef SERIAL_UART_INSTANCE
+  #define SERIAL_UART_INSTANCE  101 //Connected to ST-Link
+#endif
+
+// Default pin used for 'Serial' instance (ex: ST-Link)
+// Mandatory for Firmata
+#ifndef PIN_SERIAL_RX
+  #define PIN_SERIAL_RX         PA3
+#endif
+#ifndef PIN_SERIAL_TX
+  #define PIN_SERIAL_TX         PA2
+#endif
+
+// Extra HAL modules
+#if !defined(HAL_DAC_MODULE_DISABLED)
+  #define HAL_DAC_MODULE_ENABLED
+#endif
+
+ 
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+// These serial port names are intended to allow libraries and architecture-neutral
+// sketches to automatically default to the correct port name for a particular type
+// of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+// the first hardware serial port whose RX/TX pins are not dedicated to another use.
+//
+// SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+//
+// SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+//
+// SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+//
+// SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+//
+// SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+//                            pins are NOT connected to anything by default.
+#define SERIAL_PORT_MONITOR   Serial
+#define SERIAL_PORT_HARDWARE  Serial2
+#endif
+ 


### PR DESCRIPTION
AGAFIA SG0 is the custom board based on STM32G071CB.  

This PR fixes/implements the following bugs/features

- [x] Adding a new variant for Generic G071CBT
