### PR TITLE
fix: Nucleo G474RE: define LED_BUILTIN in the proper way

### DIFF
--- a/variants/STM32G4xx/G473R(B-C-E)T_G474R(B-C-E)T_G483RET_G484RET/variant_NUCLEO_G474RE.h
+++ b/variants/STM32G4xx/G473R(B-C-E)T_G474R(B-C-E)T_G483RET_G484RET/variant_NUCLEO_G474RE.h
@@ -138,10 +138,10 @@
 #define NUM_ANALOG_INPUTS       13
 
 // On-board LED pin number
+#define LED_GREEN               PA5
 #ifndef LED_BUILTIN
-  #define LED_BUILTIN           PA5
+  #define LED_BUILTIN           LED_GREEN
 #endif
-#define LED_GREEN               LED_BUILTIN
 
 // On-board user button
 #ifndef USER_BTN


### PR DESCRIPTION
fix: Nucleo G474RE: define LED_BUILTIN in the proper way