### PR TITLE
fix: silence the warnings from ExternalProject_Add

### DIFF
--- a/cmake/FindArduinoCtags.cmake
+++ b/cmake/FindArduinoCtags.cmake
@@ -3,6 +3,11 @@ include(FetchContent)
 include(FindPackageHandleStandardArgs)
 
 function(get_ctags)
+
+  # Prevent warnings in CMake>=3.24 regarding ExternalProject_Add()
+  # cf. https://cmake.org/cmake/help/latest/policy/CMP0135.html
+  cmake_policy(SET CMP0135 OLD)
+
   cmake_host_system_information(
     RESULT HOSTINFO
     QUERY OS_NAME OS_PLATFORM

--- a/cmake/ensure_core_deps.cmake
+++ b/cmake/ensure_core_deps.cmake
@@ -58,6 +58,11 @@ function(get_target_url JSONARR OUT_URL OUT_SHA)
 endfunction()
 
 function(declare_deps CORE_VERSION)
+
+  # Prevent warnings in CMake>=3.24 regarding ExternalProject_Add()
+  # cf. https://cmake.org/cmake/help/latest/policy/CMP0135.html
+  cmake_policy(SET CMP0135 OLD)
+
   file(REAL_PATH "${DL_DIR}/package_stmicroelectronics_index.json" JSONFILE)
   if (NOT EXISTS ${JSONFILE})
     file(DOWNLOAD "${JSONCONFIG_URL}" ${JSONFILE})


### PR DESCRIPTION
CMake 3.24 introduced a change in behavior in ExternalProject_Add() regarding timestamps when extracting an archive.
As updating the code would break compatibility with older CMake versions, this commit instead tells newer CMake versions to behave like older ones, using a policy setting.

Note from the CMake docs:
The OLD behavior of a policy is deprecated by definition and may be removed in a future version of CMake.

-> so the code will have to be updated eventually, and compatibility be broken...