### PR TITLE
Add debug openocd

### DIFF
--- a/CI/update/stm32variant.py
+++ b/CI/update/stm32variant.py
@@ -2063,7 +2063,7 @@ def aggregate_dir():
         # Get all mcu_dir
         mcu_dirs = sorted(mcu_family.glob("*/"))
         # Get original directory list of current serie STM32YYxx
-        mcu_out_dirs_ori = sorted(out_family_path.glob("*/"))
+        mcu_out_dirs_ori = sorted(out_family_path.glob("*/**"))
         mcu_out_dirs_up = []
         # Group mcu directories when only expressions and xml file name are different
         while mcu_dirs:

--- a/platform.txt
+++ b/platform.txt
@@ -215,3 +215,16 @@ tools.remoteproc_gen.script=run_arduino_gen.sh
 tools.remoteproc_gen.upload.params.verbose=
 tools.remoteproc_gen.upload.params.quiet=
 tools.remoteproc_gen.upload.pattern="{busybox}" sh "{path}/{script}" generate "{build.path}/{build.project_name}.elf" "{build.path}/run_arduino_{build.project_name}.sh"
+
+# Debugger configuration (general options)
+# ----------------------------------------
+# EXPERIMENTAL feature:
+# - this is alpha and may be subject to change without notice
+debug.executable={build.path}/{build.project_name}.elf
+debug.toolchain=gcc
+debug.toolchain.path={compiler.path}
+debug.toolchain.prefix=arm-none-eabi-
+debug.server=openocd
+debug.server.openocd.path={runtime.tools.xpack-openocd-0.12.0-1.path}/bin/openocd
+debug.server.openocd.scripts_dir={runtime.tools.xpack-openocd-0.12.0-1.path}/openocd/scripts
+debug.server.openocd.script={build.path}/openocd.cfg

--- a/platform.txt
+++ b/platform.txt
@@ -119,6 +119,8 @@ extras.path={build.system.path}/extras
 # Create {build.opt} if not exists in the output sketch dir and force include of SrcWrapper library
 recipe.hooks.prebuild.1.pattern="{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}" "{runtime.platform.path}"
 recipe.hooks.prebuild.1.pattern.windows="{runtime.tools.STM32Tools.path}/win/busybox.exe" sh "{extras.path}/prebuild.sh" "{build.path}" "{build.source.path}" "{runtime.platform.path}"
+recipe.hooks.postbuild.1.pattern="{extras.path}/postbuild.sh" "{build.path}" "{build.series}" "{runtime.platform.path}"
+recipe.hooks.postbuild.1.pattern.windows="{runtime.tools.STM32Tools.path}/win/busybox.exe" sh "{extras.path}/postbuild.sh" "{build.path}" "{build.series}" "{runtime.platform.path}"
 
 # compile patterns
 # ---------------------

--- a/system/extras/postbuild.sh
+++ b/system/extras/postbuild.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BUILD_PATH="$1"
+BUILD_SERIE="$2"
+BOARD_PLATFORM_PATH="$3"
+
+# Copy the correct openocd.cfg
+cp -f "$BOARD_PLATFORM_PATH/variants/$BUILD_SERIE/openocd.cfg" "$BUILD_PATH"

--- a/variants/STM32F0xx/openocd.cfg
+++ b/variants/STM32F0xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f0x.cfg]
+
+reset_config srst_only

--- a/variants/STM32F1xx/openocd.cfg
+++ b/variants/STM32F1xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f1x.cfg]
+
+reset_config srst_only

--- a/variants/STM32F2xx/openocd.cfg
+++ b/variants/STM32F2xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f2x.cfg]
+
+reset_config srst_only

--- a/variants/STM32F3xx/openocd.cfg
+++ b/variants/STM32F3xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f3x.cfg]
+
+reset_config srst_only

--- a/variants/STM32F4xx/openocd.cfg
+++ b/variants/STM32F4xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f4x.cfg]
+
+reset_config srst_only

--- a/variants/STM32F7xx/openocd.cfg
+++ b/variants/STM32F7xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f7x.cfg]
+
+reset_config srst_only

--- a/variants/STM32G0xx/openocd.cfg
+++ b/variants/STM32G0xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32g0x.cfg]
+
+reset_config srst_only

--- a/variants/STM32G4xx/openocd.cfg
+++ b/variants/STM32G4xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32g4x.cfg]
+
+reset_config srst_only

--- a/variants/STM32H7xx/openocd.cfg
+++ b/variants/STM32H7xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32h7x.cfg]
+
+reset_config srst_only

--- a/variants/STM32L0xx/openocd.cfg
+++ b/variants/STM32L0xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32l0.cfg]
+
+reset_config srst_only

--- a/variants/STM32L1xx/openocd.cfg
+++ b/variants/STM32L1xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32l1.cfg]
+
+reset_config srst_only

--- a/variants/STM32L4xx/openocd.cfg
+++ b/variants/STM32L4xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32l4x.cfg]
+
+reset_config srst_only

--- a/variants/STM32L5xx/openocd.cfg
+++ b/variants/STM32L5xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32l5x.cfg]
+
+reset_config srst_only

--- a/variants/STM32MP1xx/openocd.cfg
+++ b/variants/STM32MP1xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32mp15x.cfg]
+
+reset_config srst_only

--- a/variants/STM32U5xx/openocd.cfg
+++ b/variants/STM32U5xx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32u5x.cfg]
+
+reset_config srst_only

--- a/variants/STM32WBxx/openocd.cfg
+++ b/variants/STM32WBxx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32wbx.cfg]
+
+reset_config srst_only

--- a/variants/STM32WLxx/openocd.cfg
+++ b/variants/STM32WLxx/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023, STMicroelectronics
+# All rights reserved.
+#
+# This software component is licensed by ST under BSD 3-Clause license,
+# the "License"; You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at:
+#                        opensource.org/licenses/BSD-3-Clause
+#
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32wlx.cfg]
+
+reset_config srst_only


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR implements the debug feature in Arduino 2.0

* [x] Modifies variant script to generate openocd.cfg file for all variants
* [x] Adds debugger configuration to platform.txt
* [x] Update boards.txt for all families
* [x] Adds openocd.cfg for all variants

**Limitations**

Doesn't work if selected board is a Nucleo-* due to https://github.com/arduino/arduino-ide/issues/1960
Only use with Generic STM32xx series for the moment.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #1896
