### PR TITLE
HardwareTimer: call refresh() after parameter update when timer not running

### DIFF
--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -151,6 +151,8 @@ class HardwareTimer {
     static void captureCompareCallback(TIM_HandleTypeDef *htim); // Generic Capture and Compare callback which will call user callback
     static void updateCallback(TIM_HandleTypeDef *htim);  // Generic Update (rollover) callback which will call user callback
 
+    void updateRegistersIfNotRunning(TIM_TypeDef *TIMx); // Take into account registers update immediately if timer is not running,
+
     bool isRunning(); // return true if HardwareTimer is running
     bool isRunningChannel(uint32_t channel); // return true if channel is running
 


### PR DESCRIPTION
**Summary**
HardwareTimer: call refresh() after parameter update when timer not running

In case timer is not running,
after an update of parameters (setOverflow(), setCaptureCompare(), setPrescaleFactor()),
call refresh() to force register update independently of Preload setting.

Fixes https://www.stm32duino.com/viewtopic.php?f=7&t=1563