### PR TITLE
I2C slave: allow function wrapped callbacks

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -438,13 +438,13 @@ void TwoWire::onRequestService(i2c_t *obj)
 }
 
 // sets function called on slave write
-void TwoWire::onReceive(void (*function)(int))
+void TwoWire::onReceive(cb_function_receive_t function)
 {
   user_onReceive = function;
 }
 
 // sets function called on slave read
-void TwoWire::onRequest(void (*function)(void))
+void TwoWire::onRequest(cb_function_request_t function)
 {
   user_onRequest = function;
 }

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -22,6 +22,8 @@
 #ifndef TwoWire_h
 #define TwoWire_h
 
+#include <functional>
+
 #include "Stream.h"
 #include "Arduino.h"
 extern "C" {
@@ -40,6 +42,10 @@ extern "C" {
 #define WIRE_HAS_END 1
 
 class TwoWire : public Stream {
+  public:
+    typedef std::function<void(int)> cb_function_receive_t;
+    typedef std::function<void(void)> cb_function_request_t;
+
   private:
     uint8_t *rxBuffer;
     uint16_t rxBufferAllocated;
@@ -56,8 +62,9 @@ class TwoWire : public Stream {
     uint8_t ownAddress;
     i2c_t _i2c;
 
-    void (*user_onRequest)(void);
-    void (*user_onReceive)(int);
+    std::function<void(int)> user_onReceive;
+    std::function<void(void)> user_onRequest;
+
     static void onRequestService(i2c_t *);
     static void onReceiveService(i2c_t *);
 
@@ -110,8 +117,9 @@ class TwoWire : public Stream {
     virtual int read(void);
     virtual int peek(void);
     virtual void flush(void);
-    void onReceive(void (*)(int));
-    void onRequest(void (*)(void));
+
+    void onReceive(cb_function_receive_t callback);
+    void onRequest(cb_function_request_t callback);
 
     inline size_t write(unsigned long n)
     {


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] #1833

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

This allow to have TwoWire callbacks methods inside classes. You can use std::bind to wrap the callback functions.

This is an example of a Class that completely handle the I2C comunication without having the user to manually implement the callbacks:

```cpp
/*
 * Lib Functions
 */

I2Client::I2Client(TwoWire *bus)
{
    this->_bus = bus;
}

bool I2Client::begin(uint8_t baseAddress)
{
    _bus->begin(baseAddress);
    _bus->onRequest(std::bind(&I2Client::onHandleRequest, this));

    return true;
}

void I2Client::onHandleRequest()
{
    _bus->write("hello\n");
}

/*
 * Library Usage (main.cpp)
 */

#include <Arduino.h>
#include <Wire.h>

TwoWire bus(PB9, PB8);
I2Client client(&bus);

 void setup()
{
    client.begin(0x4E); // join i2c bus on address 0x4E
}

void loop()
{
    // put your main code here, to run repeatedly:
}
```

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Validation**

* Ensure CI build is passed.
* Demonstrate the code is solid. [e.g. Provide a sketch]

<!-- Make sure tests pass on both CI. -->

**Code formatting**

* Ensure AStyle check is passed thanks CI

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Closes #1833
