### PR TITLE
Added F13-F24 to USB HID.

### DIFF
--- a/cores/arduino/stm32/usb/hid/usbd_hid_composite.c
+++ b/cores/arduino/stm32/usb/hid/usbd_hid_composite.c
@@ -478,10 +478,10 @@ __ALIGN_BEGIN static uint8_t HID_KEYBOARD_ReportDesc[HID_KEYBOARD_REPORT_DESC_SI
   0x95, 0x06,       // Report Count (6)
   0x75, 0x08,       // Report Size (8)
   0x15, 0x00,       // Logical Minimum (0)
-  0x25, 0x65,       // Logical Maximum(101)
+  0x25, 0x73,       // Logical Maximum(115)
   0x05, 0x07,       // Usage Page (Key Codes)
   0x19, 0x00,       // Usage Minimum (0)
-  0x29, 0x65,       // Usage Maximum (101)
+  0x29, 0x73,       // Usage Maximum (115)
   0x81, 0x00,       // Input (Data, Array)
 
   0xC0              // End Collection

--- a/libraries/Keyboard/src/Keyboard.h
+++ b/libraries/Keyboard/src/Keyboard.h
@@ -70,6 +70,18 @@
 #define KEY_F10       0xCB
 #define KEY_F11       0xCC
 #define KEY_F12       0xCD
+#define KEY_F13       0xF0
+#define KEY_F14       0xF1
+#define KEY_F15       0xF2
+#define KEY_F16       0xF3
+#define KEY_F17       0xF4
+#define KEY_F18       0xF5
+#define KEY_F19       0xF6
+#define KEY_F20       0xF7
+#define KEY_F21       0xF8
+#define KEY_F22       0xF9
+#define KEY_F23       0xFA
+#define KEY_F24       0xFB  // Keyboard F24
 
 //  Low level key report: up to 6 keys and shift, ctrl etc at once
 typedef struct {


### PR DESCRIPTION
Summary:
Adds F13 to F24 to USB HID, make it possible to use KEY F13 to F24 on USB HID keyboard.


```
#include <Keyboard.h>

void setup() {
    Keyboard.begin();
}

void loop() {
   Keyboard.press(KEY_F13);
   delay(100);

   Keyboard.release(KEY_F13);   
   delay(1000);
}
```
