### PR TITLE
fix(H7): restore DATA_IN_D2_SRAM comment in system source file

### DIFF
--- a/system/STM32H7xx/system_stm32h7xx.c
+++ b/system/STM32H7xx/system_stm32h7xx.c
@@ -64,6 +64,8 @@
   */
 
 /************************* Miscellaneous Configuration ************************/
+/*!< Uncomment the following line if you need to use initialized data in D2 domain SRAM (AHB SRAM) */
+/* #define DATA_IN_D2_SRAM */
 
 /* Note: Following vector table addresses must be defined in line with linker
          configuration. */


### PR DESCRIPTION
Fixes #2094
