### PR TITLE
fix(SPI): SPI does not work with STM32G031J6M6

### DIFF
--- a/variants/STM32G0xx/G031J(4-6)M_G041J6M/variant_generic.h
+++ b/variants/STM32G0xx/G031J(4-6)M_G041J6M/variant_generic.h
@@ -71,7 +71,7 @@
   #define PIN_SPI_SS3           PNUM_NOT_DEFINED
 #endif
 #ifndef PIN_SPI_MOSI
-  #define PIN_SPI_MOSI          PA2
+  #define PIN_SPI_MOSI          PA12
 #endif
 #ifndef PIN_SPI_MISO
   #define PIN_SPI_MISO          PA11


### PR DESCRIPTION
The code
```
#include <SPI.h>
SPISettings spiSettings = {1000000, MSBFIRST, SPI_MODE0};

void setup() {
  SPI.begin();
  /* : */
}

void loop() {
  uint8_t recv;
  /* : */
  SPI.beginTransaction(spiSettings);
  SPI.transfer('a');
  recv = SPI.transfer(0);
  /* : */
  SPI.endTransaction();
  /* : */
}
```
does not work. SPI controller could not send and receive any data.

When using SPI with STM32G031J6M6, SPI pin is defined by
https://github.com/stm32duino/Arduino_Core_STM32/blob/bf0b3e39e1b4aa3eee99ccecfd3e4a151ce7fffb/variants/STM32G0xx/G031J(4-6)M_G041J6M/variant_generic.h#L73-L81
but the definition of PIN_SPI_MOSI(PA2) is conflicted with PIN_SPI_SCK(PA1).
To use SPI1 with PA1 as SCK and PA11 as MISO, MOSI is PA12.

To avoid this, call SPI.setMOSI(PA12) before SPI.begin() like this:
```
void setup() {
  /* Change MOSI */
  SPI.setMOSI(PA12);
  SPI.begin();
}
```

More better solution is changing PIN_SPI_MOSI pin to PA12.
This change makes that does not need to call SPI.setMOSI().

**Validation**

* Tested on STM32G031J6M6