### PR TITLE
Fix links for "WeAct MiniSTM32H7*" boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart: | STM32H743IG<br>STM32H743II | Generic Board | *2.0.0* |  |
 | :green_heart: | STM32H743VG<br>STM32H743VI | Generic Board | *2.0.0* |  |
 | :green_heart: | STM32H743VI | [DevEBox H743VIT6](https://github.com/mcauser/MCUDEV_DEVEBOX_H7XX_M) | *2.2.0* | |
-| :green_heart: | STM32H743VI | [WeAct MiniSTM32H743VIT6](https://github.com/WeActTC/MiniSTM32H7xx) | *2.2.0* | [More info](https://github.com/stm32duino/Arduino_Core_STM32/pull/1552) |
+| :green_heart: | STM32H743VI | [WeAct MiniSTM32H743VIT6](https://github.com/WeActStudio/MiniSTM32H7xx) | *2.2.0* | [More info](https://github.com/stm32duino/Arduino_Core_STM32/pull/1552) |
 | :green_heart: | STM32H743ZG<br>STM32H743ZI | Generic Board | *2.0.0* |  |
 | :green_heart: | STM32H747AG<br>STM32H747AI | Generic Board | *2.0.0* |  |
 | :green_heart: | STM32H747IG<br>STM32H747II | Generic Board | *2.0.0* |  |
@@ -529,7 +529,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart: | STM32H750IB | [Daisy Petal SM](https://www.electro-smith.com/daisy/petal-125b-sm) | *2.2.0* |  |
 | :green_heart: | STM32H750VB | Generic Board | *2.0.0* |  |
 | :green_heart: | STM32H750VB | [DevEBox H750VBT6](https://github.com/mcauser/MCUDEV_DEVEBOX_H7XX_M) | *2.2.0* | |
-| :green_heart: | STM32H750VB | [WeAct MiniSTM32H750VBT6](https://github.com/WeActTC/MiniSTM32H7xx) | *2.2.0* | [More info](https://github.com/stm32duino/Arduino_Core_STM32/pull/1552) |
+| :green_heart: | STM32H750VB | [WeAct MiniSTM32H750VBT6](https://github.com/WeActStudio/MiniSTM32H7xx) | *2.2.0* | [More info](https://github.com/stm32duino/Arduino_Core_STM32/pull/1552) |
 | :green_heart: | STM32H753VI | Generic Board | *2.0.0* |  |
 | :green_heart: | STM32H753ZI | Generic Board | *2.0.0* |  |
 | :green_heart: | STM32H757AI | Generic Board | *2.0.0* |  |


### PR DESCRIPTION
## Pull Request template

**Summary**

Fix useless, confusing, and potentially malicious links for "WeAct MiniSTM32H7*" boards.

CC: @ag88

This PR fixes/implements the following **bugs/features**

* [x] Fix useless, confusing, and potentially malicious links for "WeAct MiniSTM32H7*" boards
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The previous links lead through a GitHub username change redirect to a repository that appears to be used to demonstrate a security vulnerability.

I replaced them with links to the repo under the WeActStudio GitHub account which actually contains information about the hardware. The other links for WeAct hardware in the readme are under that GitHub and the product listings under the "WeAct Studio Official Store" on AliExpress.

**Validation**

1. Open the previous link:
   https://github.com/WeActTC/MiniSTM32H7xx
1. Note that there is no useful information there.
1. Note that the readme contains a link to a dependency, which is then explained to be a PoC placeholder for malware.
1. Consider that a user visiting this link to get information about the board would only be confused and distressed by what they found there.
1. Open the replacement link:
   https://github.com/WeActStudio/MiniSTM32H7xx
1. Note that there is useful information.
1. Open the "Official WeAct Studio Store" page on Aliexpress:
   https://weactstudio.aliexpress.com/store/1101545918
1. Find the listing for the STM32H750VBT6 dev board.
1. Note that the listing text contains `https://github.com/WeActStudio/MiniSTM32H7xx`

**Code formatting**

* Ensure AStyle check is passed thanks CI

N/A

**Closing issues**

None