### PR TITLE
fix(CRC): explicitly set InputDataFormat to avoid assert

### DIFF
--- a/libraries/SrcWrapper/src/stm32/hw_config.c
+++ b/libraries/SrcWrapper/src/stm32/hw_config.c
@@ -22,11 +22,14 @@ extern "C" {
 #if defined(HAL_CRC_MODULE_ENABLED)
 CRC_HandleTypeDef hcrc = {.Instance =
 #if defined(CRC2_BASE)
-                            CRC2
+                            CRC2,
 #elif defined(CRC_BASE)
-                            CRC
+                            CRC,
 #else
 #error "No CRC instance available!"
+#endif
+#if defined(CRC_INPUTDATA_FORMAT_BYTES)
+                          .InputDataFormat = CRC_INPUTDATA_FORMAT_BYTES
 #endif
                          };
 #endif


### PR DESCRIPTION
when assert feature is enabled.
Default value (0) is not correct.

Issue raised on the forum:
https://www.stm32duino.com/viewtopic.php?t=1864

/CC @cparata 