### PR TITLE
Update generic_clock.c

### DIFF
--- a/variants/STM32F4xx/F413Z(G-H)(J-T)_F423ZH(J-T)/generic_clock.c
+++ b/variants/STM32F4xx/F413Z(G-H)(J-T)_F423ZH(J-T)/generic_clock.c
@@ -34,13 +34,13 @@ WEAK void SystemClock_Config(void)
   * in the RCC_OscInitTypeDef structure.
   */
   RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-  RCC_OscInitStruct.HSEState = RCC_HSE_OFF;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
   RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
   RCC_OscInitStruct.PLL.PLLM = 8;
-  RCC_OscInitStruct.PLL.PLLN = 100;
-  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
-  RCC_OscInitStruct.PLL.PLLQ = 4;
+  RCC_OscInitStruct.PLL.PLLN = 384;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV4;
+  RCC_OscInitStruct.PLL.PLLQ = 8;
   RCC_OscInitStruct.PLL.PLLR = 2;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
     Error_Handler();


### PR DESCRIPTION
Proper clock definition 96MHz and RCC_HSE_ON based on STM32CubeIDE

As discussed here: https://www.stm32duino.com/viewtopic.php?p=10988#p10988



