### PR TITLE
Fix issue on upload for old NUCLEO-F401RE boards

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -385,7 +385,7 @@ Nucleo_64.menu.pnum.NUCLEO_F303RE.build.cmsis_lib_gcc=arm_cortexM4lf_math
 
 # NUCLEO_F401RE board
 Nucleo_64.menu.pnum.NUCLEO_F401RE=Nucleo F401RE
-Nucleo_64.menu.pnum.NUCLEO_F401RE.node=NODE_F401RE
+Nucleo_64.menu.pnum.NUCLEO_F401RE.node="NODE_F401RE,NUCLEO"
 Nucleo_64.menu.pnum.NUCLEO_F401RE.upload.maximum_size=524288
 Nucleo_64.menu.pnum.NUCLEO_F401RE.upload.maximum_data_size=98304
 Nucleo_64.menu.pnum.NUCLEO_F401RE.build.mcu=cortex-m4


### PR DESCRIPTION
**Summary**

This PR fixes the upload issue foe some old NUCLEO-F401RE boards

**Motivation**

Some users have NUCLEO-F401RE boards that are seen in the PC as "NUCLEO" mass storage disk

**Validation**

NA

**Code formatting**

NA

**Closing issues**

NA
