### PR TITLE
fix: remove RTC clock source selection for Nucleo_F446

### DIFF
--- a/variants/STM32F4xx/F446R(C-E)T/variant_NUCLEO_F446RE.cpp
+++ b/variants/STM32F4xx/F446R(C-E)T/variant_NUCLEO_F446RE.cpp
@@ -173,14 +173,13 @@ WEAK void SystemClock_Config(void)
     Error_Handler();
   }
 
-  PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_I2S_APB1 | RCC_PERIPHCLK_RTC;
+  PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_I2S_APB1;
   PeriphClkInitStruct.PLLI2S.PLLI2SN = 192;
   PeriphClkInitStruct.PLLI2S.PLLI2SP = RCC_PLLI2SP_DIV2;
   PeriphClkInitStruct.PLLI2S.PLLI2SM = 16;
   PeriphClkInitStruct.PLLI2S.PLLI2SR = 2;
   PeriphClkInitStruct.PLLI2S.PLLI2SQ = 2;
   PeriphClkInitStruct.PLLI2SDivQ = 1;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
   PeriphClkInitStruct.I2sApb1ClockSelection = RCC_I2SAPB1CLKSOURCE_PLLI2S;
   if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
     /* Initialization Error */


### PR DESCRIPTION
This prevents to reset the RTC backup domain when clock source is not the same and a poweroff with VBAT or software reset occurs. Moreover, LSI does not count when power off and VBAT so it is not useful.

Fixes #1919

# Sketch used to test
Board: Nucleo F446RE with SB45 removed. Then connect external 3.3V to VBAT.

```C++
#include <STM32RTC.h>

/* Get the rtc object */
STM32RTC& rtc = STM32RTC::getInstance();

/* Change these values to set the current initial time

   format: date: "Dec 31 2017" and time: "23:59:56"
   by default use built date and time
*/
static const char* mydate = __DATE__;
static const char* mytime = __TIME__;
//static const char* mydate = "Dec 31 2017";
//static const char* mytime = "23:59:56";

static byte seconds = 0;
static byte minutes = 0;
static byte hours = 0;
static uint32_t subSeconds = 0;

static byte weekDay = 1;
static byte day = 0;
static byte month = 0;
static byte year = 0;
static STM32RTC::Hour_Format hourFormat = STM32RTC::HOUR_24;
static STM32RTC::AM_PM period = STM32RTC::AM;

static uint8_t conv2d(const char* p) {
  uint8_t v = 0;
  if ('0' <= *p && *p <= '9')
    v = *p - '0';
  return 10 * v + *++p - '0';
}

// sample input: date = "Dec 26 2009", time = "12:34:56"
void initDateTime (void) {
  year = conv2d(mydate + 9);
  // Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
  switch (mydate[0]) {
    case 'J': month = (mydate[1] == 'a') ? 1 : ((mydate[2] == 'n') ? 6 : 7); break;
    case 'F': month = 2; break;
    case 'A': month = mydate[2] == 'r' ? 4 : 8; break;
    case 'M': month = mydate[2] == 'r' ? 3 : 5; break;
    case 'S': month = 9; break;
    case 'O': month = 10; break;
    case 'N': month = 11; break;
    case 'D': month = 12; break;
  }
  day = conv2d(mydate + 4);
  hours = conv2d(mytime);
  if (hourFormat == rtc.HOUR_12) {
    period = hours >= 12 ? rtc.PM : rtc.AM;
    hours = hours >= 13 ? hours - 12 : (hours < 1 ? hours + 12 : hours);
  }
  minutes = conv2d(mytime + 3);
  seconds = conv2d(mytime + 6);
}

void setup()
{
  Serial.begin(9600);
  while (!Serial);
  initDateTime();
  // Select RTC clock source: LSI_CLOCK, LSE_CLOCK or HSE_CLOCK.
  // By default the LSI is selected as source.
  rtc.setClockSource(STM32RTC::LSE_CLOCK);

  rtc.begin(); // initialize RTC 24H format
  if (!rtc.isTimeSet()) {
    Serial.printf("RTC time not set\n Set it!\n");
    // Set the time
    rtc.setTime(hours, minutes, seconds);
    rtc.setDate(weekDay, day, month, year);
  } else {
    Serial.printf("RTC time already set\n");
  }
}

void loop()
{
  rtc.getTime(&hours, &minutes, &seconds, &subSeconds, &period);
  // Print date time
  Serial.printf("%02d/%02d/%02d %02d:%02d:%02d.%03d\n", rtc.getDay(), rtc.getMonth(), rtc.getYear(), hours, minutes, seconds, subSeconds);
  delay(1000);
}
```