### PR TITLE
chore: Enable Swan `CDCgen` by default

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -7130,13 +7130,13 @@ GenWB.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 3dprinter.menu.xusb.HSFS=High Speed in Full Speed mode
 3dprinter.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 
-BluesW.menu.usb.none=None
 BluesW.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 BluesW.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 BluesW.menu.usb.CDC=CDC (no generic 'Serial')
 BluesW.menu.usb.CDC.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC -DDISABLE_GENERIC_SERIALUSB
 BluesW.menu.usb.HID=HID (keyboard and mouse)
 BluesW.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
+BluesW.menu.usb.none=None
 BluesW.menu.xusb.FS=Low/Full Speed
 BluesW.menu.xusb.HS=High Speed
 BluesW.menu.xusb.HS.build.usb_speed=-DUSE_USB_HS


### PR DESCRIPTION
To make it easier for Swan users, we have decided to enable `CDC (generic 'Serial' supersede U(S)ART)` by default. If customers wish to remove USB support to optimize their binary, they may deselect it from the menu.

## Pull Request template

Please, Make sure that your PR is not a duplicate.
Search among the [Pull request](https://github.com/stm32duino/Arduino_Core_STM32/pulls) before creating one.

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

Thanks for submitting a pull request.
Please provide enough information so that others can review your pull request:

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Validation**

* Ensure CI build is passed.
* Demonstrate the code is solid. [e.g. Provide a sketch]

<!-- Make sure tests pass on both CI. -->

**Code formatting**

* Ensure AStyle check is passed thanks CI

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #xxx
