### PR TITLE
fix #2071 add support for max overflow value for 32 bits timer

### DIFF
--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -113,7 +113,7 @@ class HardwareTimer {
     uint32_t getPrescaleFactor();
 
     void setOverflow(uint64_t val, TimerFormat_t format = TICK_FORMAT); // set AutoReload register depending on format provided
-    uint32_t getOverflow(TimerFormat_t format = TICK_FORMAT); // return overflow depending on format provided
+    uint64_t getOverflow(TimerFormat_t format = TICK_FORMAT); // return overflow depending on format provided
 
     void setPWM(uint32_t channel, PinName pin, uint32_t frequency, uint32_t dutycycle, callback_function_t PeriodCallback = nullptr, callback_function_t CompareCallback = nullptr); // Set all in one command freq in HZ, Duty in percentage. Including both interrupt.
     void setPWM(uint32_t channel, uint32_t pin, uint32_t frequency, uint32_t dutycycle, callback_function_t PeriodCallback = nullptr, callback_function_t CompareCallback = nullptr);

--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -112,7 +112,7 @@ class HardwareTimer {
     void setPrescaleFactor(uint32_t prescaler); // set prescaler register (which is factor value - 1)
     uint32_t getPrescaleFactor();
 
-    void setOverflow(uint32_t val, TimerFormat_t format = TICK_FORMAT); // set AutoReload register depending on format provided
+    void setOverflow(uint64_t val, TimerFormat_t format = TICK_FORMAT); // set AutoReload register depending on format provided
     uint32_t getOverflow(TimerFormat_t format = TICK_FORMAT); // return overflow depending on format provided
 
     void setPWM(uint32_t channel, PinName pin, uint32_t frequency, uint32_t dutycycle, callback_function_t PeriodCallback = nullptr, callback_function_t CompareCallback = nullptr); // Set all in one command freq in HZ, Duty in percentage. Including both interrupt.

--- a/libraries/SrcWrapper/src/HardwareTimer.cpp
+++ b/libraries/SrcWrapper/src/HardwareTimer.cpp
@@ -483,18 +483,18 @@ void HardwareTimer::setPrescaleFactor(uint32_t prescaler)
   *           MICROSEC_FORMAT: return number of microsecondes for overflow
   *           HERTZ_FORMAT:    return frequency in hertz for overflow
   */
-uint32_t HardwareTimer::getOverflow(TimerFormat_t format)
+uint64_t HardwareTimer::getOverflow(TimerFormat_t format)
 {
   // Hardware register correspond to period count-1. Example ARR register value 9 means period of 10 timer cycle
   uint32_t ARR_RegisterValue = LL_TIM_GetAutoReload(_timerObj.handle.Instance);
   uint32_t Prescalerfactor = LL_TIM_GetPrescaler(_timerObj.handle.Instance) + 1;
-  uint32_t return_value;
+  uint64_t return_value;
   switch (format) {
     case MICROSEC_FORMAT:
-      return_value = (uint32_t)(((ARR_RegisterValue + 1) * Prescalerfactor * 1000000.0) / getTimerClkFreq());
+      return_value = (uint64_t)(((ARR_RegisterValue + 1) * Prescalerfactor * 1000000.0) / getTimerClkFreq());
       break;
     case HERTZ_FORMAT:
-      return_value = (uint32_t)(getTimerClkFreq() / ((ARR_RegisterValue + 1) * Prescalerfactor));
+      return_value = (uint64_t)(getTimerClkFreq() / ((ARR_RegisterValue + 1) * Prescalerfactor));
       break;
     case TICK_FORMAT:
     default :

--- a/libraries/SrcWrapper/src/HardwareTimer.cpp
+++ b/libraries/SrcWrapper/src/HardwareTimer.cpp
@@ -518,7 +518,7 @@ uint32_t HardwareTimer::getOverflow(TimerFormat_t format)
   *           HERTZ_FORMAT:    overflow is the frequency in hertz for overflow
   * @retval None
   */
-void HardwareTimer::setOverflow(uint32_t overflow, TimerFormat_t format)
+void HardwareTimer::setOverflow(uint64_t overflow, TimerFormat_t format)
 {
   uint32_t ARR_RegisterValue;
   uint32_t PeriodTicks;

--- a/libraries/SrcWrapper/src/HardwareTimer.cpp
+++ b/libraries/SrcWrapper/src/HardwareTimer.cpp
@@ -521,7 +521,7 @@ uint32_t HardwareTimer::getOverflow(TimerFormat_t format)
 void HardwareTimer::setOverflow(uint64_t overflow, TimerFormat_t format)
 {
   uint32_t ARR_RegisterValue;
-  uint32_t PeriodTicks;
+  uint64_t PeriodTicks;
   uint32_t Prescalerfactor;
   uint32_t period_cyc;
   // Remark: Hardware register correspond to period count-1. Example ARR register value 9 means period of 10 timer cycle


### PR DESCRIPTION
**Summary**
the following fixes #2071  in the way proposed in the issue itself.

this will now allow to set the 32bit HW timers overflow to the full value.

the `getOverflow()` function was also modified to accomodate the new value.
this will not cause problems with existing code since they are using values castable in `uint32_t`

**This PR fixes the following bug**
#2071 

**Validation**
the modification was tested and work as expected
testing code present in #2071
