### PR TITLE
Add RAK3172 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart:  | STM32L073RZ | [AcSIP S76S](https://www.acsip.com.tw) | *2.3.0* |  |
 | :green_heart:  | STM32F072C8<br>STM32F072CB | [Elektor LoRa Node](https://github.com/ElektorLabs/180516-Elektor_LoRa_Node) | *1.8.0* | [More info](https://www.elektormagazine.com/labs/lorawan-node-experimental-platform) |
 | :yellow_heart:  | STM32WLE5JC | [LoRa-E5 mini](https://wiki.seeedstudio.com/LoRa_E5_mini/) | **2.6.0** |  |
+| :yellow_heart:  | STM32WLE5CC | [RAK3172 Module](https://github.com/RAKWireless/rakwireless-docs/tree/master/docs/Product-Categories/WisDuo/RAK3172-Module) | **2.6.0** |  |
 | :green_heart:  | STM32L151CB | [RAK811 LoRa Tracker](https://www.rakwireless.com/en/) | *1.4.0* | [Wiki](https://github.com/stm32duino/Arduino_Core_STM32/wiki/Connectivities#lora) |
 | :green_heart:  | STM32L051C8 | [RHF76-052](https://lora-alliance.org/lora_products/rhf76-052/) | *1.7.0* | Basic support |
 

--- a/boards.txt
+++ b/boards.txt
@@ -10482,6 +10482,18 @@ LoRa.menu.pnum.LORA_E5_MINI.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 LoRa.menu.pnum.LORA_E5_MINI.build.variant_h=variant_LORA_E5_MINI.h
 LoRa.menu.pnum.LORA_E5_MINI.build.cmsis_lib_gcc=arm_cortexM4l_math
 
+# RAK3172 module
+LoRa.menu.pnum.RAK3172_MODULE=RAK3172 Module
+LoRa.menu.pnum.RAK3172_MODULE.upload.maximum_size=262144
+LoRa.menu.pnum.RAK3172_MODULE.upload.maximum_data_size=65536
+LoRa.menu.pnum.RAK3172_MODULE.build.mcu=cortex-m4
+LoRa.menu.pnum.RAK3172_MODULE.build.board=RAK3172_MODULE
+LoRa.menu.pnum.RAK3172_MODULE.build.series=STM32WLxx
+LoRa.menu.pnum.RAK3172_MODULE.build.product_line=STM32WLE5xx
+LoRa.menu.pnum.RAK3172_MODULE.build.variant=STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U
+LoRa.menu.pnum.RAK3172_MODULE.build.variant_h=variant_RAK3172_MODULE.h
+LoRa.menu.pnum.RAK3172_MODULE.build.cmsis_lib_gcc=arm_cortexM4l_math
+
 # RAK811_TRACKER board
 LoRa.menu.pnum.RAK811_TRACKER=RAK811 LoRa Tracker (16kb RAM)
 LoRa.menu.pnum.RAK811_TRACKER.upload.maximum_size=131072

--- a/variants/STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U/variant_RAK3172_MODULE.cpp
+++ b/variants/STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U/variant_RAK3172_MODULE.cpp
@@ -1,0 +1,107 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#if defined(ARDUINO_RAK3172_MODULE)
+#include "pins_arduino.h"
+
+// Digital PinName array
+const PinName digitalPin[] = {
+  PA_0,   // D0
+  PA_1,   // D1
+  PA_2,   // D2     - USART2/LPUART1 TX
+  PA_3,   // D3     - USART2/LPUART1 RX
+  PA_4,   // D4     - SPI_NSS
+  PA_5,   // D5     - SPI_SCK
+  PA_6,   // D6     - SPI_MISO
+  PA_7,   // D7     - SPI_MOSI
+  PA_8,   // D8
+  PA_9,   // D9
+  PA_10,  // D10/A3
+  PA_11,  // D11/A7 - I2C_SDA
+  PA_12,  // D12/A8 - I2C_SCL
+  PA_13,  // D13/A5 - SWDIO
+  PA_14,  // D14/A6 - SWCLK
+  PA_15,  // D15/A4
+  PB_2,   // D16/A2
+  PB_3,   // D17/A0
+  PB_4,   // D18/A1
+  PB_5,   // D19
+  PB_6,   // D20    - USART1_TX
+  PB_7,   // D21    - USAR1_RX
+  PB_8,   // D22
+  PB_12,  // D23
+  PC_13,  // D24
+  PH_3    // D25    - BOOT0
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInputPin[] = {
+  17, // A0,  PB3
+  18, // A1,  PB4
+  16, // A2,  PB2
+  10, // A3,  PA10
+  15, // A4,  PA15
+  13, // A5,  PA13
+  14, // A6,  PA14
+  11, // A7,  PA11
+  12  // A8,  PA12
+};
+
+// ----------------------------------------------------------------------------
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief  System Clock Configuration
+  * @param  None
+  * @retval None
+  */
+WEAK void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {};
+
+  /** Configure the main internal regulator output voltage
+  */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+  /** Initializes the CPU, AHB and APB busses clocks
+  */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
+  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
+  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
+  */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3 | RCC_CLOCKTYPE_HCLK
+                                | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1
+                                | RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK) {
+    Error_Handler();
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_RAK3172_MODULE */

--- a/variants/STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U/variant_RAK3172_MODULE.h
+++ b/variants/STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U/variant_RAK3172_MODULE.h
@@ -1,0 +1,184 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#pragma once
+
+/*----------------------------------------------------------------------------
+ *        STM32 pins number
+ *----------------------------------------------------------------------------*/
+#define PA0                     0
+#define PA1                     1
+#define PA2                     2
+#define PA3                     3
+#define PA4                     4
+#define PA5                     5
+#define PA6                     6
+#define PA7                     7
+#define PA8                     8
+#define PA9                     9
+#define PA10                    PIN_A3
+#define PA11                    PIN_A7
+#define PA12                    PIN_A8
+#define PA13                    PIN_A5
+#define PA14                    PIN_A6
+#define PA15                    PIN_A4
+#define PB2                     PIN_A2
+#define PB3                     PIN_A0
+#define PB4                     PIN_A1
+#define PB5                     19
+#define PB6                     20
+#define PB7                     21
+#define PB8                     22
+#define PB12                    23
+#define PC13                    24
+#define PH3                     25
+
+// Not available
+// PB0
+// PC14
+// PC15
+
+// Alternate pins number
+#define PA1_ALT1                (PA1 | ALT1)
+#define PA2_ALT1                (PA2 | ALT1)
+#define PA3_ALT1                (PA3 | ALT1)
+#define PA4_ALT1                (PA4 | ALT1)
+#define PA5_ALT1                (PA5 | ALT1)
+#define PA6_ALT1                (PA6 | ALT1)
+#define PA7_ALT1                (PA7 | ALT1)
+#define PB8_ALT1                (PB8 | ALT1)
+
+#define NUM_DIGITAL_PINS        26
+#define NUM_ANALOG_INPUTS       9
+
+// On-board LED pin number
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN           PNUM_NOT_DEFINED
+#endif
+
+// On-board user button
+#ifndef USER_BTN
+  #define USER_BTN              PNUM_NOT_DEFINED
+#endif
+
+// SPI definitions
+#ifndef PIN_SPI_SS
+  #define PIN_SPI_SS            PA4
+#endif
+#ifndef PIN_SPI_SS1
+  #define PIN_SPI_SS1           PB2
+#endif
+#ifndef PIN_SPI_SS2
+  #define PIN_SPI_SS2           PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_SS3
+  #define PIN_SPI_SS3           PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_MOSI
+  #define PIN_SPI_MOSI          PA7
+#endif
+#ifndef PIN_SPI_MISOSPI1_SCK
+  #define PIN_SPI_MISO          PA6
+#endif
+#ifndef PIN_SPI_SCK
+  #define PIN_SPI_SCK           PA5
+#endif
+
+// I2C definitions
+#ifndef PIN_WIRE_SDA
+  #define PIN_WIRE_SDA          PA11
+#endif
+#ifndef PIN_WIRE_SCL
+  #define PIN_WIRE_SCL          PA12
+#endif
+
+// Timer Definitions
+// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
+#ifndef TIMER_TONE
+  #define TIMER_TONE            TIM16
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO           TIM17
+#endif
+
+// UART Definitions
+#ifndef SERIAL_UART_INSTANCE
+  #define SERIAL_UART_INSTANCE  101
+#endif
+
+// Default pin used for generic 'Serial' instance
+// Mandatory for Firmata
+#ifndef PIN_SERIAL_RX
+  #define PIN_SERIAL_RX         PA3
+#endif
+#ifndef PIN_SERIAL_TX
+  #define PIN_SERIAL_TX         PA2
+#endif
+
+// Alias
+#ifndef DEBUG_SUBGHZSPI_MOSI
+  #define DEBUG_SUBGHZSPI_MOSI  PA7_ALT1
+#endif
+#ifndef DEBUG_SUBGHZSPI_MISO
+  #define DEBUG_SUBGHZSPI_MISO  PA6_ALT1
+#endif
+#ifndef DEBUG_SUBGHZSPI_SCLK
+  #define DEBUG_SUBGHZSPI_SCLK  PA5_ALT1
+#endif
+#ifndef DEBUG_SUBGHZSPI_SS
+  #define DEBUG_SUBGHZSPI_SS    PA4_ALT1
+#endif
+
+// Extra HAL modules
+#if !defined(HAL_DAC_MODULE_DISABLED)
+  #define HAL_DAC_MODULE_ENABLED
+#endif
+
+// LoRaWAN definitions
+#define LORAWAN_BOARD_HAS_TCXO          0U
+#define LORAWAN_BOARD_HAS_DCDC          1U
+#define LORAWAN_TX_CONFIG               RBI_CONF_RFO_HP
+
+#define LORAWAN_RFSWITCH_PINS           PB8, PC13
+#define LORAWAN_RFSWITCH_PIN_COUNT      2
+#define LORAWAN_RFSWITCH_OFF_VALUES     LOW, LOW
+#define LORAWAN_RFSWITCH_RX_VALUES      HIGH, LOW
+#define LORAWAN_RFSWITCH_RFO_LP_VALUES  LOW, HIGH
+#define LORAWAN_RFSWITCH_RFO_HP_VALUES  LOW, HIGH
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+  // These serial port names are intended to allow libraries and architecture-neutral
+  // sketches to automatically default to the correct port name for a particular type
+  // of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+  // the first hardware serial port whose RX/TX pins are not dedicated to another use.
+  //
+  // SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+  //
+  // SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+  //
+  // SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+  //
+  // SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+  //
+  // SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+  //                            pins are NOT connected to anything by default.
+  #ifndef SERIAL_PORT_MONITOR
+    #define SERIAL_PORT_MONITOR   Serial
+  #endif
+  #ifndef SERIAL_PORT_HARDWARE
+    #define SERIAL_PORT_HARDWARE  Serial
+  #endif
+#endif


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR implements RAK3172 module bases on STM32WLE5CCU

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

As discussed the LoRaWAN repo (https://github.com/stm32duino/STM32LoRaWAN/pull/13) it is cleaner to add it here.  
This is still a draft as I did not update the main Readme because of a question: I created the section `LoRa modules` , but is it correct? If not, should I place it in the `LoRa`  boards instead?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Validation**

* LoRaWAN works on the module. I did not test the other peripherals like SPI or I2C
