### PR TITLE
fix: Stabilize SWD Programming for Swan (STM32L4R5)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -5828,8 +5828,8 @@ BluesW.menu.pnum.SWAN_R5.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 
 # Upload menu
 BluesW.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
-BluesW.menu.upload_method.swdMethod.upload.protocol=0
-BluesW.menu.upload_method.swdMethod.upload.options=-g -ob nBOOT0=0 -ob nBOOT0=1
+BluesW.menu.upload_method.swdMethod.upload.protocol=10
+BluesW.menu.upload_method.swdMethod.upload.options=-g
 BluesW.menu.upload_method.swdMethod.upload.tool=stm32CubeProg
 
 BluesW.menu.upload_method.serialMethod=STM32CubeProgrammer (Serial)


### PR DESCRIPTION
Previous value for `BluesW.menu.upload_method.swdMethod.upload.options` causes option bytes to become corrupted.

Fix leverages `ERASE` option provided by `stm32CubeProg.sh`, which includes `-e all` in the parameters provided to `STM32_Programmer_CLI`.