### PR TITLE
fix: U575Z(G-I)TxQ_U585ZITxQ ram issue

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -211,7 +211,7 @@ Nucleo_144.menu.pnum.NUCLEO_L552ZE_Q.build.cmsis_lib_gcc=arm_ARMv8MMLlfsp_math
 Nucleo_144.menu.pnum.NUCLEO_U575ZI_Q=Nucleo U575ZI-Q
 Nucleo_144.menu.pnum.NUCLEO_U575ZI_Q.node=NOD_U575ZI
 Nucleo_144.menu.pnum.NUCLEO_U575ZI_Q.upload.maximum_size=2097152
-Nucleo_144.menu.pnum.NUCLEO_U575ZI_Q.upload.maximum_data_size=262144
+Nucleo_144.menu.pnum.NUCLEO_U575ZI_Q.upload.maximum_data_size=786432
 Nucleo_144.menu.pnum.NUCLEO_U575ZI_Q.build.mcu=cortex-m33
 Nucleo_144.menu.pnum.NUCLEO_U575ZI_Q.build.fpu=-mfpu=fpv4-sp-d16
 Nucleo_144.menu.pnum.NUCLEO_U575ZI_Q.build.float-abi=-mfloat-abi=hard
@@ -9403,7 +9403,7 @@ GenU5.menu.pnum.GENERIC_U575AIIXQ.build.variant=STM32U5xx/U575A(G-I)IxQ_U585AIIx
 # Generic U575ZGTxQ
 GenU5.menu.pnum.GENERIC_U575ZGTXQ=Generic U575ZGTxQ
 GenU5.menu.pnum.GENERIC_U575ZGTXQ.upload.maximum_size=1048576
-GenU5.menu.pnum.GENERIC_U575ZGTXQ.upload.maximum_data_size=262144
+GenU5.menu.pnum.GENERIC_U575ZGTXQ.upload.maximum_data_size=786432
 GenU5.menu.pnum.GENERIC_U575ZGTXQ.build.board=GENERIC_U575ZGTXQ
 GenU5.menu.pnum.GENERIC_U575ZGTXQ.build.product_line=STM32U575xx
 GenU5.menu.pnum.GENERIC_U575ZGTXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ
@@ -9411,7 +9411,7 @@ GenU5.menu.pnum.GENERIC_U575ZGTXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITx
 # Generic U575ZITxQ
 GenU5.menu.pnum.GENERIC_U575ZITXQ=Generic U575ZITxQ
 GenU5.menu.pnum.GENERIC_U575ZITXQ.upload.maximum_size=2097152
-GenU5.menu.pnum.GENERIC_U575ZITXQ.upload.maximum_data_size=262144
+GenU5.menu.pnum.GENERIC_U575ZITXQ.upload.maximum_data_size=786432
 GenU5.menu.pnum.GENERIC_U575ZITXQ.build.board=GENERIC_U575ZITXQ
 GenU5.menu.pnum.GENERIC_U575ZITXQ.build.product_line=STM32U575xx
 GenU5.menu.pnum.GENERIC_U575ZITXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ
@@ -9419,7 +9419,7 @@ GenU5.menu.pnum.GENERIC_U575ZITXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITx
 # Generic U585ZITxQ
 GenU5.menu.pnum.GENERIC_U585ZITXQ=Generic U585ZITxQ
 GenU5.menu.pnum.GENERIC_U585ZITXQ.upload.maximum_size=2097152
-GenU5.menu.pnum.GENERIC_U585ZITXQ.upload.maximum_data_size=262144
+GenU5.menu.pnum.GENERIC_U585ZITXQ.upload.maximum_data_size=786432
 GenU5.menu.pnum.GENERIC_U585ZITXQ.build.board=GENERIC_U585ZITXQ
 GenU5.menu.pnum.GENERIC_U585ZITXQ.build.product_line=STM32U585xx
 GenU5.menu.pnum.GENERIC_U585ZITXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ

--- a/variants/STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ/boards_entry.txt
+++ b/variants/STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ/boards_entry.txt
@@ -6,7 +6,7 @@
 # Generic U575ZGTxQ
 GenU5.menu.pnum.GENERIC_U575ZGTXQ=Generic U575ZGTxQ
 GenU5.menu.pnum.GENERIC_U575ZGTXQ.upload.maximum_size=1048576
-GenU5.menu.pnum.GENERIC_U575ZGTXQ.upload.maximum_data_size=262144
+GenU5.menu.pnum.GENERIC_U575ZGTXQ.upload.maximum_data_size=786432
 GenU5.menu.pnum.GENERIC_U575ZGTXQ.build.board=GENERIC_U575ZGTXQ
 GenU5.menu.pnum.GENERIC_U575ZGTXQ.build.product_line=STM32U575xx
 GenU5.menu.pnum.GENERIC_U575ZGTXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ
@@ -14,7 +14,7 @@ GenU5.menu.pnum.GENERIC_U575ZGTXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITx
 # Generic U575ZITxQ
 GenU5.menu.pnum.GENERIC_U575ZITXQ=Generic U575ZITxQ
 GenU5.menu.pnum.GENERIC_U575ZITXQ.upload.maximum_size=2097152
-GenU5.menu.pnum.GENERIC_U575ZITXQ.upload.maximum_data_size=262144
+GenU5.menu.pnum.GENERIC_U575ZITXQ.upload.maximum_data_size=786432
 GenU5.menu.pnum.GENERIC_U575ZITXQ.build.board=GENERIC_U575ZITXQ
 GenU5.menu.pnum.GENERIC_U575ZITXQ.build.product_line=STM32U575xx
 GenU5.menu.pnum.GENERIC_U575ZITXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ
@@ -22,7 +22,7 @@ GenU5.menu.pnum.GENERIC_U575ZITXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITx
 # Generic U585ZITxQ
 GenU5.menu.pnum.GENERIC_U585ZITXQ=Generic U585ZITxQ
 GenU5.menu.pnum.GENERIC_U585ZITXQ.upload.maximum_size=2097152
-GenU5.menu.pnum.GENERIC_U585ZITXQ.upload.maximum_data_size=262144
+GenU5.menu.pnum.GENERIC_U585ZITXQ.upload.maximum_data_size=786432
 GenU5.menu.pnum.GENERIC_U585ZITXQ.build.board=GENERIC_U585ZITXQ
 GenU5.menu.pnum.GENERIC_U585ZITXQ.build.product_line=STM32U585xx
 GenU5.menu.pnum.GENERIC_U585ZITXQ.build.variant=STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ

--- a/variants/STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ/ldscript.ld
+++ b/variants/STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ/ldscript.ld
@@ -46,6 +46,7 @@ _Min_Stack_Size = 0x400 ;	/* required amount of stack */
 MEMORY
 {
   RAM	(xrw)	: ORIGIN = 0x20000000,	LENGTH = LD_MAX_DATA_SIZE
+  SRAM4	(xrw)	: ORIGIN = 0x28000000,	LENGTH = 16K
   FLASH	(rx)	: ORIGIN = 0x8000000 + LD_FLASH_OFFSET, LENGTH = LD_MAX_SIZE - LD_FLASH_OFFSET
 }
 


### PR DESCRIPTION
The xml describing those mcu give 256Kb ram.
Issue raised internally to fix this then it will be corrected in generated files.

Based on RM0456:
![image](https://user-images.githubusercontent.com/20641798/192783770-f7ed801f-7647-4c78-bb49-573a2eb51b41.png)

SRAM 1/2/3 are consecutive but SRAM4 not.

Fixes #1827

