### PR TITLE
Add functionality to ignore library examples in CI for PlatformIO

### DIFF
--- a/CI/build/platformio-builder.py
+++ b/CI/build/platformio-builder.py
@@ -3,6 +3,12 @@ import os
 import subprocess
 import sys
 
+# Libraries that are not meant to be checked in CI by default
+DEFAULT_IGNORED_LIBRARIES = (
+    "keyboard",
+    "mouse"
+)
+
 
 def run_platformio(example_path, boards):
     return subprocess.call(
@@ -10,9 +16,13 @@ def run_platformio(example_path, boards):
     )
 
 
-def collect_examples(libs_dir):
+def collect_examples(libs_dir, ignored_libraries=None):
+    ignored_libraries = ignored_libraries or []
     examples = []
     for lib in os.listdir(libs_dir):
+        if lib.lower() in ignored_libraries:
+            print(f"Skipping examples from the `{lib}` library...")
+            continue
         lib_dir = os.path.join(libs_dir, lib)
         examples_dir = os.path.join(lib_dir, "examples")
         if os.path.isdir(examples_dir):
@@ -27,6 +37,9 @@ parser = argparse.ArgumentParser(description="Basic PlatformIO runner")
 parser.add_argument(
     "-b", "--board", action="append", help="board ID used for PlatformIO project"
 )
+parser.add_argument(
+    "-i", "--ignore-library", action="append", help="Library name to ignore when collecting project examples"
+)
 
 
 def main():
@@ -35,8 +48,12 @@ def main():
     if boards is None:
         boards = ["nucleo_f401re"]
 
+    ignored_libraries = args.ignore_library
+    if ignored_libraries is None:
+        ignored_libraries = DEFAULT_IGNORED_LIBRARIES
+
     libs_dir = os.path.join(os.environ["GITHUB_WORKSPACE"], "libraries")
-    if any(run_platformio(example, boards) for example in collect_examples(libs_dir)):
+    if any(run_platformio(example, boards) for example in collect_examples(libs_dir, ignored_libraries)):
         sys.exit(1)
 
 


### PR DESCRIPTION
By default `Keyboard` and `Mouse` libraries are skipped as they may require additional configuration steps

Related #1743