### PR TITLE
Error management: save space when core logs are not enabled

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -7346,8 +7346,8 @@ GenU5.menu.opt.o3std=Fastest (-O3)
 GenU5.menu.opt.o3std.build.flags.optimize=-O3
 GenU5.menu.opt.o3lto=Fastest (-O3) with LTO
 GenU5.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-GenU5.menu.opt.ogstd=Debug (-g)
-GenU5.menu.opt.ogstd.build.flags.optimize=-g -Og
+GenU5.menu.opt.ogstd=Debug (-Og)
+GenU5.menu.opt.ogstd.build.flags.optimize=-Og
 GenU5.menu.opt.o0std=No Optimization (-O0)
 GenU5.menu.opt.o0std.build.flags.optimize=-O0
 

--- a/boards.txt
+++ b/boards.txt
@@ -729,7 +729,7 @@ Disco.menu.pnum.B_L475E_IOT01A.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 Disco.menu.pnum.B_L475E_IOT01A.build.board=B_L475E_IOT01A
 Disco.menu.pnum.B_L475E_IOT01A.build.series=STM32L4xx
 Disco.menu.pnum.B_L475E_IOT01A.build.product_line=STM32L475xx
-Disco.menu.pnum.B_L475E_IOT01A.build.variant=STM32L4xx//L475V(C-E-G)T_L476V(C-E-G)T_L486VGT
+Disco.menu.pnum.B_L475E_IOT01A.build.variant=STM32L4xx/L475V(C-E-G)T_L476V(C-E-G)T_L486VGT
 Disco.menu.pnum.B_L475E_IOT01A.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 Disco.menu.pnum.B_L475E_IOT01A.build.cmsis_lib_gcc=arm_cortexM4lf_math
 

--- a/boards.txt
+++ b/boards.txt
@@ -8,7 +8,7 @@ menu.xusb=USB speed (if available)
 menu.virtio=Virtual serial support
 
 menu.opt=Optimize
-menu.dbg=Debug symbols
+menu.dbg=Debug symbols and core logs
 menu.rtlib=C Runtime Library
 menu.upload_method=Upload method
 
@@ -7553,120 +7553,236 @@ Midatronics.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 Nucleo_144.menu.dbg.none=None
-Nucleo_144.menu.dbg.enable=Enabled (-g)
-Nucleo_144.menu.dbg.enable.build.flags.debug=-g
+Nucleo_144.menu.dbg.enable_sym=Symbols Enabled (-g)
+Nucleo_144.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+Nucleo_144.menu.dbg.enable_log=Core logs Enabled
+Nucleo_144.menu.dbg.enable_log.build.flags.debug=
+Nucleo_144.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+Nucleo_144.menu.dbg.enable_all.build.flags.debug=-g
 
 Nucleo_64.menu.dbg.none=None
-Nucleo_64.menu.dbg.enable=Enabled (-g)
-Nucleo_64.menu.dbg.enable.build.flags.debug=-g
+Nucleo_64.menu.dbg.enable_sym=Symbols Enabled (-g)
+Nucleo_64.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+Nucleo_64.menu.dbg.enable_log=Core logs Enabled
+Nucleo_64.menu.dbg.enable_log.build.flags.debug=
+Nucleo_64.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+Nucleo_64.menu.dbg.enable_all.build.flags.debug=-g
 
 Nucleo_32.menu.dbg.none=None
-Nucleo_32.menu.dbg.enable=Enabled (-g)
-Nucleo_32.menu.dbg.enable.build.flags.debug=-g
+Nucleo_32.menu.dbg.enable_sym=Symbols Enabled (-g)
+Nucleo_32.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+Nucleo_32.menu.dbg.enable_log=Core logs Enabled
+Nucleo_32.menu.dbg.enable_log.build.flags.debug=
+Nucleo_32.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+Nucleo_32.menu.dbg.enable_all.build.flags.debug=-g
 
 Disco.menu.dbg.none=None
-Disco.menu.dbg.enable=Enabled (-g)
-Disco.menu.dbg.enable.build.flags.debug=-g
+Disco.menu.dbg.enable_sym=Symbols Enabled (-g)
+Disco.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+Disco.menu.dbg.enable_log=Core logs Enabled
+Disco.menu.dbg.enable_log.build.flags.debug=
+Disco.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+Disco.menu.dbg.enable_all.build.flags.debug=-g
 
 Eval.menu.dbg.none=None
-Eval.menu.dbg.enable=Enabled (-g)
-Eval.menu.dbg.enable.build.flags.debug=-g
+Eval.menu.dbg.enable_sym=Symbols Enabled (-g)
+Eval.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+Eval.menu.dbg.enable_log=Core logs Enabled
+Eval.menu.dbg.enable_log.build.flags.debug=
+Eval.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+Eval.menu.dbg.enable_all.build.flags.debug=-g
 
 STM32MP1.menu.dbg.none=None
-STM32MP1.menu.dbg.enable=Enabled (-g)
-STM32MP1.menu.dbg.enable.build.flags.debug=-g
+STM32MP1.menu.dbg.enable_sym=Symbols Enabled (-g)
+STM32MP1.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+STM32MP1.menu.dbg.enable_log=Core logs Enabled
+STM32MP1.menu.dbg.enable_log.build.flags.debug=
+STM32MP1.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+STM32MP1.menu.dbg.enable_all.build.flags.debug=-g
 
 GenF0.menu.dbg.none=None
-GenF0.menu.dbg.enable=Enabled (-g)
-GenF0.menu.dbg.enable.build.flags.debug=-g
+GenF0.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenF0.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenF0.menu.dbg.enable_log=Core logs Enabled
+GenF0.menu.dbg.enable_log.build.flags.debug=
+GenF0.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenF0.menu.dbg.enable_all.build.flags.debug=-g
 
 GenF1.menu.dbg.none=None
-GenF1.menu.dbg.enable=Enabled (-g)
-GenF1.menu.dbg.enable.build.flags.debug=-g
+GenF1.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenF1.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenF1.menu.dbg.enable_log=Core logs Enabled
+GenF1.menu.dbg.enable_log.build.flags.debug=
+GenF1.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenF1.menu.dbg.enable_all.build.flags.debug=-g
 
 GenF2.menu.dbg.none=None
-GenF2.menu.dbg.enable=Enabled (-g)
-GenF2.menu.dbg.enable.build.flags.debug=-g
+GenF2.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenF2.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenF2.menu.dbg.enable_log=Core logs Enabled
+GenF2.menu.dbg.enable_log.build.flags.debug=
+GenF2.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenF2.menu.dbg.enable_all.build.flags.debug=-g
 
 GenF3.menu.dbg.none=None
-GenF3.menu.dbg.enable=Enabled (-g)
-GenF3.menu.dbg.enable.build.flags.debug=-g
+GenF3.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenF3.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenF3.menu.dbg.enable_log=Core logs Enabled
+GenF3.menu.dbg.enable_log.build.flags.debug=
+GenF3.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenF3.menu.dbg.enable_all.build.flags.debug=-g
 
 GenF4.menu.dbg.none=None
-GenF4.menu.dbg.enable=Enabled (-g)
-GenF4.menu.dbg.enable.build.flags.debug=-g
+GenF4.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenF4.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenF4.menu.dbg.enable_log=Core logs Enabled
+GenF4.menu.dbg.enable_log.build.flags.debug=
+GenF4.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenF4.menu.dbg.enable_all.build.flags.debug=-g
 
 GenF7.menu.dbg.none=None
-GenF7.menu.dbg.enable=Enabled (-g)
-GenF7.menu.dbg.enable.build.flags.debug=-g
+GenF7.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenF7.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenF7.menu.dbg.enable_log=Core logs Enabled
+GenF7.menu.dbg.enable_log.build.flags.debug=
+GenF7.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenF7.menu.dbg.enable_all.build.flags.debug=-g
 
 GenG0.menu.dbg.none=None
-GenG0.menu.dbg.enable=Enabled (-g)
-GenG0.menu.dbg.enable.build.flags.debug=-g
+GenG0.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenG0.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenG0.menu.dbg.enable_log=Core logs Enabled
+GenG0.menu.dbg.enable_log.build.flags.debug=
+GenG0.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenG0.menu.dbg.enable_all.build.flags.debug=-g
 
 GenG4.menu.dbg.none=None
-GenG4.menu.dbg.enable=Enabled (-g)
-GenG4.menu.dbg.enable.build.flags.debug=-g
+GenG4.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenG4.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenG4.menu.dbg.enable_log=Core logs Enabled
+GenG4.menu.dbg.enable_log.build.flags.debug=
+GenG4.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenG4.menu.dbg.enable_all.build.flags.debug=-g
 
 GenH7.menu.dbg.none=None
-GenH7.menu.dbg.enable=Enabled (-g)
-GenH7.menu.dbg.enable.build.flags.debug=-g
+GenH7.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenH7.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenH7.menu.dbg.enable_log=Core logs Enabled
+GenH7.menu.dbg.enable_log.build.flags.debug=
+GenH7.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenH7.menu.dbg.enable_all.build.flags.debug=-g
 
 GenL0.menu.dbg.none=None
-GenL0.menu.dbg.enable=Enabled (-g)
-GenL0.menu.dbg.enable.build.flags.debug=-g
+GenL0.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenL0.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenL0.menu.dbg.enable_log=Core logs Enabled
+GenL0.menu.dbg.enable_log.build.flags.debug=
+GenL0.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenL0.menu.dbg.enable_all.build.flags.debug=-g
 
 GenL1.menu.dbg.none=None
-GenL1.menu.dbg.enable=Enabled (-g)
-GenL1.menu.dbg.enable.build.flags.debug=-g
+GenL1.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenL1.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenL1.menu.dbg.enable_log=Core logs Enabled
+GenL1.menu.dbg.enable_log.build.flags.debug=
+GenL1.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenL1.menu.dbg.enable_all.build.flags.debug=-g
 
 GenL4.menu.dbg.none=None
-GenL4.menu.dbg.enable=Enabled (-g)
-GenL4.menu.dbg.enable.build.flags.debug=-g
+GenL4.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenL4.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenL4.menu.dbg.enable_log=Core logs Enabled
+GenL4.menu.dbg.enable_log.build.flags.debug=
+GenL4.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenL4.menu.dbg.enable_all.build.flags.debug=-g
 
 GenL5.menu.dbg.none=None
-GenL5.menu.dbg.enable=Enabled (-g)
-GenL5.menu.dbg.enable.build.flags.debug=-g
+GenL5.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenL5.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenL5.menu.dbg.enable_log=Core logs Enabled
+GenL5.menu.dbg.enable_log.build.flags.debug=
+GenL5.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenL5.menu.dbg.enable_all.build.flags.debug=-g
 
 GenWB.menu.dbg.none=None
-GenWB.menu.dbg.enable=Enabled (-g)
-GenWB.menu.dbg.enable.build.flags.debug=-g
+GenWB.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenWB.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenWB.menu.dbg.enable_log=Core logs Enabled
+GenWB.menu.dbg.enable_log.build.flags.debug=
+GenWB.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenWB.menu.dbg.enable_all.build.flags.debug=-g
 
 GenWL.menu.dbg.none=None
-GenWL.menu.dbg.enable=Enabled (-g)
-GenWL.menu.dbg.enable.build.flags.debug=-g
+GenWL.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenWL.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenWL.menu.dbg.enable_log=Core logs Enabled
+GenWL.menu.dbg.enable_log.build.flags.debug=
+GenWL.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenWL.menu.dbg.enable_all.build.flags.debug=-g
 
 3dprinter.menu.dbg.none=None
-3dprinter.menu.dbg.enable=Enabled (-g)
-3dprinter.menu.dbg.enable.build.flags.debug=-g
+3dprinter.menu.dbg.enable_sym=Symbols Enabled (-g)
+3dprinter.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+3dprinter.menu.dbg.enable_log=Core logs Enabled
+3dprinter.menu.dbg.enable_log.build.flags.debug=
+3dprinter.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+3dprinter.menu.dbg.enable_all.build.flags.debug=-g
 
 BluesW.menu.dbg.none=None
-BluesW.menu.dbg.enable=Enabled (-g)
-BluesW.menu.dbg.enable.build.flags.debug=-g
+BluesW.menu.dbg.enable_sym=Symbols Enabled (-g)
+BluesW.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+BluesW.menu.dbg.enable_log=Core logs Enabled
+BluesW.menu.dbg.enable_log.build.flags.debug=
+BluesW.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+BluesW.menu.dbg.enable_all.build.flags.debug=-g
 
 Elecgator.menu.dbg.none=None
-Elecgator.menu.dbg.enable=Enabled (-g)
-Elecgator.menu.dbg.enable.build.flags.debug=-g
+Elecgator.menu.dbg.enable_sym=Symbols Enabled (-g)
+Elecgator.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+Elecgator.menu.dbg.enable_log=Core logs Enabled
+Elecgator.menu.dbg.enable_log.build.flags.debug=
+Elecgator.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+Elecgator.menu.dbg.enable_all.build.flags.debug=-g
 
 ESC_board.menu.dbg.none=None
-ESC_board.menu.dbg.enable=Enabled (-g)
-ESC_board.menu.dbg.enable.build.flags.debug=-g
+ESC_board.menu.dbg.enable_sym=Symbols Enabled (-g)
+ESC_board.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+ESC_board.menu.dbg.enable_log=Core logs Enabled
+ESC_board.menu.dbg.enable_log.build.flags.debug=
+ESC_board.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+ESC_board.menu.dbg.enable_all.build.flags.debug=-g
 
 Garatronic.menu.dbg.none=None
-Garatronic.menu.dbg.enable=Enabled (-g)
-Garatronic.menu.dbg.enable.build.flags.debug=-g
+Garatronic.menu.dbg.enable_sym=Symbols Enabled (-g)
+Garatronic.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+Garatronic.menu.dbg.enable_log=Core logs Enabled
+Garatronic.menu.dbg.enable_log.build.flags.debug=
+Garatronic.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+Garatronic.menu.dbg.enable_all.build.flags.debug=-g
 
 GenFlight.menu.dbg.none=None
-GenFlight.menu.dbg.enable=Enabled (-g)
-GenFlight.menu.dbg.enable.build.flags.debug=-g
+GenFlight.menu.dbg.enable_sym=Symbols Enabled (-g)
+GenFlight.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+GenFlight.menu.dbg.enable_log=Core logs Enabled
+GenFlight.menu.dbg.enable_log.build.flags.debug=
+GenFlight.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+GenFlight.menu.dbg.enable_all.build.flags.debug=-g
 
 LoRa.menu.dbg.none=None
-LoRa.menu.dbg.enable=Enabled (-g)
-LoRa.menu.dbg.enable.build.flags.debug=-g
+LoRa.menu.dbg.enable_sym=Symbols Enabled (-g)
+LoRa.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+LoRa.menu.dbg.enable_log=Core logs Enabled
+LoRa.menu.dbg.enable_log.build.flags.debug=
+LoRa.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+LoRa.menu.dbg.enable_all.build.flags.debug=-g
 
 Midatronics.menu.dbg.none=None
-Midatronics.menu.dbg.enable=Enabled (-g)
-Midatronics.menu.dbg.enable.build.flags.debug=-g
+Midatronics.menu.dbg.enable_sym=Symbols Enabled (-g)
+Midatronics.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+Midatronics.menu.dbg.enable_log=Core logs Enabled
+Midatronics.menu.dbg.enable_log.build.flags.debug=
+Midatronics.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+Midatronics.menu.dbg.enable_all.build.flags.debug=-g
 
 # C Runtime Library
 Nucleo_144.menu.rtlib.nano=Newlib Nano (default)

--- a/cores/arduino/core_debug.h
+++ b/cores/arduino/core_debug.h
@@ -1,9 +1,9 @@
 #ifndef _CORE_DEBUG_H
 #define _CORE_DEBUG_H
-#ifdef CORE_DEBUG
+#if !defined(NDEBUG)
   #include <stdio.h>
   #include <stdarg.h>
-#endif /* CORE_DEBUG */
+#endif /* NDEBUG */
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,14 +18,14 @@ extern "C" {
  */
 static inline void core_debug(const char *format, ...)
 {
-#ifdef CORE_DEBUG
+#if !defined(NDEBUG)
   va_list args;
   va_start(args, format);
   vfprintf(stderr, format, args);
   va_end(args);
 #else
   (void)(format);
-#endif /* CORE_DEBUG */
+#endif /* NDEBUG */
 }
 
 #ifdef __cplusplus

--- a/cores/arduino/stm32/stm32_def.h
+++ b/cores/arduino/stm32/stm32_def.h
@@ -104,9 +104,22 @@ extern "C" {
 // weaked functions declaration
 void SystemClock_Config(void);
 
+#if defined(NDEBUG)
+#if !defined(_Error_Handler)
+#define _Error_Handler(str, value) \
+  while (1) {\
+  }
+#endif
+#if !defined(Error_Handler)
+#define Error_Handler() \
+  while (1) {\
+  }
+#endif
+#else
 void _Error_Handler(const char *, int);
 
 #define Error_Handler() _Error_Handler(__FILE__, __LINE__)
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/libraries/SrcWrapper/src/stm32/stm32_def.c
+++ b/libraries/SrcWrapper/src/stm32/stm32_def.c
@@ -10,6 +10,7 @@ extern "C" {
   * @param  None
   * @retval None
   */
+#if !defined(NDEBUG)
 WEAK void _Error_Handler(const char *msg, int val)
 {
   /* User can add his own implementation to report the HAL error return state */
@@ -17,6 +18,7 @@ WEAK void _Error_Handler(const char *msg, int val)
   while (1) {
   }
 }
+#endif
 
 #ifdef __cplusplus
 }

--- a/platform.txt
+++ b/platform.txt
@@ -120,9 +120,9 @@ build.opt.path={build.path}/sketch/{build.opt.name}
 
 extras.path={build.system.path}/extras
 
-# Create empty {build.opt} if not exists in the output sketch dir and force include of SrcWrapper library
-recipe.hooks.prebuild.1.pattern="{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}"
-recipe.hooks.prebuild.1.pattern.windows="{runtime.tools.STM32Tools.path}/win/busybox.exe" sh "{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}"
+# Create {build.opt} if not exists in the output sketch dir and force include of SrcWrapper library
+recipe.hooks.prebuild.1.pattern="{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}" "{runtime.platform.path}"
+recipe.hooks.prebuild.1.pattern.windows="{runtime.tools.STM32Tools.path}/win/busybox.exe" sh "{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}" "{runtime.platform.path}"
 
 # compile patterns
 # ---------------------

--- a/platform.txt
+++ b/platform.txt
@@ -110,7 +110,7 @@ build.peripheral_pins=
 build.startup_file=
 build.flags.fp=
 build.flags.optimize=-Os
-build.flags.debug=
+build.flags.debug=-DNDEBUG
 build.flags.ldspecs=--specs=nano.specs
 build.flash_offset=0
 

--- a/system/extras/prebuild.sh
+++ b/system/extras/prebuild.sh
@@ -2,6 +2,7 @@
 
 BUILD_PATH="$1"
 BUILD_SOURCE_PATH="$2"
+BOARD_PLATFORM_PATH="$3"
 
 # Create sketch dir if not exists
 if [ ! -f "$BUILD_PATH/sketch" ]; then
@@ -17,6 +18,11 @@ else
   # See https://github.com/arduino/arduino-cli/issues/1338
   cp "$BUILD_SOURCE_PATH/build_opt.h" "$BUILD_PATH/sketch/build.opt"
 fi
+
+# Append -fmacro-prefix-map option to change __FILE__ absolute path of the board
+# platform folder to a relative path by using '.'.
+# (i.e. the folder containing boards.txt)
+printf '\n-fmacro-prefix-map=%s=.' "${BOARD_PLATFORM_PATH//\\/\\\\}" > "$BUILD_PATH/sketch/build.opt"
 
 # Force include of SrcWrapper library
 echo "#include <SrcWrapper.h>" > "$BUILD_PATH/sketch/SrcWrapper.cpp"

--- a/variants/STM32MP1xx/MP153AAC_MP153CAC_MP153DAC_MP153FAC_MP157AAC_MP157CAC_MP157DAC_MP157FAC/README.md
+++ b/variants/STM32MP1xx/MP153AAC_MP153CAC_MP153DAC_MP153FAC_MP157AAC_MP157CAC_MP157DAC_MP157FAC/README.md
@@ -157,17 +157,18 @@ After loading Arduino, You can use SerialVirtIO in two ways in this example:
 
 For printf-style debugging, `core_debug()` is highly recommended instead of using Arduino Serial. In STM32MP1, `core_debug()` utilizes OpenAMP trace buffer and it has a minimal real-time impact (other than the overhead of printf) because it is not bound to the speed of a hardware IO peripheral while printing it.
 
-Create [build_opt.h] in the sketch directory and simply put `-DCORE_DEBUG`. Additionally you can resize the buffer size of logging by redefining `VIRTIO_LOG_BUFFER_SIZE` (2kb by default). As an example you can create a file like the following:
+Select `Core logs Enabled` in `Tools->Debug symbols and core logs`.
+Additionally you can resize the buffer size of logging by redefining `VIRTIO_LOG_BUFFER_SIZE` (2kb by default).
+Create [build_opt.h] in the sketch directory and simply put `-DVIRTIO_LOG_BUFFER_SIZE=xxxx`. As an example you can create a file like the following:
 
 ```
 build_opt.h (in the same directory of your Sketch)
 -----------------------------
 
--DCORE_DEBUG
 -DVIRTIO_LOG_BUFFER_SIZE=4086
 ```
 
-Don't forget to change any of Arduino IDE option to reflect this as in the warning section in [build_opt.h description in wiki]. This is important because if `-DCORE_DEBUG` is not configured correctly `core_debug()` silently becomes an empty function without triggering any build error. Don't forget to add `#include "core_debug.h"` in your code in order to use `core_debug()`.
+Don't forget to add `#include "core_debug.h"` in your code in order to use `core_debug()`.
 
 Also, you must enable the Virtual Serial (described in the above section) and include `SerialVirtIO.begin();` in your Arduino sketch, because this logging feature is tightly coupled to OpenAMP virtio.
 
@@ -201,7 +202,7 @@ void loop() {
 }
 ```
 
-Don't forget to add [build_opt.h] described above.
+Don't forget to select `Core logs Enabled` in `Tools->Debug symbols and core logs` as described above.
 
 After loading Arduino, you can simply `sh run_arduino_<sketch name>.sh log` to print the current `core_debug()` logs.
 


### PR DESCRIPTION
This PR refactor the core debug log management:
- Add menu entries to enable the Core logs:
![image](https://user-images.githubusercontent.com/20641798/173871922-cd9dd120-707b-4c64-9138-538c0294697f.png)
- Remove `CORE_DEBUG` usage as replaced by the menu.
- Refactor error handler definition to save space when core logs are not enabled (removed unused const char array from .rodata).
   When core logs are not enable, `NDEBUG` is defined and used to prevent  print from `Error_Handler` thanks to `core_debug.`

### Build result of AnalogReadSerial.ino for NucleoWL55JC1
* Before this PR:

> Sketch uses 18780 bytes (7%) of program storage space. Maximum is 262144 bytes.
> Global variables use 896 bytes (1%) of dynamic memory, leaving 64640 bytes for local variables. Maximum is 65536 bytes.


* With this PR and Core logs disabled:

> Sketch uses 17832 bytes (6%) of program storage space. Maximum is 262144 bytes.
> Global variables use 896 bytes (1%) of dynamic memory, leaving 64640 bytes for local variables. Maximum is 65536 bytes.

* With this PR and Core logs enabled:

> Sketch uses 24012 bytes (9%) of program storage space. Maximum is 262144 bytes.
> Global variables use 1108 bytes (1%) of dynamic memory, leaving 64428 bytes for local variables. Maximum is 65536 bytes.

Finally, to reduce const char array size from .rodata and also having the same binary size whatever the core location. 
`__FILE__` has been shorten to be relative to the core path  using `-fmacro-prefix-map` option. It simply replaces absolute core path by `.`
See https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html

Ex: 
```
AnalogReadSerial.ino.elf:     file format elf32-littlearm

Contents of section .rodata:
 8005d6c 433a5c53 544d3332 5c617264 75696e6f  C:\STM32\arduino
 8005d7c 5c617264 75696e6f 2d312e38 2e31395c  \arduino-1.8.19\
 8005d8c 706f7274 61626c65 5c706163 6b616765  portable\package
 8005d9c 735c5354 4d696372 6f656c65 6374726f  s\STMicroelectro
 8005dac 6e696373 5c686172 64776172 655c7374  nics\hardware\st
 8005dbc 6d33325c 322e322e 305c6c69 62726172  m32\2.2.0\librar
 8005dcc 6965735c 53726357 72617070 65725c73  ies\SrcWrapper\s
 8005ddc 72635c48 61726477 61726554 696d6572  rc\HardwareTimer
 8005dec 2e637070 00040208 00101010 04101010  .cpp............

```
to:
```
AnalogReadSerial.ino.elf:     file format elf32-littlearm

Contents of section .rodata:
 8005d6c 2e5c6c69 62726172 6965735c 53726357  .\libraries\SrcW
 8005d7c 72617070 65725c73 72635c48 61726477  rapper\src\Hardw
 8005d8c 61726554 696d6572 2e637070 00040208  areTimer.cpp....
```


* With this PR and Core logs enabled and shorten `__FILE__ `:

> Sketch uses 23572 bytes (8%) of program storage space. Maximum is 262144 bytes.
> Global variables use 1108 bytes (1%) of dynamic memory, leaving 64428 bytes for local variables. Maximum is 65536 bytes.
> 

N.B. to check .rodata contents:
`arm-none-eabi-objdump.exe -s -j .rodata *.elf`

N.B.2: huge size of the binary is mainly due to the libc `printf()` usage. Maybe a tiny printf implementation could be done to decrease it.