### PR TITLE
[chore] Speedup for simple SPI.transfer

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -407,18 +407,18 @@ void SPIClass::transfer(byte _pin, void *_bufout, void *_bufin, size_t _count, S
 uint8_t SPIClass::transfer(uint8_t data)
 {
 #if defined(SPI_SR_TXP)
-    while (!LL_SPI_IsActiveFlag_TXP(_spi.handle.Instance));
+  while (!LL_SPI_IsActiveFlag_TXP(_spi.handle.Instance));
 #else
-    while (!LL_SPI_IsActiveFlag_TXE(_spi.handle.Instance));
+  while (!LL_SPI_IsActiveFlag_TXE(_spi.handle.Instance));
 #endif
-    LL_SPI_TransmitData8(_spi.handle.Instance, data);
+  LL_SPI_TransmitData8(_spi.handle.Instance, data);
 
 #if defined(SPI_SR_RXP)
-      while (!LL_SPI_IsActiveFlag_RXP(_spi.handle.Instance));
+  while (!LL_SPI_IsActiveFlag_RXP(_spi.handle.Instance));
 #else
-      while (!LL_SPI_IsActiveFlag_RXNE(_spi.handle.Instance));
+  while (!LL_SPI_IsActiveFlag_RXNE(_spi.handle.Instance));
 #endif
-      return LL_SPI_ReceiveData8(_spi.handle.Instance);
+  return LL_SPI_ReceiveData8(_spi.handle.Instance);
 }
 
 /**
@@ -430,23 +430,22 @@ uint8_t SPIClass::transfer(uint8_t data)
   */
 void SPIClass::transfer(void *buf, size_t count)
 {
-    uint8_t *buffer = (uint8_t *) buf;
-    for (size_t index = 0; index < count; index++)
-    {
+  uint8_t *buffer = (uint8_t *) buf;
+  for (size_t index = 0; index < count; index++) {
 #if defined(SPI_SR_TXP)
-        while (!LL_SPI_IsActiveFlag_TXP(_spi.handle.Instance));
+    while (!LL_SPI_IsActiveFlag_TXP(_spi.handle.Instance));
 #else
-        while (!LL_SPI_IsActiveFlag_TXE(_spi.handle.Instance));
+    while (!LL_SPI_IsActiveFlag_TXE(_spi.handle.Instance));
 #endif
-        LL_SPI_TransmitData8(_spi.handle.Instance, buffer[index]);
+    LL_SPI_TransmitData8(_spi.handle.Instance, buffer[index]);
 
 #if defined(SPI_SR_RXP)
-        while (!LL_SPI_IsActiveFlag_RXP(_spi.handle.Instance));
+    while (!LL_SPI_IsActiveFlag_RXP(_spi.handle.Instance));
 #else
-        while (!LL_SPI_IsActiveFlag_RXNE(_spi.handle.Instance));
+    while (!LL_SPI_IsActiveFlag_RXNE(_spi.handle.Instance));
 #endif
-        buffer[index] = LL_SPI_ReceiveData8(_spi.handle.Instance);
-    }
+    buffer[index] = LL_SPI_ReceiveData8(_spi.handle.Instance);
+  }
 }
 
 /**

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -399,6 +399,57 @@ void SPIClass::transfer(byte _pin, void *_bufout, void *_bufin, size_t _count, S
 }
 
 /**
+  * @brief  Transfer one byte on the SPI bus.
+  *         begin() or beginTransaction() must be called at least once before.
+  * @param  data: byte to send.
+  * @return byte received from the slave.
+  */
+uint8_t SPIClass::transfer(uint8_t data)
+{
+#if defined(SPI_SR_TXP)
+    while (!LL_SPI_IsActiveFlag_TXP(_spi.handle.Instance));
+#else
+    while (!LL_SPI_IsActiveFlag_TXE(_spi.handle.Instance));
+#endif
+    LL_SPI_TransmitData8(_spi.handle.Instance, data);
+
+#if defined(SPI_SR_RXP)
+      while (!LL_SPI_IsActiveFlag_RXP(_spi.handle.Instance));
+#else
+      while (!LL_SPI_IsActiveFlag_RXNE(_spi.handle.Instance));
+#endif
+      return LL_SPI_ReceiveData8(_spi.handle.Instance);
+}
+
+/**
+  * @brief  Transfer several bytes. Only one buffer used to send and receive data.
+  *         begin() or beginTransaction() must be called at least once before.
+  * @param  buf: pointer to the bytes to send. The bytes received are copy in
+  *         this buffer.
+  * @param  count: number of bytes to send/receive.
+  */
+void SPIClass::transfer(void *buf, size_t count)
+{
+    uint8_t *buffer = (uint8_t *) buf;
+    for (size_t index = 0; index < count; index++)
+    {
+#if defined(SPI_SR_TXP)
+        while (!LL_SPI_IsActiveFlag_TXP(_spi.handle.Instance));
+#else
+        while (!LL_SPI_IsActiveFlag_TXE(_spi.handle.Instance));
+#endif
+        LL_SPI_TransmitData8(_spi.handle.Instance, buffer[index]);
+
+#if defined(SPI_SR_RXP)
+        while (!LL_SPI_IsActiveFlag_RXP(_spi.handle.Instance));
+#else
+        while (!LL_SPI_IsActiveFlag_RXNE(_spi.handle.Instance));
+#endif
+        buffer[index] = LL_SPI_ReceiveData8(_spi.handle.Instance);
+    }
+}
+
+/**
   * @brief  Not implemented.
   */
 void SPIClass::usingInterrupt(uint8_t interruptNumber)

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -17,6 +17,7 @@
 extern "C" {
 #include "utility/spi_com.h"
 }
+#include "stm32yyxx_ll_spi.h"
 
 // SPI_HAS_TRANSACTION means SPI has
 //   - beginTransaction()
@@ -178,19 +179,12 @@ class SPIClass {
     virtual void transfer(byte _pin, void *_bufout, void *_bufin, size_t _count, SPITransferMode _mode = SPI_LAST);
 
     // Transfer functions when user controls himself the CS pin.
-    byte transfer(uint8_t _data, SPITransferMode _mode = SPI_LAST)
-    {
-      return transfer(CS_PIN_CONTROLLED_BY_USER, _data, _mode);
-    }
+    virtual uint8_t transfer(uint8_t data);
+    virtual void transfer(void *buf, size_t count);
 
     uint16_t transfer16(uint16_t _data, SPITransferMode _mode = SPI_LAST)
     {
       return transfer16(CS_PIN_CONTROLLED_BY_USER, _data, _mode);
-    }
-
-    void transfer(void *_buf, size_t _count, SPITransferMode _mode = SPI_LAST)
-    {
-      transfer(CS_PIN_CONTROLLED_BY_USER, _buf, _count, _mode);
     }
 
     void transfer(void *_bufout, void *_bufin, size_t _count, SPITransferMode _mode = SPI_LAST)


### PR DESCRIPTION
**Summary**

This PR gives a speed boost to simple SPI.transfer(data) and SPI.transfer(buffer, count) operations
in which the user controls the chip-select by directly using only the necessary LL-HAL functions and not going thru the CS controlling functions and the spi_transfer() function.

With no DMA support in the SPI class the sending of a buffer takes a long time and with this modification
it takes at least less time.

Measured with STM32C031C6, SPI clock 8MHz and a buffer of 231 bytes:
digitalWrite(CS, LOW);
SPI.transfer(&buffer, 231);
digitalWrite(CS, HIGH);

original code: 587,26µs
this pr: 474.92µs
