### PR TITLE
feat(serial): add timeout support to flush()

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -125,7 +125,7 @@ class HardwareSerial : public Stream {
     virtual int peek(void);
     virtual int read(void);
     int availableForWrite(void);
-    virtual void flush(void);
+    virtual void flush(uint32_t timeout = 0);
     virtual size_t write(uint8_t);
     inline size_t write(unsigned long n)
     {

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -86,7 +86,9 @@ struct serial_s {
 };
 
 /* Exported constants --------------------------------------------------------*/
+#ifndef TX_TIMEOUT
 #define TX_TIMEOUT  1000
+#endif
 
 #if !defined(RCC_USART1CLKSOURCE_HSI)
 /* Some series like C0 have 2 derivated clock from HSI: HSIKER (for peripherals)


### PR DESCRIPTION
when called by `end()`.
Default, no timeout (0). When called by `end()`, default timeout is
`TX_TIMEOUT` which can be redefined if needed.

Fixes #2122.

Tested with below sketch on a Nucleo-WL55JC1.
`Serial1` is instantiate with CTS/RTS. With original code, it wait forever while with this PR it continue after `TIMEOUT_TX` expiration.

```C++
HardwareSerial Serial1(PB7, PB6, PB3, PB4);
uint32_t baud_val[] = {
  1200,
  2400,
  4800,
  9600,
  115200,
  250000
};
// the setup routine runs once when you press reset:
void setup() {
  // initialize serial communication at 9600 bits per second:
  Serial.begin(9600);
}

// the loop routine runs over and over again forever:
void loop() {
  for (uint8_t idx = 0; idx < 6; idx++) {
    Serial1.end();
    Serial.printf("Test %u\n", baud_val[idx]);
    Serial1.begin(baud_val[idx]);
    Serial1.println("ATE0");
  }
  delay(100);
}
```

##### Output
```
09:20:52.421 -> Test 1200
09:20:53.419 -> Test 2400
09:20:54.384 -> Test 4800
09:20:55.383 -> Test 9600
09:20:56.380 -> Test 115200
09:20:57.379 -> Test 250000
09:20:58.473 -> Test 1200
09:20:59.471 -> Test 2400
09:21:00.470 -> Test 4800
09:21:01.465 -> Test 9600
```
