### PR TITLE
fix(serial): warning Warray-bounds

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -132,12 +132,14 @@ HardwareSerial::HardwareSerial(void *peripheral, HalfDuplexMode_t halfDuplex)
   // If Serial is defined in variant set
   // the Rx/Tx pins for com port if defined
 #if defined(Serial) && defined(PIN_SERIAL_TX)
+#if !defined(USBCON) || defined(USBD_USE_CDC) && defined(DISABLE_GENERIC_SERIALUSB)
   if ((void *)this == (void *)&Serial) {
 #if defined(PIN_SERIAL_RX)
     setRx(PIN_SERIAL_RX);
 #endif
     setTx(PIN_SERIAL_TX);
   } else
+#endif
 #endif
 #if defined(PIN_SERIAL1_TX) && defined(USART1_BASE)
     if (peripheral == USART1) {


### PR DESCRIPTION
when USB CDC enabled and generic Serial

```
In member function 'void HardwareSerial::setRx(uint32_t)',
    inlined from 'HardwareSerial::HardwareSerial(void*, HalfDuplexMode_t)' at C:\Users\<user>\AppData\Local\Arduino15\packages\STMicroelectronics\hardware\stm32\2.5.0-dev\cores\arduino\HardwareSerial.cpp:137:10:
C:\Users\<user>\AppData\Local\Arduino15\packages\STMicroelectronics\hardware\stm32\2.5.0-dev\cores\arduino\HardwareSerial.cpp:573:18: warning: array subscript 'HardwareSerial[0]' is partly outside array bounds of 'USBSerial [1]' [-Warray-bounds]
  573 |   _serial.pin_rx = digitalPinToPinName(_rx);
In file included from C:\Users\<user>\AppData\Local\Arduino15\packages\STMicroelectronics\hardware\stm32\2.5.0-dev\cores\arduino\WSerial.h:6,
                 from C:\Users\<user>\AppData\Local\Arduino15\packages\STMicroelectronics\hardware\stm32\2.5.0-dev\cores\arduino\wiring.h:48,
                 from C:\Users\<user>\AppData\Local\Arduino15\packages\STMicroelectronics\hardware\stm32\2.5.0-dev\cores\arduino\Arduino.h:36,
                 from C:\Users\<user>\AppData\Local\Arduino15\packages\STMicroelectronics\hardware\stm32\2.5.0-dev\cores\arduino\HardwareSerial.cpp:26:
C:\Users\<user>\AppData\Local\Arduino15\packages\STMicroelectronics\hardware\stm32\2.5.0-dev\cores\arduino\USBSerial.h: In constructor 'HardwareSerial::HardwareSerial(void*, HalfDuplexMode_t)':
C:\Users\<user>\AppData\Local\Arduino15\packages\STMicroelectronics\hardware\stm32\2.5.0-dev\cores\arduino\USBSerial.h:72:18: note: object 'SerialUSB' of size 16
   72 | extern USBSerial SerialUSB;

```