### PR TITLE
Add flags about fpv4 for cortex-m33 on platformio-build.py

### DIFF
--- a/tools/platformio/platformio-build.py
+++ b/tools/platformio/platformio-build.py
@@ -158,7 +158,7 @@ def configure_application_offset(mcu, upload_protocol):
 
 
 if (
-    any(cpu in board_config.get("build.cpu") for cpu in ("cortex-m4", "cortex-m7"))
+    any(cpu in board_config.get("build.cpu") for cpu in ("cortex-m33", "cortex-m4", "cortex-m7"))
     and "stm32wl" not in mcu
 ):
     env.Append(


### PR DESCRIPTION
I tried to build FreeRTOS for STM32L552ZE-Q with using PlatformIO bud failed.
https://github.com/stm32duino/STM32FreeRTOS/issues/51
However, it succeeds on Arduino IDE.

I see log of them and I found that PlatformIO does not add the following flags for arm-none-eabi-gcc and arm-none-eabi-g++.
```
-mfpu=fpv4-sp-d16
-mfloat-abi=hard
```

The modification of this PR allow building FreeRTOS for STM32L552ZE-Q on PlatformIO.
Thank you.