### PR TITLE
Fix for ADC timing for NUCLEO-WL55JC (STM32WLxx)

### DIFF
--- a/libraries/SrcWrapper/src/stm32/analog.cpp
+++ b/libraries/SrcWrapper/src/stm32/analog.cpp
@@ -898,7 +898,7 @@ uint16_t adc_read_value(PinName pin, uint32_t resolution)
 #if defined(STM32F0xx)
   AdcHandle.Init.SamplingTimeCommon    = samplingTime;
 #endif
-#if defined(STM32G0xx)
+#if defined(STM32G0xx) || defined(STM32WLxx)
   AdcHandle.Init.SamplingTimeCommon1   = samplingTime;              /* Set sampling time common to a group of channels. */
   AdcHandle.Init.SamplingTimeCommon2   = samplingTime;              /* Set sampling time common to a group of channels, second common setting possible.*/
 #endif


### PR DESCRIPTION
<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [X] Bug

**Motivation**

When using the STM32Examples (internal channels) sketch to read the internal ADC values from the NUCLEO-WL55JC (STM32WLxx) the following is observed:

VRef(mv)= 3223  Temp(°C)= -92   Vbat(mv)= 598   A0(mv)= 0
VRef(mv)= 3274  Temp(°C)= -88   Vbat(mv)= 606   A0(mv)= 0
VRef(mv)= 3223  Temp(°C)= -91   Vbat(mv)= 597   A0(mv)= 0

Note that VRef is a little on the low side for USB power and that Temp provides an implausible and erroneous negative number. Vbat is also somewhat questionable.

With the small fix applied the following is observed:

VRef(mv)= 3308  Temp(°C)= 28    Vbat(mv)= 1109  A0(mv)= 0
VRef(mv)= 3310  Temp(°C)= 28    Vbat(mv)= 1110  A0(mv)= 0
VRef(mv)= 3313  Temp(°C)= 29    Vbat(mv)= 1110  A0(mv)= 0

Note that VRef reads more or less correct and that Temp presents a value more aligned with ambient room temperature. Vbat also appears more realistic.

**Validation**

* Tested on NUCLEO-WL55JC
