### PR TITLE
wire: add fix for toggling NoStretch

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -59,7 +59,7 @@ void TwoWire::begin(bool generalCall)
   begin(MASTER_ADDRESS, generalCall);
 }
 
-void TwoWire::begin(uint8_t address, bool generalCall)
+void TwoWire::begin(uint8_t address, bool generalCall, bool NoStretchMode)
 {
   rxBufferIndex = 0;
   rxBufferLength = 0;
@@ -83,6 +83,8 @@ void TwoWire::begin(uint8_t address, bool generalCall)
 
   _i2c.generalCall = (generalCall == true) ? 1 : 0;
 
+  _i2c.NoStretchMode = (NoStretchMode == true) ? 1 : 0;
+
   recoverBus(); // in case I2C bus (device) is stuck after a reset for example
 
   i2c_custom_init(&_i2c, 100000, I2C_ADDRESSINGMODE_7BIT, ownAddress);
@@ -96,9 +98,9 @@ void TwoWire::begin(uint8_t address, bool generalCall)
   }
 }
 
-void TwoWire::begin(int address, bool generalCall)
+void TwoWire::begin(int address, bool generalCall, bool NoStretchMode)
 {
-  begin((uint8_t)address, generalCall);
+  begin((uint8_t)address, generalCall, NoStretchMode);
 }
 
 void TwoWire::end(void)

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -90,8 +90,8 @@ class TwoWire : public Stream {
     };
     void begin(bool generalCall = false);
     void begin(uint32_t, uint32_t);
-    void begin(uint8_t, bool generalCall = false);
-    void begin(int, bool generalCall = false);
+    void begin(uint8_t, bool generalCall = false, bool NoStretchMode = false);
+    void begin(int, bool generalCall = false, bool NoStretchMode = false);
     void end();
     void setClock(uint32_t);
     void beginTransmission(uint8_t);

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -766,7 +766,7 @@ void i2c_custom_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode, uint3
         handle->Init.AddressingMode  = addressingMode;
         handle->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
         handle->Init.GeneralCallMode = (obj->generalCall == 0) ? I2C_GENERALCALL_DISABLE : I2C_GENERALCALL_ENABLE;
-        handle->Init.NoStretchMode   = I2C_NOSTRETCH_DISABLE;
+        handle->Init.NoStretchMode   = (obj->NoStretchMode == 0) ? I2C_NOSTRETCH_DISABLE : I2C_NOSTRETCH_ENABLE;
 
         handle->State = HAL_I2C_STATE_RESET;
 

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -122,6 +122,7 @@ struct i2c_s {
   volatile uint8_t slaveMode;
   uint8_t isMaster;
   uint8_t generalCall;
+  uint8_t NoStretchMode;
 };
 
 ///@brief I2C state


### PR DESCRIPTION
On a few devboards running linux, dragonboard410c, pi4 etc, I am
seeing issues with i2cdetect and other i2c bash utilities where
the stm32 holds the SCL line low and hangs the bus. This seems
to fix the issue.

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>