### PR TITLE
variant: G0: add Nucleo-G070RB

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart:  | STM32F401RE | [Nucleo F401RE](http://www.st.com/en/evaluation-tools/nucleo-f401re.html) | *0.2.1* |  |
 | :green_heart:  | STM32F411RE | [Nucleo F411RE](http://www.st.com/en/evaluation-tools/nucleo-f411re.html) | *0.2.1* |  |
 | :green_heart:  | STM32F446RE | [Nucleo F446RE](http://www.st.com/en/evaluation-tools/nucleo-f446re.html) | *1.1.1* |  |
+| :yellow_heart:  | STM32G070RB | [Nucleo G070RB](https://www.st.com/en/evaluation-tools/nucleo-g070rb.html) | **2.3.0** |  |
 | :green_heart:  | STM32G071RB | [Nucleo G071RB](https://www.st.com/en/evaluation-tools/nucleo-g071rb.html) | *1.6.0* |  |
 | :green_heart:  | STM32G0B1RE | [Nucleo G0B1RE](https://www.st.com/en/evaluation-tools/nucleo-g0b1re.html) | *2.1.0* |  |
 | :green_heart:  | STM32G431RB | [Nucleo G431RB](https://www.st.com/en/evaluation-tools/nucleo-g431rb.html) | *1.7.0* |  |

--- a/boards.txt
+++ b/boards.txt
@@ -349,6 +349,19 @@ Nucleo_64.menu.pnum.NUCLEO_F446RE.build.product_line=STM32F446xx
 Nucleo_64.menu.pnum.NUCLEO_F446RE.build.variant=STM32F4xx/F446R(C-E)T
 Nucleo_64.menu.pnum.NUCLEO_F446RE.build.cmsis_lib_gcc=arm_cortexM4lf_math
 
+# NUCLEO_G070RB board
+Nucleo_64.menu.pnum.NUCLEO_G070RB=Nucleo G070RB
+Nucleo_64.menu.pnum.NUCLEO_G070RB.node=NODE_G070RB
+Nucleo_64.menu.pnum.NUCLEO_G070RB.upload.maximum_size=131072
+Nucleo_64.menu.pnum.NUCLEO_G070RB.upload.maximum_data_size=36864
+Nucleo_64.menu.pnum.NUCLEO_G070RB.build.mcu=cortex-m0plus
+Nucleo_64.menu.pnum.NUCLEO_G070RB.build.board=NUCLEO_G070RB
+Nucleo_64.menu.pnum.NUCLEO_G070RB.build.series=STM32G0xx
+Nucleo_64.menu.pnum.NUCLEO_G070RB.build.product_line=STM32G070xx
+Nucleo_64.menu.pnum.NUCLEO_G070RB.build.variant=STM32G0xx/G070RBT
+Nucleo_64.menu.pnum.NUCLEO_G070RB.build.cmsis_lib_gcc=arm_cortexM0l_math
+Nucleo_64.menu.pnum.NUCLEO_G070RB.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -D__CORTEX_SC=0
+
 # NUCLEO_G071RB board
 Nucleo_64.menu.pnum.NUCLEO_G071RB=Nucleo G071RB
 Nucleo_64.menu.pnum.NUCLEO_G071RB.node=NODE_G071RB

--- a/variants/STM32G0xx/G070RBT/variant_NUCLEO_G070RB.cpp
+++ b/variants/STM32G0xx/G070RBT/variant_NUCLEO_G070RB.cpp
@@ -1,0 +1,160 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2022, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+#if defined(ARDUINO_NUCLEO_G070RB)
+#include "pins_arduino.h"
+
+// Pin number
+const PinName digitalPin[] = {
+  PC_5,
+  PC_4,
+  PA_10,
+  PB_3,
+  PB_5,
+  PB_4,
+  PB_14,
+  PA_8,
+  PA_9,
+  PC_7,
+  PB_0,
+  PA_7,
+  PA_6,
+  PA_5,
+  PB_9,
+  PB_8,
+  // ST Morpho
+  // CN7 Left Side
+  PC_10,
+  PC_12,
+  PA_14,
+  PD_0,
+  PD_3,
+  PA_13,
+  PD_4,
+  PA_15,
+  PB_7,
+  PC_13,
+  PC_14,
+  PC_15,
+  PF_0,
+  PF_1,
+  PC_2,
+  PC_3,
+  // CN7 Right Side
+  PC_11,
+  PD_2,
+  PD_1,
+  PD_5,
+  // CN10 Left Side
+  PC_9,
+  // CN10 Right side
+  PC_8,
+  PC_6,
+  PA_3,
+  PD_6,
+  PA_11,
+  PA_12,
+  PC_1,
+  PC_0,
+  PB_2,
+  PB_6,
+  PB_15,
+  PB_10,
+  PB_13,
+  PA_2,
+  PD_8,
+  PD_9,
+  PA_0,
+  PA_1,
+  PA_4,
+  PB_1,
+  PB_11,
+  PB_12,
+  PF_2,
+  PA_9_R,
+  PA_10_R
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInputPin[] = {
+  53, //A0
+  54, //A1
+  55, //A2
+  56, //A3
+  57, //A4
+  58, //A5
+  11, //A6
+  12, //A7
+  45, //A8
+  48, //A9
+  0,  //A10
+  1,  //A11
+  10, //A12
+  13, //A13 - LED
+  39, //A14 - STLINK RX
+  50  //A15 - STLINK TX
+};
+
+// ----------------------------------------------------------------------------
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief  System Clock Configuration
+  * @param  None
+  * @retval None
+  */
+WEAK void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {};
+
+  /** Configure the main internal regulator output voltage
+  */
+  HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1);
+  /** Initializes the RCC Oscillators according to the specified parameters
+  * in the RCC_OscInitTypeDef structure.
+  */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.HSIDiv = RCC_HSI_DIV1;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+  RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV1;
+  RCC_OscInitStruct.PLL.PLLN = 8;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+  RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+  /** Initializes the CPU, AHB and APB buses clocks
+  */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK
+                                | RCC_CLOCKTYPE_PCLK1;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK) {
+    Error_Handler();
+  }
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ARDUINO_NUCLEO_G070RB */

--- a/variants/STM32G0xx/G070RBT/variant_NUCLEO_G070RB.h
+++ b/variants/STM32G0xx/G070RBT/variant_NUCLEO_G070RB.h
@@ -1,0 +1,168 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2022, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#pragma once
+
+/*----------------------------------------------------------------------------
+ *        STM32 pins number
+ *----------------------------------------------------------------------------*/
+#define PC5                     PIN_A10
+#define PC4                     PIN_A11
+#define PA10                    2
+#define PB3                     3
+#define PB5                     4
+#define PB4                     5
+#define PB14                    6
+#define PA8                     7
+#define PA9                     8
+#define PC7                     9
+#define PB0                     PIN_A12
+#define PA7                     PIN_A6
+#define PA6                     PIN_A7
+#define PA5                     PIN_A13 // LED
+#define PB9                     14
+#define PB8                     15
+// ST Morpho
+// CN7 Left Side
+#define PC10                    16
+#define PC12                    17
+#define PA14                    18 // SWD
+#define PD0                     19
+#define PD3                     20
+#define PA13                    21 // SWD
+#define PD4                     22
+#define PA15                    23
+#define PB7                     24
+#define PC13                    25
+#define PC14                    26
+#define PC15                    27
+#define PF0                     28
+#define PF1                     29
+#define PC2                     30
+#define PC3                     31
+// CN7 Right Side
+#define PC11                    32
+#define PD2                     33
+#define PD1                     34
+#define PD5                     35
+// CN10 Left Side
+#define PC9                     36
+// CN10 Right side
+#define PC8                     37
+#define PC6                     38
+#define PA3                     PIN_A14
+#define PD6                     40
+#define PA11                    41
+#define PA12                    42
+#define PC1                     43
+#define PC0                     44
+#define PB2                     PIN_A8
+#define PB6                     46
+#define PB15                    47
+#define PB10                    PIN_A9
+#define PB13                    49
+#define PA2                     PIN_A15
+#define PD8                     51
+#define PD9                     52
+#define PA0                     PIN_A0
+#define PA1                     PIN_A1
+#define PA4                     PIN_A2
+#define PB1                     PIN_A3
+#define PB11                    PIN_A4
+#define PB12                    PIN_A5
+#define PF2                     59
+#define PA9_R                   60
+#define PA10_R                  61
+
+// Alternate pins number
+#define PA6_ALT1                (PA6  | ALT1)
+#define PA7_ALT1                (PA7  | ALT1)
+#define PA7_ALT2                (PA7  | ALT2)
+#define PA7_ALT3                (PA7  | ALT3)
+#define PA15_ALT1               (PA15 | ALT1)
+#define PB0_ALT1                (PB0  | ALT1)
+#define PB1_ALT1                (PB1  | ALT1)
+#define PB1_ALT2                (PB1  | ALT2)
+#define PB6_ALT1                (PB6  | ALT1)
+#define PB13_ALT1               (PB13 | ALT1)
+#define PB14_ALT1               (PB14 | ALT1)
+#define PB15_ALT1               (PB15 | ALT1)
+#define PB15_ALT2               (PB15 | ALT2)
+#define PC4_ALT1                (PC4  | ALT1)
+#define PC5_ALT1                (PC5  | ALT1)
+#define PC8_ALT1                (PC8  | ALT1)
+#define PC9_ALT1                (PC9  | ALT1)
+#define PC10_ALT1               (PC10 | ALT1)
+#define PC11_ALT1               (PC11 | ALT1)
+
+#define NUM_DIGITAL_PINS        62
+#define NUM_REMAP_PINS          2
+#define NUM_ANALOG_INPUTS       16
+
+// On-board LED pin number
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN           PA5
+#endif
+#define LED_GREEN               LED_BUILTIN
+
+// On-board user button
+#ifndef USER_BTN
+  #define USER_BTN              PC13
+#endif
+
+// Timer Definitions
+// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
+#ifndef TIMER_TONE
+  #define TIMER_TONE            TIM6
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO           TIM7
+#endif
+
+// UART Definitions
+#ifndef SERIAL_UART_INSTANCE
+  #define SERIAL_UART_INSTANCE  2 //Connected to ST-Link
+#endif
+
+// Default pin used for 'Serial' instance (ex: ST-Link)
+// Mandatory for Firmata
+#ifndef PIN_SERIAL_RX
+  #define PIN_SERIAL_RX         PA3
+#endif
+#ifndef PIN_SERIAL_TX
+  #define PIN_SERIAL_TX         PA2
+#endif
+
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+  // These serial port names are intended to allow libraries and architecture-neutral
+  // sketches to automatically default to the correct port name for a particular type
+  // of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+  // the first hardware serial port whose RX/TX pins are not dedicated to another use.
+  //
+  // SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+  //
+  // SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+  //
+  // SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+  //
+  // SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+  //
+  // SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+  //                            pins are NOT connected to anything by default.
+  #define SERIAL_PORT_MONITOR   Serial
+  #define SERIAL_PORT_HARDWARE  Serial2
+#endif


### PR DESCRIPTION
[Nucleo_g070rb
](https://www.st.com/en/evaluation-tools/nucleo-g070rb.html)
### **Tested:**
 

- GPIO
- U(S)ART
- ADC
- DAC
- I2C
- SPI
- Timer
- RTC
- Low Power
- EEPROM

Fixes #1147 and fixes #1651