### PR TITLE
arduino-lint 1.2.1 requirements fix prevents upload with arduino-cli

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -17,3 +17,5 @@ jobs:
 
       - name: Arduino Lint
         uses: arduino/arduino-lint-action@v1
+        with:
+          version: 1.2.0

--- a/boards.txt
+++ b/boards.txt
@@ -20,7 +20,6 @@ Nucleo_144.build.core=arduino
 Nucleo_144.build.board=Nucleo_144
 Nucleo_144.build.variant_h=variant_{build.board}.h
 Nucleo_144.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-Nucleo_144.upload.tool.default=massStorageCopy
 Nucleo_144.upload.maximum_size=0
 Nucleo_144.upload.maximum_data_size=0
 
@@ -238,7 +237,6 @@ Nucleo_64.build.core=arduino
 Nucleo_64.build.board=Nucleo_64
 Nucleo_64.build.variant_h=variant_{build.board}.h
 Nucleo_64.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-Nucleo_64.upload.tool.default=massStorageCopy
 Nucleo_64.upload.maximum_size=0
 Nucleo_64.upload.maximum_data_size=0
 
@@ -602,7 +600,6 @@ Nucleo_32.build.core=arduino
 Nucleo_32.build.board=Nucleo_32
 Nucleo_32.build.variant_h=variant_{build.board}.h
 Nucleo_32.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-Nucleo_32.upload.tool.default=massStorageCopy
 Nucleo_32.upload.maximum_size=0
 Nucleo_32.upload.maximum_data_size=0
 
@@ -740,7 +737,6 @@ Disco.build.core=arduino
 Disco.build.board=Disco
 Disco.build.variant_h=variant_{build.board}.h
 Disco.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-Disco.upload.tool.default=massStorageCopy
 Disco.upload.maximum_size=0
 Disco.upload.maximum_data_size=0
 
@@ -969,7 +965,6 @@ Eval.build.core=arduino
 Eval.build.board=Eval
 Eval.build.variant_h=variant_{build.board}.h
 Eval.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-Eval.upload.tool.default=stm32CubeProg
 Eval.upload.maximum_size=0
 Eval.upload.maximum_data_size=0
 
@@ -1002,7 +997,6 @@ Eval.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 # STM32MP1 microprocessor series (MPU + MCU)
 
 STM32MP1.name=STM32MP1 series coprocessor
-STM32MP1.upload.tool.default=remoteproc_gen
 STM32MP1.upload.maximum_size=0
 STM32MP1.upload.maximum_data_size=0
 
@@ -1050,7 +1044,6 @@ GenF0.build.mcu=cortex-m0
 GenF0.build.series=STM32F0xx
 GenF0.build.cmsis_lib_gcc=arm_cortexM0l_math
 GenF0.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-GenF0.upload.tool.default=stm32CubeProg
 GenF0.upload.maximum_size=0
 GenF0.upload.maximum_data_size=0
 
@@ -1323,7 +1316,6 @@ GenF1.build.mcu=cortex-m3
 GenF1.build.series=STM32F1xx
 GenF1.build.cmsis_lib_gcc=arm_cortexM3l_math
 GenF1.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
-GenF1.upload.tool.default=stm32CubeProg
 GenF1.upload.maximum_size=0
 GenF1.upload.maximum_data_size=0
 
@@ -1934,7 +1926,6 @@ GenF2.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSer
 GenF2.build.mcu=cortex-m3
 GenF2.build.series=STM32F2xx
 GenF2.build.cmsis_lib_gcc=arm_cortexM3l_math
-GenF2.upload.tool.default=stm32CubeProg
 GenF2.upload.maximum_size=0
 GenF2.upload.maximum_data_size=0
 
@@ -2015,7 +2006,6 @@ GenF3.build.fpu=-mfpu=fpv4-sp-d16
 GenF3.build.float-abi=-mfloat-abi=hard
 GenF3.build.series=STM32F3xx
 GenF3.build.cmsis_lib_gcc=arm_cortexM4lf_math
-GenF3.upload.tool.default=stm32CubeProg
 GenF3.upload.maximum_size=0
 GenF3.upload.maximum_data_size=0
 
@@ -2190,7 +2180,6 @@ GenF4.build.fpu=-mfpu=fpv4-sp-d16
 GenF4.build.float-abi=-mfloat-abi=hard
 GenF4.build.series=STM32F4xx
 GenF4.build.cmsis_lib_gcc=arm_cortexM4lf_math
-GenF4.upload.tool.default=stm32CubeProg
 GenF4.upload.maximum_size=0
 GenF4.upload.maximum_data_size=0
 
@@ -2993,7 +2982,6 @@ GenF7.build.fpu=-mfpu=fpv4-sp-d16
 GenF7.build.float-abi=-mfloat-abi=hard
 GenF7.build.series=STM32F7xx
 GenF7.build.cmsis_lib_gcc=arm_cortexM7lfsp_math
-GenF7.upload.tool.default=stm32CubeProg
 GenF7.upload.maximum_size=0
 GenF7.upload.maximum_data_size=0
 
@@ -3383,7 +3371,6 @@ GenG0.build.mcu=cortex-m0plus
 GenG0.build.series=STM32G0xx
 GenG0.build.cmsis_lib_gcc=arm_cortexM0l_math
 GenG0.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -D__CORTEX_SC=0
-GenG0.upload.tool.default=stm32CubeProg
 GenG0.upload.maximum_size=0
 GenG0.upload.maximum_data_size=0
 
@@ -3833,7 +3820,6 @@ GenG4.build.fpu=-mfpu=fpv4-sp-d16
 GenG4.build.float-abi=-mfloat-abi=hard
 GenG4.build.series=STM32G4xx
 GenG4.build.cmsis_lib_gcc=arm_cortexM4lf_math
-GenG4.upload.tool.default=stm32CubeProg
 GenG4.upload.maximum_size=0
 GenG4.upload.maximum_data_size=0
 
@@ -4156,7 +4142,6 @@ GenH7.build.fpu=-mfpu=fpv4-sp-d16
 GenH7.build.float-abi=-mfloat-abi=hard
 GenH7.build.series=STM32H7xx
 GenH7.build.mcu=cortex-m7
-GenH7.upload.tool.default=stm32CubeProg
 GenH7.upload.maximum_size=0
 GenH7.upload.maximum_data_size=0
 
@@ -4539,7 +4524,6 @@ GenL0.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSer
 GenL0.build.mcu=cortex-m0plus
 GenL0.build.series=STM32L0xx
 GenL0.build.cmsis_lib_gcc=arm_cortexM0l_math
-GenL0.upload.tool.default=stm32CubeProg
 GenL0.upload.maximum_size=0
 GenL0.upload.maximum_data_size=0
 
@@ -4817,7 +4801,6 @@ GenL1.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSer
 GenL1.build.mcu=cortex-m3
 GenL1.build.series=STM32L1xx
 GenL1.build.cmsis_lib_gcc=arm_cortexM3l_math
-GenL1.upload.tool.default=stm32CubeProg
 GenL1.upload.maximum_size=0
 GenL1.upload.maximum_data_size=0
 
@@ -5081,7 +5064,6 @@ GenL4.build.fpu=-mfpu=fpv4-sp-d16
 GenL4.build.float-abi=-mfloat-abi=hard
 GenL4.build.series=STM32L4xx
 GenL4.build.cmsis_lib_gcc=arm_cortexM4lf_math
-GenL4.upload.tool.default=stm32CubeProg
 GenL4.upload.maximum_size=0
 GenL4.upload.maximum_data_size=0
 
@@ -5681,7 +5663,6 @@ GenL5.build.fpu=-mfpu=fpv4-sp-d16
 GenL5.build.float-abi=-mfloat-abi=hard
 GenL5.build.series=STM32L5xx
 GenL5.build.cmsis_lib_gcc=arm_ARMv8MMLlfsp_math
-GenL5.upload.tool.default=stm32CubeProg
 GenL5.upload.maximum_size=0
 GenL5.upload.maximum_data_size=0
 
@@ -5737,7 +5718,6 @@ GenU5.build.fpu=-mfpu=fpv4-sp-d16
 GenU5.build.float-abi=-mfloat-abi=hard
 GenU5.build.series=STM32U5xx
 GenU5.build.cmsis_lib_gcc=arm_ARMv8MMLlfsp_math
-GenU5.upload.tool.default=stm32CubeProg
 GenU5.upload.maximum_size=0
 GenU5.upload.maximum_data_size=0
 
@@ -5817,7 +5797,6 @@ GenWB.build.fpu=-mfpu=fpv4-sp-d16
 GenWB.build.float-abi=-mfloat-abi=hard
 GenWB.build.series=STM32WBxx
 GenWB.build.cmsis_lib_gcc=arm_cortexM4lf_math
-GenWB.upload.tool.default=stm32CubeProg
 GenWB.upload.maximum_size=0
 GenWB.upload.maximum_data_size=0
 
@@ -5905,7 +5884,6 @@ GenWL.build.mcu=cortex-m4
 #GenWL.build.float-abi=-mfloat-abi=hard
 GenWL.build.series=STM32WLxx
 GenWL.build.cmsis_lib_gcc=arm_cortexM4l_math
-GenWL.upload.tool.default=stm32CubeProg
 GenWL.upload.maximum_size=0
 GenWL.upload.maximum_data_size=0
 
@@ -6071,7 +6049,6 @@ GenWL.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
 3dprinter.build.board=3dprinter
 3dprinter.build.variant_h=variant_{build.board}.h
 3dprinter.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-3dprinter.upload.tool.default=stm32CubeProg
 3dprinter.upload.maximum_size=0
 3dprinter.upload.maximum_data_size=0
 
@@ -6275,7 +6252,6 @@ BluesW.build.core=arduino
 BluesW.build.board=BluesWireless
 BluesW.build.variant_h=variant_{build.board}.h
 BluesW.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-BluesW.upload.tool.default=stm32CubeProg
 BluesW.upload.maximum_size=0
 BluesW.upload.maximum_data_size=0
 
@@ -6318,7 +6294,6 @@ Elecgator.build.core=arduino
 Elecgator.build.board=elecgator
 Elecgator.build.variant_h=variant_{build.board}.h
 Elecgator.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-Elecgator.upload.tool.default=stm32CubeProg
 Elecgator.upload.maximum_size=0
 Elecgator.upload.maximum_data_size=0
 
@@ -6356,7 +6331,6 @@ ESC_board.build.core=arduino
 ESC_board.build.board=FCE_board
 ESC_board.build.variant_h=variant_{build.board}.h
 ESC_board.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-ESC_board.upload.tool.default=stm32CubeProg
 ESC_board.upload.maximum_size=0
 ESC_board.upload.maximum_data_size=0
 
@@ -6409,7 +6383,6 @@ Garatronic.build.core=arduino
 Garatronic.build.board=Garatronic
 Garatronic.build.variant_h=variant_{build.board}.h
 Garatronic.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-Garatronic.upload.tool.default=stm32CubeProg
 Garatronic.upload.maximum_size=0
 Garatronic.upload.maximum_data_size=0
 
@@ -6482,7 +6455,6 @@ GenFlight.build.core=arduino
 GenFlight.build.board=Genericflight
 GenFlight.build.variant_h=variant_{build.board}.h
 GenFlight.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} {build.bootloader_flags}
-GenFlight.upload.tool.default=stm32CubeProg
 GenFlight.upload.maximum_size=0
 GenFlight.upload.maximum_data_size=0
 
@@ -6573,7 +6545,6 @@ LoRa.build.core=arduino
 LoRa.build.board=LoRa
 LoRa.build.variant_h=variant_{build.board}.h
 LoRa.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-LoRa.upload.tool.default=stm32CubeProg
 LoRa.upload.maximum_size=0
 LoRa.upload.maximum_data_size=0
 
@@ -6680,7 +6651,6 @@ Midatronics.build.core=arduino
 Midatronics.build.board=Midatronics
 Midatronics.build.variant_h=variant_{build.board}.h
 Midatronics.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-Midatronics.upload.tool.default=massStorageCopy
 Midatronics.upload.maximum_size=0
 Midatronics.upload.maximum_data_size=0
 

--- a/platform.txt
+++ b/platform.txt
@@ -108,9 +108,6 @@ build.flags.optimize=-Os
 build.flags.debug=-DNDEBUG
 build.flags.ldspecs=--specs=nano.specs
 build.flash_offset=0
-# Default upload config for stm32CubeProg (SWD)
-upload.protocol=0
-upload.options=-g
 
 # Pre and post build hooks
 build.opt.name=build.opt


### PR DESCRIPTION
Currently, defining a default upload tools prevents flashing with arduino-cli as default methods is always used even if new one is passed as fqbn parameters.

See:
#1654
https://github.com/arduino/arduino-cli/issues/1444

So force usage of 1.2.0 release of the arduino-lint.