### PR TITLE
fix: take into account STM32G0B0 USART IRQ multiplexing specificities

### DIFF
--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -116,7 +116,7 @@ struct serial_s {
 #elif defined(LPUART1_BASE)
 #define USART3_IRQn USART3_4_LPUART1_IRQn
 #define USART3_IRQHandler USART3_4_LPUART1_IRQHandler
-#elif defined(STM32G0B0xx)
+#elif defined(USART5_BASE)
 #define USART3_IRQn USART3_4_5_6_IRQn
 #define USART3_IRQHandler USART3_4_5_6_IRQHandler
 #else
@@ -143,9 +143,8 @@ struct serial_s {
 #define USART4_IRQn USART3_4_5_6_LPUART1_IRQn
 #elif defined(LPUART1_BASE)
 #define USART4_IRQn USART3_4_LPUART1_IRQn
-#elif defined(STM32G0B0xx)
+#elif defined(USART5_BASE)
 #define USART4_IRQn USART3_4_5_6_IRQn
-#define USART4_IRQHandler USART3_4_5_6_IRQHandler
 #else
 #define USART4_IRQn USART3_4_IRQn
 #endif
@@ -163,9 +162,8 @@ struct serial_s {
 #elif defined(STM32G0xx)
 #if defined(LPUART2_BASE)
 #define USART5_IRQn USART3_4_5_6_LPUART1_IRQn
-#elif defined(STM32G0B0xx)
+#elif defined(USART5_BASE)
 #define USART5_IRQn USART3_4_5_6_IRQn
-#define USART5_IRQHandler USART3_4_5_6_IRQHandler
 #endif
 #elif defined(STM32L0xx)
 #define USART5_IRQn USART4_5_IRQn
@@ -183,9 +181,8 @@ struct serial_s {
 #elif defined(STM32G0xx)
 #if defined(LPUART2_BASE)
 #define USART6_IRQn USART3_4_5_6_LPUART1_IRQn
-#elif defined(STM32G0B0xx)
+#elif defined(USART5_BASE)
 #define USART6_IRQn USART3_4_5_6_IRQn
-#define USART6_IRQHandler USART3_4_5_6_IRQHandler
 #endif
 #endif /* STM32F0xx */
 #endif

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -116,6 +116,9 @@ struct serial_s {
 #elif defined(LPUART1_BASE)
 #define USART3_IRQn USART3_4_LPUART1_IRQn
 #define USART3_IRQHandler USART3_4_LPUART1_IRQHandler
+#elif defined(STM32G0B0xx)
+#define USART3_IRQn USART3_4_5_6_IRQn
+#define USART3_IRQHandler USART3_4_5_6_IRQHandler
 #else
 #define USART3_IRQn USART3_4_IRQn
 #define USART3_IRQHandler USART3_4_IRQHandler
@@ -140,6 +143,9 @@ struct serial_s {
 #define USART4_IRQn USART3_4_5_6_LPUART1_IRQn
 #elif defined(LPUART1_BASE)
 #define USART4_IRQn USART3_4_LPUART1_IRQn
+#elif defined(STM32G0B0xx)
+#define USART4_IRQn USART3_4_5_6_IRQn
+#define USART4_IRQHandler USART3_4_5_6_IRQHandler
 #else
 #define USART4_IRQn USART3_4_IRQn
 #endif
@@ -157,6 +163,9 @@ struct serial_s {
 #elif defined(STM32G0xx)
 #if defined(LPUART2_BASE)
 #define USART5_IRQn USART3_4_5_6_LPUART1_IRQn
+#elif defined(STM32G0B0xx)
+#define USART5_IRQn USART3_4_5_6_IRQn
+#define USART5_IRQHandler USART3_4_5_6_IRQHandler
 #endif
 #elif defined(STM32L0xx)
 #define USART5_IRQn USART4_5_IRQn
@@ -174,6 +183,9 @@ struct serial_s {
 #elif defined(STM32G0xx)
 #if defined(LPUART2_BASE)
 #define USART6_IRQn USART3_4_5_6_LPUART1_IRQn
+#elif defined(STM32G0B0xx)
+#define USART6_IRQn USART3_4_5_6_IRQn
+#define USART6_IRQHandler USART3_4_5_6_IRQHandler
 #endif
 #endif /* STM32F0xx */
 #endif

--- a/libraries/SrcWrapper/src/stm32/uart.c
+++ b/libraries/SrcWrapper/src/stm32/uart.c
@@ -1024,7 +1024,7 @@ void USART3_IRQHandler(void)
   if (uart_handlers[UART4_INDEX] != NULL) {
     HAL_UART_IRQHandler(uart_handlers[UART4_INDEX]);
   }
-#if defined(STM32F030xC) || defined(STM32G0xx) && (defined(LPUART2_BASE) || defined(STM32G0B0xx))
+#if defined(STM32F030xC) || defined(STM32G0xx) && (defined(LPUART2_BASE) || defined(USART5_BASE))
   if (uart_handlers[UART5_INDEX] != NULL) {
     HAL_UART_IRQHandler(uart_handlers[UART5_INDEX]);
   }
@@ -1093,7 +1093,7 @@ void UART5_IRQHandler(void)
   * @param  None
   * @retval None
   */
-#if defined(USART6_BASE) && !defined(STM32F0xx) && !defined(STM32G0B0xx)
+#if defined(USART6_BASE) && !defined(STM32F0xx) && !defined(STM32G0xx)
 void USART6_IRQHandler(void)
 {
   HAL_NVIC_ClearPendingIRQ(USART6_IRQn);

--- a/libraries/SrcWrapper/src/stm32/uart.c
+++ b/libraries/SrcWrapper/src/stm32/uart.c
@@ -1024,7 +1024,7 @@ void USART3_IRQHandler(void)
   if (uart_handlers[UART4_INDEX] != NULL) {
     HAL_UART_IRQHandler(uart_handlers[UART4_INDEX]);
   }
-#if defined(STM32F030xC) || defined(STM32G0xx) && defined(LPUART2_BASE)
+#if defined(STM32F030xC) || defined(STM32G0xx) && (defined(LPUART2_BASE) || defined(STM32G0B0xx))
   if (uart_handlers[UART5_INDEX] != NULL) {
     HAL_UART_IRQHandler(uart_handlers[UART5_INDEX]);
   }
@@ -1093,7 +1093,7 @@ void UART5_IRQHandler(void)
   * @param  None
   * @retval None
   */
-#if defined(USART6_BASE) && !defined(STM32F0xx)
+#if defined(USART6_BASE) && !defined(STM32F0xx) && !defined(STM32G0B0xx)
 void USART6_IRQHandler(void)
 {
   HAL_NVIC_ClearPendingIRQ(USART6_IRQn);


### PR DESCRIPTION
**Summary**
fix: take into account STM32G0B0 USART IRQ multiplexing specificities

Fixes CI  failed compilation of PR #1784
