### PR TITLE
Print and debug improvements

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -277,6 +277,17 @@ int Print::printf(const __FlashStringHelper *format, ...)
   return retval;
 }
 
+int Print::vprintf(const char *format, va_list ap)
+{
+  return vdprintf((int)this, format, ap);
+}
+
+int Print::vprintf(const __FlashStringHelper *format, va_list ap)
+{
+  return vdprintf((int)this, (const char *)format, ap);
+}
+
+
 // Private Methods /////////////////////////////////////////////////////////////
 
 size_t Print::printNumber(unsigned long n, uint8_t base)

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -106,6 +106,8 @@ class Print {
 
     int printf(const char *format, ...);
     int printf(const __FlashStringHelper *format, ...);
+    int vprintf(const __FlashStringHelper *format, va_list ap);
+    int vprintf(const char *format, va_list ap);
 
     virtual void flush() { /* Empty implementation for backward compatibility */ }
 };

--- a/cores/arduino/core_debug.c
+++ b/cores/arduino/core_debug.c
@@ -1,0 +1,5 @@
+#include "core_debug.h"
+
+// Ensure inline functions have a definition emitted for when they are
+// not inlined (needed for C functions only)
+extern void core_debug(const char *format, ...);

--- a/cores/arduino/core_debug.c
+++ b/cores/arduino/core_debug.c
@@ -3,3 +3,4 @@
 // Ensure inline functions have a definition emitted for when they are
 // not inlined (needed for C functions only)
 extern void core_debug(const char *format, ...);
+extern void vcore_debug(const char *format, va_list args);

--- a/cores/arduino/core_debug.h
+++ b/cores/arduino/core_debug.h
@@ -1,8 +1,9 @@
 #ifndef _CORE_DEBUG_H
 #define _CORE_DEBUG_H
+
+#include <stdarg.h>
 #if !defined(NDEBUG)
   #include <stdio.h>
-  #include <stdarg.h>
 #endif /* NDEBUG */
 
 #ifdef __cplusplus
@@ -25,6 +26,16 @@ inline void core_debug(const char *format, ...)
   va_end(args);
 #else
   (void)(format);
+#endif /* NDEBUG */
+}
+
+inline void vcore_debug(const char *format, va_list args)
+{
+#if !defined(NDEBUG)
+  vfprintf(stderr, format, args);
+#else
+  (void)(format);
+  (void)(args);
 #endif /* NDEBUG */
 }
 

--- a/cores/arduino/core_debug.h
+++ b/cores/arduino/core_debug.h
@@ -16,7 +16,7 @@ extern "C" {
  * the code, use a lot of stack. An alternative, will be to implement a tiny
  * and limited functionality implementation of printf.
  */
-static inline void core_debug(const char *format, ...)
+inline void core_debug(const char *format, ...)
 {
 #if !defined(NDEBUG)
   va_list args;


### PR DESCRIPTION
**Summary**

This PR makes some changes to the printing/printf code, both in the Print class and in `core_debug`.

The main change that I needed is to add a "v" version of the `core_debug()` function. Like `vprintf` vs `printf`, the `vcore_debug` function does not accept individual arguments to interpolate into format string, but a `va_list` instance. This allows it to be called from another function that is itself a varargs function and forwards its variable arguments.

I originally thought I needed this for `Print::printf`, so I implemented `Print::vprintf` too. I ended up using `core_debug()` instead, but the `vprintf()` implementation might be useful for others (and adds zero code space if unused), so I just added it.

Finally, when looking at the `core_debug()` code, I noticed the function was `static` and declared in a header file, which causes it to potentially take up a lot more flash space than needed, so I fixed that as well. See the commit message for details.