### PR TITLE
fix(SoftwareSerial):  correct TX to RX switch when using half-duplex

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -157,6 +157,8 @@ bool SoftwareSerial::listen()
     active_listener = this;
     if (!_half_duplex) {
       active_in = this;
+    } else if (!active_out) {
+      setRXTX(true);
     }
     return true;
   }


### PR DESCRIPTION
**Summary**

When working with single-pin half-duplex SoftwareSerial, I noticed that after the call to `listen()` receiving data is not possible until data is written. In fact `setRXTX(true)` is only called within `send()`, which in turn is only called as long as `active_out` is set (i.e. ongoing transmission). Since at the beginning of `listen()` completion of any ongoing transmissions is awaited, the SoftwareSerial will not actively listen before another transmission is completed.

This PR fixes/implements the following **bugs/features**

* [ ] Fixes the above behavior
* [ ] No intentional breaking changes

This occurs if the communication is not initiated by the STM32. Otherwise, one would simply call `listen()` and then send whatever will trigger the other side to respond. 

In my case, I wanted to use a second line to indicate the direction of communication (which however can not be used as a second line for full-duplex). I must admit that this is probably a very rare case, and the fix I suggest will in fact change the current behavior of calling `listen()` before sending data. However it took me a few hours to debug this and I thought I should at least mention this finding in case someone else stumbles upon it.
