### PR TITLE
variant: F3: add Nucleo-F334R8

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart:  | STM32F103RB | [Nucleo F103RB](http://www.st.com/en/evaluation-tools/nucleo-f103rb.html) | *0.2.0* |  |
 | :green_heart:  | STM32F302R8 | [Nucleo F302R8](http://www.st.com/en/evaluation-tools/nucleo-f302r8.html) | *1.1.0* |  |
 | :green_heart:  | STM32F303RE | [Nucleo F303RE](http://www.st.com/en/evaluation-tools/nucleo-f303re.html) | *0.1.0* |  |
+| :yellow_heart:  | STM32F334R8 | [Nucleo F334R8](https://www.st.com/en/evaluation-tools/nucleo-f334r8.html) | **2.4.0** |  |
 | :green_heart:  | STM32F401RE | [Nucleo F401RE](http://www.st.com/en/evaluation-tools/nucleo-f401re.html) | *0.2.1* |  |
 | :green_heart:  | STM32F411RE | [Nucleo F411RE](http://www.st.com/en/evaluation-tools/nucleo-f411re.html) | *0.2.1* |  |
 | :green_heart:  | STM32F446RE | [Nucleo F446RE](http://www.st.com/en/evaluation-tools/nucleo-f446re.html) | *1.1.1* |  |

--- a/boards.txt
+++ b/boards.txt
@@ -328,6 +328,20 @@ Nucleo_64.menu.pnum.NUCLEO_F303RE.build.product_line=STM32F303xE
 Nucleo_64.menu.pnum.NUCLEO_F303RE.build.variant=STM32F3xx/F303R(D-E)T
 Nucleo_64.menu.pnum.NUCLEO_F303RE.build.cmsis_lib_gcc=arm_cortexM4lf_math
 
+# NUCLEO_F334R8 board
+Nucleo_64.menu.pnum.NUCLEO_F334R8=Nucleo F334R8
+Nucleo_64.menu.pnum.NUCLEO_F334R8.node=NODE_F334R8
+Nucleo_64.menu.pnum.NUCLEO_F334R8.upload.maximum_size=65536
+Nucleo_64.menu.pnum.NUCLEO_F334R8.upload.maximum_data_size=12288
+Nucleo_64.menu.pnum.NUCLEO_F334R8.build.mcu=cortex-m4
+Nucleo_64.menu.pnum.NUCLEO_F334R8.build.fpu=-mfpu=fpv4-sp-d16
+Nucleo_64.menu.pnum.NUCLEO_F334R8.build.float-abi=-mfloat-abi=hard
+Nucleo_64.menu.pnum.NUCLEO_F334R8.build.board=NUCLEO_F334R8
+Nucleo_64.menu.pnum.NUCLEO_F334R8.build.series=STM32F3xx
+Nucleo_64.menu.pnum.NUCLEO_F334R8.build.product_line=STM32F334x8
+Nucleo_64.menu.pnum.NUCLEO_F334R8.build.variant=STM32F3xx/F303R(6-8)T_F334R(6-8)T
+Nucleo_64.menu.pnum.NUCLEO_F334R8.build.cmsis_lib_gcc=arm_cortexM4lf_math
+
 # NUCLEO_F401RE board
 Nucleo_64.menu.pnum.NUCLEO_F401RE=Nucleo F401RE
 Nucleo_64.menu.pnum.NUCLEO_F401RE.node=NODE_F401RE

--- a/variants/STM32F3xx/F303R(6-8)T_F334R(6-8)T/variant_NUCLEO_F334R8.cpp
+++ b/variants/STM32F3xx/F303R(6-8)T_F334R(6-8)T/variant_NUCLEO_F334R8.cpp
@@ -1,0 +1,144 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#if defined(ARDUINO_GENERIC_F303R6TX) || defined(ARDUINO_GENERIC_F303R8TX) ||\
+    defined(ARDUINO_GENERIC_F334R6TX) || defined(ARDUINO_GENERIC_F334R8TX)
+#include "pins_arduino.h"
+
+// Digital PinName array
+const PinName digitalPin[] = {
+  PA_0,   // D0/A0
+  PA_1,   // D1/A1
+  PA_2,   // D2/A2
+  PA_3,   // D3/A3
+  PA_4,   // D4/A4
+  PA_5,   // D5/A5
+  PA_6,   // D6/A6
+  PA_7,   // D7/A7
+  PA_8,   // D8
+  PA_9,   // D9
+  PA_10,  // D10
+  PA_11,  // D11
+  PA_12,  // D12
+  PA_13,  // D13
+  PA_14,  // D14
+  PA_15,  // D15
+  PB_0,   // D16/A8
+  PB_1,   // D17/A9
+  PB_2,   // D18/A10
+  PB_3,   // D19
+  PB_4,   // D20
+  PB_5,   // D21
+  PB_6,   // D22
+  PB_7,   // D23
+  PB_8,   // D24
+  PB_9,   // D25
+  PB_10,  // D26
+  PB_11,  // D27
+  PB_12,  // D28/A11
+  PB_13,  // D29/A12
+  PB_14,  // D30/A13
+  PB_15,  // D31/A14
+  PC_0,   // D32/A15
+  PC_1,   // D33/A16
+  PC_2,   // D34/A17
+  PC_3,   // D35/A18
+  PC_4,   // D36/A19
+  PC_5,   // D37/A20
+  PC_6,   // D38
+  PC_7,   // D39
+  PC_8,   // D40
+  PC_9,   // D41
+  PC_10,  // D42
+  PC_11,  // D43
+  PC_12,  // D44
+  PC_13,  // D45
+  PC_14,  // D46
+  PC_15,  // D47
+  PD_2,   // D48
+  PF_0,   // D49
+  PF_1    // D50
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInputPin[] = {
+  0,  // A0,  PA0
+  1,  // A1,  PA1
+  2,  // A2,  PA2
+  3,  // A3,  PA3
+  4,  // A4,  PA4
+  5,  // A5,  PA5
+  6,  // A6,  PA6
+  7,  // A7,  PA7
+  16, // A8,  PB0
+  17, // A9,  PB1
+  18, // A10, PB2
+  28, // A11, PB12
+  29, // A12, PB13
+  30, // A13, PB14
+  31, // A14, PB15
+  32, // A15, PC0
+  33, // A16, PC1
+  34, // A17, PC2
+  35, // A18, PC3
+  36, // A19, PC4
+  37  // A20, PC5
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief  System Clock Configuration
+  * @param  None
+  * @retval None
+  */
+WEAK void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+
+  /** Initializes the RCC Oscillators according to the specified parameters
+  * in the RCC_OscInitTypeDef structure.
+  */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+  RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL16;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
+  {
+    Error_Handler();
+  }
+
+  /** Initializes the CPU, AHB and APB buses clocks
+  */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK
+                              |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
+  {
+    Error_Handler();
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_GENERIC_* */

--- a/variants/STM32F3xx/F303R(6-8)T_F334R(6-8)T/variant_NUCLEO_F334R8.h
+++ b/variants/STM32F3xx/F303R(6-8)T_F334R(6-8)T/variant_NUCLEO_F334R8.h
@@ -1,0 +1,192 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#pragma once
+
+/*----------------------------------------------------------------------------
+ *        STM32 pins number
+ *----------------------------------------------------------------------------*/
+#define PA0                     PIN_A0
+#define PA1                     PIN_A1
+#define PA2                     PIN_A2
+#define PA3                     PIN_A3
+#define PA4                     PIN_A4
+#define PA5                     PIN_A5
+#define PA6                     PIN_A6
+#define PA7                     PIN_A7
+#define PA8                     8
+#define PA9                     9
+#define PA10                    10
+#define PA11                    11
+#define PA12                    12
+#define PA13                    13
+#define PA14                    14
+#define PA15                    15
+#define PB0                     PIN_A8
+#define PB1                     PIN_A9
+#define PB2                     PIN_A10
+#define PB3                     19
+#define PB4                     20
+#define PB5                     21
+#define PB6                     22
+#define PB7                     23
+#define PB8                     24
+#define PB9                     25
+#define PB10                    26
+#define PB11                    27
+#define PB12                    PIN_A11
+#define PB13                    PIN_A12
+#define PB14                    PIN_A13
+#define PB15                    PIN_A14
+#define PC0                     PIN_A15
+#define PC1                     PIN_A16
+#define PC2                     PIN_A17
+#define PC3                     PIN_A18
+#define PC4                     PIN_A19
+#define PC5                     PIN_A20
+#define PC6                     38
+#define PC7                     39
+#define PC8                     40
+#define PC9                     41
+#define PC10                    42
+#define PC11                    43
+#define PC12                    44
+#define PC13                    45
+#define PC14                    46
+#define PC15                    47
+#define PD2                     48
+#define PF0                     49
+#define PF1                     50
+
+// Alternate pins number
+#define PA1_ALT1                (PA1  | ALT1)
+#define PA2_ALT1                (PA2  | ALT1)
+#define PA3_ALT1                (PA3  | ALT1)
+#define PA6_ALT1                (PA6  | ALT1)
+#define PA7_ALT1                (PA7  | ALT1)
+#define PA7_ALT2                (PA7  | ALT2)
+#define PA9_ALT1                (PA9  | ALT1)
+#define PA10_ALT1               (PA10 | ALT1)
+#define PA11_ALT1               (PA11 | ALT1)
+#define PA12_ALT1               (PA12 | ALT1)
+#define PB0_ALT1                (PB0  | ALT1)
+#define PB1_ALT1                (PB1  | ALT1)
+#define PB4_ALT1                (PB4  | ALT1)
+#define PB5_ALT1                (PB5  | ALT1)
+#define PB7_ALT1                (PB7  | ALT1)
+#define PB14_ALT1               (PB14 | ALT1)
+#define PB15_ALT1               (PB15 | ALT1)
+#define PB15_ALT2               (PB15 | ALT2)
+#define PC0_ALT1                (PC0  | ALT1)
+#define PC1_ALT1                (PC1  | ALT1)
+#define PC2_ALT1                (PC2  | ALT1)
+#define PC3_ALT1                (PC3  | ALT1)
+
+#define NUM_DIGITAL_PINS        51
+#define NUM_ANALOG_INPUTS       21
+
+// On-board LED pin number
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN           PNUM_NOT_DEFINED
+#endif
+
+// On-board user button
+#ifndef USER_BTN
+  #define USER_BTN              PNUM_NOT_DEFINED
+#endif
+
+// SPI definitions
+#ifndef PIN_SPI_SS
+  #define PIN_SPI_SS            PA4
+#endif
+#ifndef PIN_SPI_SS1
+  #define PIN_SPI_SS1           PA15
+#endif
+#ifndef PIN_SPI_SS2
+  #define PIN_SPI_SS2           PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_SS3
+  #define PIN_SPI_SS3           PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_MOSI
+  #define PIN_SPI_MOSI          PA7
+#endif
+#ifndef PIN_SPI_MISO
+  #define PIN_SPI_MISO          PA6
+#endif
+#ifndef PIN_SPI_SCK
+  #define PIN_SPI_SCK           PA5
+#endif
+
+// I2C definitions
+#ifndef PIN_WIRE_SDA
+  #define PIN_WIRE_SDA          PA14
+#endif
+#ifndef PIN_WIRE_SCL
+  #define PIN_WIRE_SCL          PA15
+#endif
+
+// Timer Definitions
+// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
+#ifndef TIMER_TONE
+  #define TIMER_TONE            TIM6
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO           TIM7
+#endif
+
+// UART Definitions
+#ifndef SERIAL_UART_INSTANCE
+  #define SERIAL_UART_INSTANCE  2
+#endif
+
+// Default pin used for generic 'Serial' instance
+// Mandatory for Firmata
+#ifndef PIN_SERIAL_RX
+  #define PIN_SERIAL_RX         PA3
+#endif
+#ifndef PIN_SERIAL_TX
+  #define PIN_SERIAL_TX         PA2
+#endif
+
+// Extra HAL modules
+#if !defined(HAL_DAC_MODULE_DISABLED)
+  #define HAL_DAC_MODULE_ENABLED
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+  // These serial port names are intended to allow libraries and architecture-neutral
+  // sketches to automatically default to the correct port name for a particular type
+  // of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+  // the first hardware serial port whose RX/TX pins are not dedicated to another use.
+  //
+  // SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+  //
+  // SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+  //
+  // SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+  //
+  // SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+  //
+  // SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+  //                            pins are NOT connected to anything by default.
+  #ifndef SERIAL_PORT_MONITOR
+    #define SERIAL_PORT_MONITOR   Serial
+  #endif
+  #ifndef SERIAL_PORT_HARDWARE
+    #define SERIAL_PORT_HARDWARE  Serial
+  #endif
+#endif


### PR DESCRIPTION
[Nucleo-F334R8](https://www.st.com/en/evaluation-tools/nucleo-f334r8.html)

Variant based of of existing generic config, Clock configured for a LSE of 32.768 and a HSI
HCLK of 64MHz

Not tested as I dont have access to the hardware

Request for board found in [#722 ](https://github.com/stm32duino/Arduino_Core_STM32/issues/722)
