### PR TITLE
ci: review

### DIFF
--- a/.github/workflows/CodeSpell.yml
+++ b/.github/workflows/CodeSpell.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       # See: https://github.com/codespell-project/actions-codespell/blob/master/README.md
       - name: Spell check

--- a/.github/workflows/Continuous-Integration.yml
+++ b/.github/workflows/Continuous-Integration.yml
@@ -27,27 +27,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
-  astyle_check:
-    runs-on: ubuntu-latest
-    name: AStyle check
-    steps:
-    # First of all, clone the repo using the checkout action.
-    - name: Checkout
-      uses: actions/checkout@main
-
-    - name: Astyle check
-      id: Astyle
-      uses: stm32duino/actions/astyle-check@main
-      with:
-        astyle-definition: 'CI/astyle/.astylerc'
-        ignore-path-list: 'CI/astyle/.astyleignore'
-
-    # Use the output from the `Astyle` step
-    - name: Astyle Errors
-      if: failure()
-      run: |
-        cat ${{ steps.Astyle.outputs.astyle-result }}
-        exit 1
   core_build:
     runs-on: ubuntu-latest
     name: Core compilation

--- a/.github/workflows/astyle.yml
+++ b/.github/workflows/astyle.yml
@@ -1,0 +1,48 @@
+name: Check code formatting with astyle
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '*.json'
+      - '**.md'
+      - keywords.txt
+      - CI/**
+      - '!CI/astyle/.astyleignore'
+      - '!CI/astyle/.astylerc'
+      - '!CI/astyle/astyle.py'
+      - tools/**
+  pull_request:
+    paths-ignore:
+      - '*.json'
+      - '**.md'
+      - keywords.txt
+      - CI/**
+      - '!CI/astyle/.astyleignore'
+      - '!CI/astyle/.astylerc'
+      - '!CI/astyle/astyle.py'
+      - tools/**
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  astyle_check:
+    runs-on: ubuntu-latest
+    name: Check for astyle errors
+    steps:
+    # First of all, clone the repo using the checkout action.
+    - name: Checkout
+      uses: actions/checkout@main
+
+    - name: Astyle check
+      id: Astyle
+      uses: stm32duino/actions/astyle-check@main
+      with:
+        astyle-definition: 'CI/astyle/.astylerc'
+        ignore-path-list: 'CI/astyle/.astyleignore'
+
+    # Use the output from the `Astyle` step
+    - name: Astyle Errors
+      if: failure()
+      run: |
+        cat ${{ steps.Astyle.outputs.astyle-result }}
+        exit 1


### PR DESCRIPTION
- Harden `astyle.py`
- codespell: use checkout main to remove deprecated warning about deprecated Node.js 12 actions
- made astyle check standalone workflow
