### PR TITLE
fix: add COM port prefix in bmp_upload pattern on Windows

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -190,6 +190,7 @@ tools.bmp_upload.upload.speed=230400
 tools.bmp_upload.upload.params.verbose=-batch
 tools.bmp_upload.upload.params.quiet=--batch-silent
 tools.bmp_upload.upload.pattern="{path}/{cmd}" -nx -b {upload.speed} {upload.verbose} -ex "set confirm off" -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "load" -ex "compare-sections" -ex "kill" "{build.path}/{build.project_name}.elf"
+tools.bmp_upload.upload.pattern.windows="{path}/{cmd}" -nx -b {upload.speed} {upload.verbose} -ex "set confirm off" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "load" -ex "compare-sections" -ex "kill" "{build.path}/{build.project_name}.elf"
 
 # HID flash 2.2 (HID bootloader v2.2 for STM32F1 and STM32F4 series)
 tools.hid_upload.cmd=hid-flash


### PR DESCRIPTION
This PR fixes the following bug

* [Black Magic Probe with a two-digit COM port on Windows won't work](https://github.com/stm32duino/Arduino_Core_STM32/issues/1377)

This PR adds a variant of upload.pattern for bmp_upload on Windows.
This variant adds the prefix \\\\.\ to the COM port.
Without this prefix, the command only works for COM ports < 10 (1 single digit).

Always adding the prefix works fine for me, @esden from the Black Magic Debug project has confirmed that there is no issue doing that.
https://github.com/blackmagic-debug/blackmagic/issues/1042#issuecomment-1149057852

Fixes #1377 
