### PR TITLE
map LED_BUILTIN to PA13

### DIFF
--- a/variants/STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)/variant_EBB42_V1_1.h
+++ b/variants/STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)/variant_EBB42_V1_1.h
@@ -102,7 +102,7 @@
 
 // On-board LED pin number
 #ifndef LED_BUILTIN
-  #define LED_BUILTIN           PNUM_NOT_DEFINED
+  #define LED_BUILTIN           PA13
 #endif
 
 // On-board user button


### PR DESCRIPTION
**Summary**
Mapped LED_BUILTIN to PA13, the onboard blue LED. Was mapped to PNUM_NOT_DEFINED.

This PR fixes/implements the following **bugs/features**
LED_BUILTIN works as expected

**motivation**
LED_BUILTIN was mapped to PNUM_NOT_DEFINED. Referencing it would not throw a compile-time error, leading to confusion. 

**Validation**
* CI built without warnings.
* standard Blink example now causes blue LED to blink

**Code formatting**
Trival edit

**Closing issues**
No issues raised (easier to fix than raise an issue).
