### PR TITLE
Add print(float) to save space (VS double).

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -129,6 +129,11 @@ size_t Print::print(unsigned long long n, int base)
   }
 }
 
+size_t Print::print(float n, int digits)
+{
+  return printFloat(n, digits);
+}
+
 size_t Print::print(double n, int digits)
 {
   return printFloat(n, digits);
@@ -217,6 +222,13 @@ size_t Print::println(long long num, int base)
 size_t Print::println(unsigned long long num, int base)
 {
   size_t n = print(num, base);
+  n += println();
+  return n;
+}
+
+size_t Print::println(float num, int digits)
+{
+  size_t n = print(num, digits);
   n += println();
   return n;
 }
@@ -406,7 +418,8 @@ size_t Print::printULLNumber(unsigned long long n64, uint8_t base)
   return bytes;
 }
 
-size_t Print::printFloat(double number, uint8_t digits)
+template <class T>
+size_t Print::printFloat(T number, uint8_t digits)
 {
   size_t n = 0;
 
@@ -430,7 +443,7 @@ size_t Print::printFloat(double number, uint8_t digits)
   }
 
   // Round correctly so that print(1.999, 2) prints as "2.00"
-  double rounding = 0.5;
+  T rounding = 0.5;
   for (uint8_t i = 0; i < digits; ++i) {
     rounding /= 10.0;
   }
@@ -439,7 +452,7 @@ size_t Print::printFloat(double number, uint8_t digits)
 
   // Extract the integer part of the number and print it
   unsigned long int_part = (unsigned long)number;
-  double remainder = number - (double)int_part;
+  T remainder = number - (T)int_part;
   n += print(int_part);
 
   // Print the decimal point, but only if there are digits beyond

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -36,7 +36,8 @@ class Print {
     int write_error;
     size_t printNumber(unsigned long, uint8_t);
     size_t printULLNumber(unsigned long long, uint8_t);
-    size_t printFloat(double, uint8_t);
+    template <class T>
+    size_t printFloat(T, uint8_t);
   protected:
     void setWriteError(int err = 1)
     {
@@ -86,6 +87,7 @@ class Print {
     size_t print(unsigned long, int = DEC);
     size_t print(long long, int = DEC);
     size_t print(unsigned long long, int = DEC);
+    size_t print(float, int = 2);
     size_t print(double, int = 2);
     size_t print(const Printable &);
 
@@ -100,6 +102,7 @@ class Print {
     size_t println(unsigned long, int = DEC);
     size_t println(long long, int = DEC);
     size_t println(unsigned long long, int = DEC);
+    size_t println(float, int = 2);
     size_t println(double, int = 2);
     size_t println(const Printable &);
     size_t println(void);


### PR DESCRIPTION
**Summary**

This PR implements the following methods in Print.h and Print.cpp:

* [ ] Feature 1: Print::print(float) - - - only double was available
* [ ] Feature 2: Print::println(float) - - - only double was available
* [ ] Feature 2: Print::printFloat(float) - - - only double was available => maybe it should be called printDouble(double)?

------------------------
**Motivation**

Some of the new MCUs have a limited memory (ex: 32KB for STM32C011D6) and don't have floating point calculation unit, so a simple accelerometer driver ([example](https://github.com/honnet/MXC4005XC)) can take more than 100% of the flash if we don't optimize it a bit (the compilation fails at first).

This PR saves up to 10K by avoiding the compiler to use ARM libs for double calculation subroutines such as  `__aeabi_dsub`, `__aeabi_dadd`, `__aeabi_dmul`, etc.

------------------------
**Validation**

The following command allows listing the heaviest functions after compilation:
`arm-none-eabi-nm --print-size --size-sort --radix=d -l file.elf | tail -n 3`
```
134242369 00001416 T __aeabi_dmul
134240049 00001724 T __aeabi_dadd
134243785 00001796 T __aeabi_dsub
```
The problem can also be observed in the assembly code [with C code + comments using debug enabled (-g) if there's enough space]:
`arm-none-eabi-objdump -S file.elf`

------------------------
**Note**
The printFloat(float) function repeats a lot of what printFloat(double) does and it should probably be factorized.
I expect that this PR could be rejected for this reason at least, let me know if you have any suggestion of how to implement it (using templates?).