### PR TITLE
Review get adc/dac/timer channel functions

### DIFF
--- a/cores/arduino/stm32/analog.h
+++ b/cores/arduino/stm32/analog.h
@@ -56,7 +56,6 @@ uint16_t adc_read_value(PinName pin, uint32_t resolution);
 void pwm_start(PinName pin, uint32_t clock_freq, uint32_t value, TimerCompareFormat_t resolution);
 void pwm_stop(PinName pin);
 #endif
-uint32_t get_pwm_channel(PinName pin);
 
 #ifdef __cplusplus
 }

--- a/cores/arduino/stm32/analog.h
+++ b/cores/arduino/stm32/analog.h
@@ -49,6 +49,13 @@ extern "C" {
 #endif
 
 /* Exported functions ------------------------------------------------------- */
+#if defined(HAL_ADC_MODULE_ENABLED) && !defined(HAL_ADC_MODULE_ONLY)
+uint32_t get_adc_channel(PinName pin, uint32_t *bank);
+uint32_t get_adc_internal_channel(PinName pin);
+#endif
+#if defined(HAL_DAC_MODULE_ENABLED) && !defined(HAL_DAC_MODULE_ONLY)
+uint32_t get_dac_channel(PinName pin);
+#endif
 void dac_write_value(PinName pin, uint32_t value, uint8_t do_init);
 void dac_stop(PinName pin);
 uint16_t adc_read_value(PinName pin, uint32_t resolution);

--- a/cores/arduino/stm32/analog.h
+++ b/cores/arduino/stm32/analog.h
@@ -52,13 +52,13 @@ extern "C" {
 #if defined(HAL_ADC_MODULE_ENABLED) && !defined(HAL_ADC_MODULE_ONLY)
 uint32_t get_adc_channel(PinName pin, uint32_t *bank);
 uint32_t get_adc_internal_channel(PinName pin);
+uint16_t adc_read_value(PinName pin, uint32_t resolution);
 #endif
 #if defined(HAL_DAC_MODULE_ENABLED) && !defined(HAL_DAC_MODULE_ONLY)
 uint32_t get_dac_channel(PinName pin);
-#endif
 void dac_write_value(PinName pin, uint32_t value, uint8_t do_init);
 void dac_stop(PinName pin);
-uint16_t adc_read_value(PinName pin, uint32_t resolution);
+#endif
 #if defined(HAL_TIM_MODULE_ENABLED) && !defined(HAL_TIM_MODULE_ONLY)
 void pwm_start(PinName pin, uint32_t clock_freq, uint32_t value, TimerCompareFormat_t resolution);
 void pwm_stop(PinName pin);

--- a/cores/arduino/stm32/timer.h
+++ b/cores/arduino/stm32/timer.h
@@ -284,6 +284,8 @@ uint8_t getTimerClkSrc(TIM_TypeDef *tim);
 IRQn_Type getTimerUpIrq(TIM_TypeDef *tim);
 IRQn_Type getTimerCCIrq(TIM_TypeDef *tim);
 
+uint32_t get_pwm_channel(PinName pin);
+
 #endif /* HAL_TIM_MODULE_ENABLED && !HAL_TIM_MODULE_ONLY */
 
 #ifdef __cplusplus

--- a/cores/arduino/stm32/timer.h
+++ b/cores/arduino/stm32/timer.h
@@ -284,7 +284,7 @@ uint8_t getTimerClkSrc(TIM_TypeDef *tim);
 IRQn_Type getTimerUpIrq(TIM_TypeDef *tim);
 IRQn_Type getTimerCCIrq(TIM_TypeDef *tim);
 
-uint32_t get_pwm_channel(PinName pin);
+uint32_t getTimerChannel(PinName pin);
 
 #endif /* HAL_TIM_MODULE_ENABLED && !HAL_TIM_MODULE_ONLY */
 

--- a/libraries/SrcWrapper/src/HardwareTimer.cpp
+++ b/libraries/SrcWrapper/src/HardwareTimer.cpp
@@ -740,7 +740,7 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin)
   _ChannelMode[channel - 1] = mode;
 
   if (pin != NC) {
-    if ((int)get_pwm_channel(pin) == timChannel) {
+    if ((int)getTimerChannel(pin) == timChannel) {
       /* Configure PWM GPIO pins */
       pinmap_pinout(pin, PinMap_TIM);
 #if defined(STM32F1xx)

--- a/libraries/SrcWrapper/src/stm32/analog.cpp
+++ b/libraries/SrcWrapper/src/stm32/analog.cpp
@@ -101,8 +101,14 @@ static PinName g_current_pin = NC;
 #define ADC_REGULAR_RANK_1  1
 #endif
 
-/* Private Functions */
-static uint32_t get_adc_channel(PinName pin, uint32_t *bank)
+/* Exported Functions */
+/**
+  * @brief  Return ADC HAL channel linked to a PinName
+  * @param  pin: PinName
+  * @param  bank: pointer to get ADC channel bank if required
+  * @retval HAL channel. return 0 if pin has no ADC
+  */
+uint32_t get_adc_channel(PinName pin, uint32_t *bank)
 {
   uint32_t function = pinmap_function(pin, PinMap_ADC);
   uint32_t channel = 0;
@@ -233,7 +239,14 @@ static uint32_t get_adc_channel(PinName pin, uint32_t *bank)
   return channel;
 }
 
-static uint32_t get_adc_internal_channel(PinName pin)
+/**
+  * @brief  Return ADC HAL internal channel linked to a PinName
+  * @param  pin: specific PinName's for ADC internal. Value can be:
+  *         PADC_TEMP, PADC_TEMP_ADC5, PADC_VREF, PADC_VBAT
+  *         Note that not all of these values ​​may be available for all series.
+  * @retval HAL internal channel. return 0 if pin has no ADC internal
+  */
+uint32_t get_adc_internal_channel(PinName pin)
 {
   uint32_t channel = 0;
   switch (pin) {
@@ -271,7 +284,12 @@ static uint32_t get_adc_internal_channel(PinName pin)
 #endif /* HAL_ADC_MODULE_ENABLED && !HAL_ADC_MODULE_ONLY */
 
 #if defined(HAL_DAC_MODULE_ENABLED) && !defined(HAL_DAC_MODULE_ONLY)
-static uint32_t get_dac_channel(PinName pin)
+/**
+  * @brief  Return DAC HAL channel linked to a PinName
+  * @param  pin: specific PinName's for ADC internal.
+  * @retval HAL channel. return 0 if pin has no dac
+  */
+uint32_t get_dac_channel(PinName pin)
 {
   uint32_t function = pinmap_function(pin, PinMap_DAC);
   uint32_t channel = 0;

--- a/libraries/SrcWrapper/src/stm32/analog.cpp
+++ b/libraries/SrcWrapper/src/stm32/analog.cpp
@@ -106,7 +106,7 @@ static PinName g_current_pin = NC;
   * @brief  Return ADC HAL channel linked to a PinName
   * @param  pin: PinName
   * @param  bank: pointer to get ADC channel bank if required
-  * @retval HAL channel. return 0 if pin has no ADC
+  * @retval Valid HAL channel
   */
 uint32_t get_adc_channel(PinName pin, uint32_t *bank)
 {
@@ -224,7 +224,7 @@ uint32_t get_adc_channel(PinName pin, uint32_t *bank)
 #endif
 #endif
     default:
-      channel = 0;
+      _Error_Handler("ADC: Unknown adc channel", (int)(STM_PIN_CHANNEL(function)));
       break;
   }
 #ifdef ADC_CHANNELS_BANK_B
@@ -244,7 +244,7 @@ uint32_t get_adc_channel(PinName pin, uint32_t *bank)
   * @param  pin: specific PinName's for ADC internal. Value can be:
   *         PADC_TEMP, PADC_TEMP_ADC5, PADC_VREF, PADC_VBAT
   *         Note that not all of these values ​​may be available for all series.
-  * @retval HAL internal channel. return 0 if pin has no ADC internal
+  * @retval Valid HAL internal channel.
   */
 uint32_t get_adc_internal_channel(PinName pin)
 {
@@ -276,7 +276,7 @@ uint32_t get_adc_internal_channel(PinName pin)
       break;
 #endif
     default:
-      channel = 0;
+      _Error_Handler("ADC: Unknown adc internal PiName", (int)(pin));
       break;
   }
   return channel;
@@ -287,7 +287,7 @@ uint32_t get_adc_internal_channel(PinName pin)
 /**
   * @brief  Return DAC HAL channel linked to a PinName
   * @param  pin: specific PinName's for ADC internal.
-  * @retval HAL channel. return 0 if pin has no dac
+  * @retval Valid HAL channel
   */
 uint32_t get_dac_channel(PinName pin)
 {
@@ -308,7 +308,7 @@ uint32_t get_dac_channel(PinName pin)
       break;
 #endif
     default:
-      channel = 0;
+      _Error_Handler("DAC: Unknown dac channel", (int)(STM_PIN_CHANNEL(function)));
       break;
   }
   return channel;

--- a/libraries/SrcWrapper/src/stm32/analog.cpp
+++ b/libraries/SrcWrapper/src/stm32/analog.cpp
@@ -270,32 +270,6 @@ static uint32_t get_adc_internal_channel(PinName pin)
 }
 #endif /* HAL_ADC_MODULE_ENABLED && !HAL_ADC_MODULE_ONLY */
 
-#if defined(HAL_TIM_MODULE_ENABLED) && !defined(HAL_TIM_MODULE_ONLY)
-uint32_t get_pwm_channel(PinName pin)
-{
-  uint32_t function = pinmap_function(pin, PinMap_TIM);
-  uint32_t channel = 0;
-  switch (STM_PIN_CHANNEL(function)) {
-    case 1:
-      channel = TIM_CHANNEL_1;
-      break;
-    case 2:
-      channel = TIM_CHANNEL_2;
-      break;
-    case 3:
-      channel = TIM_CHANNEL_3;
-      break;
-    case 4:
-      channel = TIM_CHANNEL_4;
-      break;
-    default:
-      channel = 0;
-      break;
-  }
-  return channel;
-}
-#endif /* HAL_TIM_MODULE_ENABLED && !HAL_TIM_MODULE_ONLY */
-
 #if defined(HAL_DAC_MODULE_ENABLED) && !defined(HAL_DAC_MODULE_ONLY)
 static uint32_t get_dac_channel(PinName pin)
 {

--- a/libraries/SrcWrapper/src/stm32/timer.c
+++ b/libraries/SrcWrapper/src/stm32/timer.c
@@ -718,7 +718,7 @@ uint8_t getTimerClkSrc(TIM_TypeDef *tim)
 /**
   * @brief  Return HAL timer channel linked to a PinName
   * @param  pin: PinName
-  * @retval HAL channel. return 0 if pin has no timer
+  * @retval Valid HAL channel
   */
 uint32_t getTimerChannel(PinName pin)
 {
@@ -738,7 +738,7 @@ uint32_t getTimerChannel(PinName pin)
       channel = TIM_CHANNEL_4;
       break;
     default:
-      channel = 0;
+      _Error_Handler("TIM: Unknown timer channel", (int)(STM_PIN_CHANNEL(function)));
       break;
   }
   return channel;

--- a/libraries/SrcWrapper/src/stm32/timer.c
+++ b/libraries/SrcWrapper/src/stm32/timer.c
@@ -715,6 +715,34 @@ uint8_t getTimerClkSrc(TIM_TypeDef *tim)
   return clkSrc;
 }
 
+/**
+  * @brief  Return HAL timer channel linked to a PinName
+  * @param  pin: PinName
+  * @retval HAL channel. return 0 if pin has no timer
+  */
+uint32_t get_pwm_channel(PinName pin)
+{
+  uint32_t function = pinmap_function(pin, PinMap_TIM);
+  uint32_t channel = 0;
+  switch (STM_PIN_CHANNEL(function)) {
+    case 1:
+      channel = TIM_CHANNEL_1;
+      break;
+    case 2:
+      channel = TIM_CHANNEL_2;
+      break;
+    case 3:
+      channel = TIM_CHANNEL_3;
+      break;
+    case 4:
+      channel = TIM_CHANNEL_4;
+      break;
+    default:
+      channel = 0;
+      break;
+  }
+  return channel;
+}
 
 #endif /* HAL_TIM_MODULE_ENABLED && !HAL_TIM_MODULE_ONLY */
 

--- a/libraries/SrcWrapper/src/stm32/timer.c
+++ b/libraries/SrcWrapper/src/stm32/timer.c
@@ -720,7 +720,7 @@ uint8_t getTimerClkSrc(TIM_TypeDef *tim)
   * @param  pin: PinName
   * @retval HAL channel. return 0 if pin has no timer
   */
-uint32_t get_pwm_channel(PinName pin)
+uint32_t getTimerChannel(PinName pin)
 {
   uint32_t function = pinmap_function(pin, PinMap_TIM);
   uint32_t channel = 0;


### PR DESCRIPTION
This PR exports some getter api:
```
uint32_t get_adc_channel(PinName pin, uint32_t *bank);
uint32_t get_adc_internal_channel(PinName pin);
uint32_t get_dac_channel(PinName pin);
```

Fixes #1669