### PR TITLE
chore(pio): disable build

### DIFF
--- a/.github/workflows/PIO-build.yml
+++ b/.github/workflows/PIO-build.yml
@@ -39,6 +39,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@main
 
-    - name: PlatformIO
-      id: Compile
-      uses: ./.github/actions/pio-build
+    # - name: PlatformIO
+    #   id: Compile
+    #   uses: ./.github/actions/pio-build
+    # Use the output from the `Astyle` step
+    - name: Warning
+      run: |
+        echo "PlatformIO build disabled while not support CMSIS update."
+        exit 0


### PR DESCRIPTION
Since #2099, pio build failed as it does not used the specified CMSIS version.

/cc @valeros 
