### PR TITLE
platform: moved from arm-none-eabi-gcc 10.3.1-2.3 to 12.2.1-1.2

### DIFF
--- a/CI/update/templates/stm32yyxx_ll.h
+++ b/CI/update/templates/stm32yyxx_ll.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 /* Include Low Layers drivers */
 {% for ll_header_name in ll_header_list %}

--- a/CI/update/templates/stm32yyxx_ll_ppp.h
+++ b/CI/update/templates/stm32yyxx_ll_ppp.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 {% for serie in serieslist %}
   {% if loop.first %}

--- a/cores/arduino/avr/dtostrf.c
+++ b/cores/arduino/avr/dtostrf.c
@@ -19,6 +19,7 @@
 */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/cores/arduino/stm32/LL/stm32yyxx_ll.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 /* Include Low Layers drivers */
 #include "stm32yyxx_ll_adc.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_adc.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_adc.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_adc.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_bdma.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_bdma.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32H7xx
   #include "stm32h7xx_ll_bdma.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_bus.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_bus.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_bus.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_comp.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_comp.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F0xx
   #include "stm32f0xx_ll_comp.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_cordic.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_cordic.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32G4xx
   #include "stm32g4xx_ll_cordic.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_cortex.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_cortex.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_cortex.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_crc.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_crc.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_crc.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_crs.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_crs.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F0xx
   #include "stm32f0xx_ll_crs.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_dac.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_dac.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F0xx
   #include "stm32f0xx_ll_dac.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_dcache.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_dcache.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32U5xx
   #include "stm32u5xx_ll_dcache.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_delayblock.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_delayblock.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32H7xx
   #include "stm32h7xx_ll_delayblock.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_dlyb.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_dlyb.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32U5xx
   #include "stm32u5xx_ll_dlyb.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_dma.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_dma.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_dma.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_dma2d.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_dma2d.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F4xx
   #include "stm32f4xx_ll_dma2d.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_dmamux.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_dmamux.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_dmamux.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_exti.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_exti.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_exti.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_fmac.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_fmac.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32G4xx
   #include "stm32g4xx_ll_fmac.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_fmc.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_fmc.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F3xx
   #include "stm32f3xx_ll_fmc.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_fmpi2c.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_fmpi2c.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F4xx
   #include "stm32f4xx_ll_fmpi2c.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_fsmc.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_fsmc.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F1xx
   #include "stm32f1xx_ll_fsmc.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_gpio.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_gpio.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_gpio.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_hrtim.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_hrtim.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F3xx
   #include "stm32f3xx_ll_hrtim.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_hsem.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_hsem.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32H7xx
   #include "stm32h7xx_ll_hsem.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_i2c.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_i2c.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_i2c.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_icache.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_icache.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32L5xx
   #include "stm32l5xx_ll_icache.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_ipcc.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_ipcc.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32MP1xx
   #include "stm32mp1xx_ll_ipcc.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_iwdg.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_iwdg.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_iwdg.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_lpgpio.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_lpgpio.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32U5xx
   #include "stm32u5xx_ll_lpgpio.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_lptim.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_lptim.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F4xx
   #include "stm32f4xx_ll_lptim.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_lpuart.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_lpuart.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32G0xx
   #include "stm32g0xx_ll_lpuart.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_mdma.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_mdma.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32H7xx
   #include "stm32h7xx_ll_mdma.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_opamp.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_opamp.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F3xx
   #include "stm32f3xx_ll_opamp.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_pka.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_pka.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32L4xx
   #include "stm32l4xx_ll_pka.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_pwr.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_pwr.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_pwr.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_rcc.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_rcc.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_rcc.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_rng.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_rng.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F2xx
   #include "stm32f2xx_ll_rng.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_rtc.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_rtc.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_rtc.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_sdmmc.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_sdmmc.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F1xx
   #include "stm32f1xx_ll_sdmmc.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_spi.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_spi.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_spi.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_swpmi.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_swpmi.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32H7xx
   #include "stm32h7xx_ll_swpmi.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_system.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_system.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_system.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_tim.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_tim.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_tim.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_ucpd.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_ucpd.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32G0xx
   #include "stm32g0xx_ll_ucpd.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_usart.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_usart.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_usart.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_usb.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_usb.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32F0xx
   #include "stm32f0xx_ll_usb.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_utils.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_utils.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_utils.h"

--- a/cores/arduino/stm32/LL/stm32yyxx_ll_wwdg.h
+++ b/cores/arduino/stm32/LL/stm32yyxx_ll_wwdg.h
@@ -4,6 +4,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#ifdef __cplusplus
+  #pragma GCC diagnostic ignored "-Wregister"
+#endif
 
 #ifdef STM32C0xx
   #include "stm32c0xx_ll_wwdg.h"

--- a/platform.txt
+++ b/platform.txt
@@ -17,7 +17,7 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
-compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-10.3.1-2.3.path}/bin/
+compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-12.2.1-1.2.path}/bin/
 
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.c.cmd=arm-none-eabi-gcc

--- a/platform.txt
+++ b/platform.txt
@@ -32,7 +32,7 @@ compiler.extra_flags=-mcpu={build.mcu} {build.fpu} {build.float-abi} -DUSE_FULL_
 
 compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.stm.extra_include}
 
-compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {build.flags.debug} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections --param max-inline-insns-single=500 -MMD {compiler.stm.extra_include}
+compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {build.flags.debug} {compiler.warning_flags} -std={compiler.c.std} -ffunction-sections -fdata-sections --param max-inline-insns-single=500 -MMD {compiler.stm.extra_include}
 
 compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {build.flags.debug} {compiler.warning_flags} -std={compiler.cpp.std} -ffunction-sections -fdata-sections -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -fno-use-cxa-atexit -MMD {compiler.stm.extra_include}
 
@@ -59,9 +59,10 @@ build.variant_h=variant_generic.h
 # These can be overridden in platform.local.txt
 compiler.c.st_extra_flags={build.peripheral_pins}
 compiler.c.extra_flags=
+compiler.c.std=gnu17
 compiler.c.elf.extra_flags=
 compiler.cpp.extra_flags=
-compiler.cpp.std=gnu++14
+compiler.cpp.std=gnu++17
 compiler.S.st_extra_flags={build.startup_file}
 compiler.S.extra_flags=
 compiler.ar.extra_flags=

--- a/platform.txt
+++ b/platform.txt
@@ -45,7 +45,7 @@ compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,
 compiler.elf2bin.flags=-O binary
 compiler.elf2hex.flags=-O ihex
 
-compiler.ldflags=
+compiler.ldflags=-Wl,--no-warn-rwx-segments
 compiler.size.cmd=arm-none-eabi-size
 compiler.define=-DARDUINO=
 


### PR DESCRIPTION
* Release [xpack-dev-tools/arm-none-eabi-gcc-xpack v12.2.1-1.2](https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/v12.2.1-1.2) from @ilg-ul (thanks to him)
* Default language standards set to gnu C/C++17 (previously gnu C/C++11)


`dev` branch of  [stm32duino/BoardManagerFiles](https://github.com/stm32duino/BoardManagerFiles) updated to references the new toolchain used by CI:
https://raw.githubusercontent.com/stm32duino/BoardManagerFiles/dev/package_stmicroelectronics_index.json

### Deprecation notices
#### 32-bit support
Support for 32-bit Intel Linux and Intel Windows was dropped in 2022. Support for 32-bit Arm Linux (armv7l) will be preserved for a while, due to the large user base of 32-bit Raspberry Pi systems.