### PR TITLE
ci(arduino-lint): fix new error raised by new version 1.2.1

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -20,6 +20,9 @@ Nucleo_144.build.core=arduino
 Nucleo_144.build.board=Nucleo_144
 Nucleo_144.build.variant_h=variant_{build.board}.h
 Nucleo_144.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+Nucleo_144.upload.tool.default=massStorageCopy
+Nucleo_144.upload.maximum_size=0
+Nucleo_144.upload.maximum_data_size=0
 
 # NUCLEO_F207ZG board
 Nucleo_144.menu.pnum.NUCLEO_F207ZG=Nucleo F207ZG
@@ -235,6 +238,9 @@ Nucleo_64.build.core=arduino
 Nucleo_64.build.board=Nucleo_64
 Nucleo_64.build.variant_h=variant_{build.board}.h
 Nucleo_64.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+Nucleo_64.upload.tool.default=massStorageCopy
+Nucleo_64.upload.maximum_size=0
+Nucleo_64.upload.maximum_data_size=0
 
 # NUCLEO_F030R8 board
 Nucleo_64.menu.pnum.NUCLEO_F030R8=Nucleo F030R8
@@ -596,6 +602,9 @@ Nucleo_32.build.core=arduino
 Nucleo_32.build.board=Nucleo_32
 Nucleo_32.build.variant_h=variant_{build.board}.h
 Nucleo_32.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+Nucleo_32.upload.tool.default=massStorageCopy
+Nucleo_32.upload.maximum_size=0
+Nucleo_32.upload.maximum_data_size=0
 
 # NUCLEO_F031K6 board
 Nucleo_32.menu.pnum.NUCLEO_F031K6=Nucleo F031K6
@@ -731,6 +740,9 @@ Disco.build.core=arduino
 Disco.build.board=Disco
 Disco.build.variant_h=variant_{build.board}.h
 Disco.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+Disco.upload.tool.default=massStorageCopy
+Disco.upload.maximum_size=0
+Disco.upload.maximum_data_size=0
 
 # B_G431B_ESC1 board
 Disco.menu.pnum.B_G431B_ESC1=B-G431B-ESC1
@@ -957,6 +969,9 @@ Eval.build.core=arduino
 Eval.build.board=Eval
 Eval.build.variant_h=variant_{build.board}.h
 Eval.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+Eval.upload.tool.default=stm32CubeProg
+Eval.upload.maximum_size=0
+Eval.upload.maximum_data_size=0
 
 # STEVAL_MKSBOX1V1 board
 Eval.menu.pnum.STEVAL_MKSBOX1V1=SensorTile.box
@@ -987,6 +1002,9 @@ Eval.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 # STM32MP1 microprocessor series (MPU + MCU)
 
 STM32MP1.name=STM32MP1 series coprocessor
+STM32MP1.upload.tool.default=remoteproc_gen
+STM32MP1.upload.maximum_size=0
+STM32MP1.upload.maximum_data_size=0
 
 STM32MP1.build.core=arduino
 STM32MP1.build.board=STM32MP1
@@ -1032,6 +1050,9 @@ GenF0.build.mcu=cortex-m0
 GenF0.build.series=STM32F0xx
 GenF0.build.cmsis_lib_gcc=arm_cortexM0l_math
 GenF0.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+GenF0.upload.tool.default=stm32CubeProg
+GenF0.upload.maximum_size=0
+GenF0.upload.maximum_data_size=0
 
 # DEMO_F030F4 board
 GenF0.menu.pnum.DEMO_F030F4=STM32F030F4 Demo board (HSE 8Mhz)
@@ -1302,6 +1323,9 @@ GenF1.build.mcu=cortex-m3
 GenF1.build.series=STM32F1xx
 GenF1.build.cmsis_lib_gcc=arm_cortexM3l_math
 GenF1.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
+GenF1.upload.tool.default=stm32CubeProg
+GenF1.upload.maximum_size=0
+GenF1.upload.maximum_data_size=0
 
 # BLUEPILL_F103C6 board
 GenF1.menu.pnum.BLUEPILL_F103C6=BluePill F103C6 (32K)
@@ -1910,6 +1934,9 @@ GenF2.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSer
 GenF2.build.mcu=cortex-m3
 GenF2.build.series=STM32F2xx
 GenF2.build.cmsis_lib_gcc=arm_cortexM3l_math
+GenF2.upload.tool.default=stm32CubeProg
+GenF2.upload.maximum_size=0
+GenF2.upload.maximum_data_size=0
 
 # Generic F207ZCTx
 GenF2.menu.pnum.GENERIC_F207ZCTX=Generic F207ZCTx
@@ -1988,6 +2015,9 @@ GenF3.build.fpu=-mfpu=fpv4-sp-d16
 GenF3.build.float-abi=-mfloat-abi=hard
 GenF3.build.series=STM32F3xx
 GenF3.build.cmsis_lib_gcc=arm_cortexM4lf_math
+GenF3.upload.tool.default=stm32CubeProg
+GenF3.upload.maximum_size=0
+GenF3.upload.maximum_data_size=0
 
 # BLACKPILL_F303CC
 GenF3.menu.pnum.BLACKPILL_F303CC=RobotDyn BlackPill F303CC
@@ -2160,6 +2190,9 @@ GenF4.build.fpu=-mfpu=fpv4-sp-d16
 GenF4.build.float-abi=-mfloat-abi=hard
 GenF4.build.series=STM32F4xx
 GenF4.build.cmsis_lib_gcc=arm_cortexM4lf_math
+GenF4.upload.tool.default=stm32CubeProg
+GenF4.upload.maximum_size=0
+GenF4.upload.maximum_data_size=0
 
 # Black F407VE
 # https://github.com/mcauser/BLACK_F407VEZ
@@ -2960,6 +2993,9 @@ GenF7.build.fpu=-mfpu=fpv4-sp-d16
 GenF7.build.float-abi=-mfloat-abi=hard
 GenF7.build.series=STM32F7xx
 GenF7.build.cmsis_lib_gcc=arm_cortexM7lfsp_math
+GenF7.upload.tool.default=stm32CubeProg
+GenF7.upload.maximum_size=0
+GenF7.upload.maximum_data_size=0
 
 # Generic F722RCTx
 GenF7.menu.pnum.GENERIC_F722RCTX=Generic F722RCTx
@@ -3347,6 +3383,9 @@ GenG0.build.mcu=cortex-m0plus
 GenG0.build.series=STM32G0xx
 GenG0.build.cmsis_lib_gcc=arm_cortexM0l_math
 GenG0.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -D__CORTEX_SC=0
+GenG0.upload.tool.default=stm32CubeProg
+GenG0.upload.maximum_size=0
+GenG0.upload.maximum_data_size=0
 
 # AGAFIA SG0
 GenG0.menu.pnum.AGAFIA_SG0=AGAFIA SG0
@@ -3794,6 +3833,9 @@ GenG4.build.fpu=-mfpu=fpv4-sp-d16
 GenG4.build.float-abi=-mfloat-abi=hard
 GenG4.build.series=STM32G4xx
 GenG4.build.cmsis_lib_gcc=arm_cortexM4lf_math
+GenG4.upload.tool.default=stm32CubeProg
+GenG4.upload.maximum_size=0
+GenG4.upload.maximum_data_size=0
 
 # Generic G431C6Ux
 GenG4.menu.pnum.GENERIC_G431C6UX=Generic G431C6Ux
@@ -4114,6 +4156,9 @@ GenH7.build.fpu=-mfpu=fpv4-sp-d16
 GenH7.build.float-abi=-mfloat-abi=hard
 GenH7.build.series=STM32H7xx
 GenH7.build.mcu=cortex-m7
+GenH7.upload.tool.default=stm32CubeProg
+GenH7.upload.maximum_size=0
+GenH7.upload.maximum_data_size=0
 
 # Daisy Seed board
 GenH7.menu.pnum.DAISY_SEED=Daisy Seed
@@ -4494,6 +4539,9 @@ GenL0.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSer
 GenL0.build.mcu=cortex-m0plus
 GenL0.build.series=STM32L0xx
 GenL0.build.cmsis_lib_gcc=arm_cortexM0l_math
+GenL0.upload.tool.default=stm32CubeProg
+GenL0.upload.maximum_size=0
+GenL0.upload.maximum_data_size=0
 
 # ThunderPack
 GenL0.menu.pnum.THUNDERPACK_L072=ThunderPack v1.0
@@ -4769,6 +4817,9 @@ GenL1.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSer
 GenL1.build.mcu=cortex-m3
 GenL1.build.series=STM32L1xx
 GenL1.build.cmsis_lib_gcc=arm_cortexM3l_math
+GenL1.upload.tool.default=stm32CubeProg
+GenL1.upload.maximum_size=0
+GenL1.upload.maximum_data_size=0
 
 # Generic L100C6Ux
 GenL1.menu.pnum.GENERIC_L100C6UX=Generic L100C6Ux
@@ -5030,6 +5081,9 @@ GenL4.build.fpu=-mfpu=fpv4-sp-d16
 GenL4.build.float-abi=-mfloat-abi=hard
 GenL4.build.series=STM32L4xx
 GenL4.build.cmsis_lib_gcc=arm_cortexM4lf_math
+GenL4.upload.tool.default=stm32CubeProg
+GenL4.upload.maximum_size=0
+GenL4.upload.maximum_data_size=0
 
 # Generic L412K8Tx
 GenL4.menu.pnum.GENERIC_L412K8TX=Generic L412K8Tx
@@ -5627,6 +5681,9 @@ GenL5.build.fpu=-mfpu=fpv4-sp-d16
 GenL5.build.float-abi=-mfloat-abi=hard
 GenL5.build.series=STM32L5xx
 GenL5.build.cmsis_lib_gcc=arm_ARMv8MMLlfsp_math
+GenL5.upload.tool.default=stm32CubeProg
+GenL5.upload.maximum_size=0
+GenL5.upload.maximum_data_size=0
 
 # Generic L552ZCTxQ
 GenL5.menu.pnum.GENERIC_L552ZCTXQ=Generic L552ZCTxQ
@@ -5680,6 +5737,9 @@ GenU5.build.fpu=-mfpu=fpv4-sp-d16
 GenU5.build.float-abi=-mfloat-abi=hard
 GenU5.build.series=STM32U5xx
 GenU5.build.cmsis_lib_gcc=arm_ARMv8MMLlfsp_math
+GenU5.upload.tool.default=stm32CubeProg
+GenU5.upload.maximum_size=0
+GenU5.upload.maximum_data_size=0
 
 # Generic U575AGIxQ
 GenU5.menu.pnum.GENERIC_U575AGIXQ=Generic U575AGIxQ
@@ -5757,6 +5817,9 @@ GenWB.build.fpu=-mfpu=fpv4-sp-d16
 GenWB.build.float-abi=-mfloat-abi=hard
 GenWB.build.series=STM32WBxx
 GenWB.build.cmsis_lib_gcc=arm_cortexM4lf_math
+GenWB.upload.tool.default=stm32CubeProg
+GenWB.upload.maximum_size=0
+GenWB.upload.maximum_data_size=0
 
 # Generic WB55CCUx
 GenWB.menu.pnum.GENERIC_WB55CCUX=Generic WB55CCUx
@@ -5842,6 +5905,9 @@ GenWL.build.mcu=cortex-m4
 #GenWL.build.float-abi=-mfloat-abi=hard
 GenWL.build.series=STM32WLxx
 GenWL.build.cmsis_lib_gcc=arm_cortexM4l_math
+GenWL.upload.tool.default=stm32CubeProg
+GenWL.upload.maximum_size=0
+GenWL.upload.maximum_data_size=0
 
 # Generic node SE by The Things Industries
 GenWL.menu.pnum.GENERIC_NODE_SE_TTI=Generic Node SE (TTI)
@@ -6005,6 +6071,9 @@ GenWL.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.build.board=3dprinter
 3dprinter.build.variant_h=variant_{build.board}.h
 3dprinter.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+3dprinter.upload.tool.default=stm32CubeProg
+3dprinter.upload.maximum_size=0
+3dprinter.upload.maximum_data_size=0
 
 # ARMED_V1 board
 3dprinter.menu.pnum.ARMED_V1=Armed V1
@@ -6206,6 +6275,9 @@ BluesW.build.core=arduino
 BluesW.build.board=BluesWireless
 BluesW.build.variant_h=variant_{build.board}.h
 BluesW.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+BluesW.upload.tool.default=stm32CubeProg
+BluesW.upload.maximum_size=0
+BluesW.upload.maximum_data_size=0
 
 # Swan R5 board
 BluesW.menu.pnum.SWAN_R5=Swan R5
@@ -6246,6 +6318,9 @@ Elecgator.build.core=arduino
 Elecgator.build.board=elecgator
 Elecgator.build.variant_h=variant_{build.board}.h
 Elecgator.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+Elecgator.upload.tool.default=stm32CubeProg
+Elecgator.upload.maximum_size=0
+Elecgator.upload.maximum_data_size=0
 
 # EtherCATduino board
 Elecgator.menu.pnum.ETHERCAT_DUINO=EtherCATduino
@@ -6281,6 +6356,9 @@ ESC_board.build.core=arduino
 ESC_board.build.board=FCE_board
 ESC_board.build.variant_h=variant_{build.board}.h
 ESC_board.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+ESC_board.upload.tool.default=stm32CubeProg
+ESC_board.upload.maximum_size=0
+ESC_board.upload.maximum_data_size=0
 
 # WRAITH32_V1 board
 ESC_board.menu.pnum.WRAITH32_V1=Wraith V1 ESC
@@ -6331,6 +6409,9 @@ Garatronic.build.core=arduino
 Garatronic.build.board=Garatronic
 Garatronic.build.variant_h=variant_{build.board}.h
 Garatronic.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+Garatronic.upload.tool.default=stm32CubeProg
+Garatronic.upload.maximum_size=0
+Garatronic.upload.maximum_data_size=0
 
 # PYBSTICK26(DUINO) board with F072RB
 Garatronic.menu.pnum.PYBSTICK26_DUINO=PYBSTICK26 Duino
@@ -6401,6 +6482,9 @@ GenFlight.build.core=arduino
 GenFlight.build.board=Genericflight
 GenFlight.build.variant_h=variant_{build.board}.h
 GenFlight.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
+GenFlight.upload.tool.default=stm32CubeProg
+GenFlight.upload.maximum_size=0
+GenFlight.upload.maximum_data_size=0
 
 # AfroFlight Rev5
 GenFlight.menu.pnum.AFROFLIGHT_F103CB=Afro Flight Rev5 (8MHz)
@@ -6489,6 +6573,9 @@ LoRa.build.core=arduino
 LoRa.build.board=LoRa
 LoRa.build.variant_h=variant_{build.board}.h
 LoRa.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+LoRa.upload.tool.default=stm32CubeProg
+LoRa.upload.maximum_size=0
+LoRa.upload.maximum_data_size=0
 
 # ACSIP S76S board
 LoRa.menu.pnum.ACSIP_S76S=ACSIP S76S
@@ -6593,6 +6680,9 @@ Midatronics.build.core=arduino
 Midatronics.build.board=Midatronics
 Midatronics.build.variant_h=variant_{build.board}.h
 Midatronics.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+Midatronics.upload.tool.default=massStorageCopy
+Midatronics.upload.maximum_size=0
+Midatronics.upload.maximum_data_size=0
 
 # MKR_SHARKY board
 Midatronics.menu.pnum.MKR_SHARKY=MKR Sharky

--- a/platform.txt
+++ b/platform.txt
@@ -108,6 +108,9 @@ build.flags.optimize=-Os
 build.flags.debug=-DNDEBUG
 build.flags.ldspecs=--specs=nano.specs
 build.flash_offset=0
+# Default upload config for stm32CubeProg (SWD)
+upload.protocol=0
+upload.options=-g
 
 # Pre and post build hooks
 build.opt.name=build.opt


### PR DESCRIPTION
```
Linting platform in STMicroelectronics\hardware\stm32\2.3.0
ERROR: Missing upload.tool.<protocol_name> property for board ID(s) Nucleo_144, Nucleo_64, Nucleo_32, Disco, Eval,
       STM32MP1, GenF0, GenF1, GenF2, GenF3, GenF4, GenF7, GenG0, GenG4, GenH7, GenL0, GenL1, GenL4, GenL5, GenU5,
       GenWB, GenWL, 3dprinter, BluesW, Elecgator, ESC_board, Garatronic, GenFlight, LoRa, Midatronics
       See: https://arduino.github.io/arduino-cli/latest/platform-specification/#sketch-upload-configuration
       (Rule PF016)
WARNING: Missing upload.maximum_size property for board ID(s) Nucleo_144, Nucleo_64, Nucleo_32, Disco, Eval, STM32MP1,
         GenF0, GenF1, GenF2, GenF3, GenF4, GenF7, GenG0, GenG4, GenH7, GenL0, GenL1, GenL4, GenL5, GenU5, GenWB, GenWL,
         3dprinter, BluesW, Elecgator, ESC_board, Garatronic, GenFlight, LoRa, Midatronics
         See: https://arduino.github.io/arduino-cli/latest/platform-specification/#recipes-to-compute-binary-sketch-size
         (Rule PF018)
WARNING: Missing upload.maximum_data_size property for board ID(s) Nucleo_144, Nucleo_64, Nucleo_32, Disco, Eval,
         STM32MP1, GenF0, GenF1, GenF2, GenF3, GenF4, GenF7, GenG0, GenG4, GenH7, GenL0, GenL1, GenL4, GenL5, GenU5,
         GenWB, GenWL, 3dprinter, BluesW, Elecgator, ESC_board, Garatronic, GenFlight, LoRa, Midatronics
         See: https://arduino.github.io/arduino-cli/latest/platform-specification/#recipes-to-compute-binary-sketch-size
         (Rule PF020)

Linter results for project: 1 ERRORS, 2 WARNINGS
```

 
