### PR TITLE
ci(compile): test arduino-cli-0.32.2

### DIFF
--- a/.github/workflows/Arduino-build.yml
+++ b/.github/workflows/Arduino-build.yml
@@ -42,6 +42,7 @@ jobs:
       uses: stm32duino/actions/compile-examples@main
       with:
         additional-url: 'https://github.com/stm32duino/BoardManagerFiles/raw/dev/package_stmicroelectronics_index.json'
+        cli-version: 0.32.2
 
     # Use the output from the `Compile` step
     - name: Compilation Errors


### PR DESCRIPTION
issue with new 0.32.x version

Maybe linked to: https://github.com/arduino/arduino-cli/issues/2144 --> Solved thanks https://github.com/arduino/arduino-cli/pull/2145

