### PR TITLE
Support for NUCLEO-H753ZI board

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :green_heart:  | STM32H563ZI | [Nucleo H563ZI](https://www.st.com/en/evaluation-tools/nucleo-h563zi.html) | *2.6.0* |  |
 | :green_heart:  | STM32H723ZG | [Nucleo H723ZG](https://www.st.com/en/evaluation-tools/nucleo-h723zg.html) | *2.4.0* |  |
 | :green_heart:  | STM32H743ZI | [Nucleo H743ZI(2)](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html) | *1.5.0* | Nucleo H743ZI2 since 1.6.0 |
+| :yellow_heart:  | STM32H753ZI | [Nucleo H753ZI](https://www.st.com/en/evaluation-tools/nucleo-h753zi.html) | **2.7.0** |  |
 | :green_heart:  | STM32L496ZG | [Nucleo L496ZG](http://www.st.com/en/evaluation-tools/nucleo-l496zg.html) | *1.3.0* |  |
 | :green_heart:  | STM32L496ZG-P | [Nucleo L496ZG-P](http://www.st.com/en/evaluation-tools/nucleo-l496zg-p.html) | *1.3.0* |  |
 | :green_heart:  | STM32L4R5ZI | [Nucleo L4R5ZI](http://www.st.com/en/evaluation-tools/nucleo-l4r5zi.html) | *1.4.0* |  |

--- a/boards.txt
+++ b/boards.txt
@@ -195,6 +195,20 @@ Nucleo_144.menu.pnum.NUCLEO_H743ZI2.build.product_line=STM32H743xx
 Nucleo_144.menu.pnum.NUCLEO_H743ZI2.build.variant=STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT
 Nucleo_144.menu.pnum.NUCLEO_H743ZI2.build.variant_h=variant_NUCLEO_H743ZI.h
 
+# NUCLEO_H753ZI board
+Nucleo_144.menu.pnum.NUCLEO_H753ZI=Nucleo H753ZI
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.node=NODE_H753ZI
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.upload.maximum_size=2097152
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.upload.maximum_data_size=524288
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.build.mcu=cortex-m7
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.build.fpu=-mfpu=fpv4-sp-d16
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.build.float-abi=-mfloat-abi=hard
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.build.board=NUCLEO_H753ZI
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.build.series=STM32H7xx
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.build.product_line=STM32H753xx
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.build.variant=STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT
+Nucleo_144.menu.pnum.NUCLEO_H753ZI.build.variant_h=variant_NUCLEO_H753ZI.h
+
 # NUCLEO_L496ZG board
 Nucleo_144.menu.pnum.NUCLEO_L496ZG=Nucleo L496ZG
 Nucleo_144.menu.pnum.NUCLEO_L496ZG.node=NODE_L496ZG

--- a/variants/STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT/CMakeLists.txt
+++ b/variants/STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(variant_bin STATIC EXCLUDE_FROM_ALL
   PeripheralPins.c
   variant_generic.cpp
   variant_NUCLEO_H743ZI.cpp
+  variant_NUCLEO_H753ZI.cpp
 )
 target_link_libraries(variant_bin PUBLIC variant_usage)
 

--- a/variants/STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT/variant_NUCLEO_H753ZI.cpp
+++ b/variants/STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT/variant_NUCLEO_H753ZI.cpp
@@ -1,0 +1,272 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2023, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#if defined(ARDUINO_NUCLEO_H753ZI)
+#include "pins_arduino.h"
+
+// Pin number
+const PinName digitalPin[] = {
+  PB_7,
+  PB_6,
+  PG_14,
+  PE_13,
+  PE_14,
+  PE_11,
+  PE_9,
+  PG_12,
+  PF_3,
+  PD_15,
+  PD_14,
+  PB_5,
+  PA_6,
+  PA_5,
+  PB_9,
+  PB_8,
+  PC_6,
+  PB_15,
+  PB_13,
+  PB_12,
+  PA_15,
+  PC_7,
+  PB_5,
+  PB_3,
+  PA_4,
+  PB_4,
+  PG_6,
+  PB_2,
+  PD_13,
+  PD_12,
+  PD_11,
+  PE_2,
+  PA_0,
+  PB_0,
+  PE_0,
+  PB_11,
+  PB_10,
+  PE_15,
+  PE_6,
+  PE_12,
+  PE_10,
+  PE_7,
+  PE_8,
+  PC_8,
+  PC_9,
+  PC_10,
+  PC_11,
+  PC_12,
+  PD_2,
+  PG_2,
+  PG_3,
+  PD_7,
+  PD_6,
+  PD_5,
+  PD_4,
+  PD_3,
+  PE_2,
+  PE_4,
+  PE_5,
+  PE_6,
+  PE_3,
+  PF_8,
+  PF_7,
+  PF_9,
+  PG_1,
+  PG_0,
+  PD_1,
+  PD_0,
+  PF_0,
+  PF_1,
+  PF_2,
+  PE_9,
+  PB_2,
+  PA_3,
+  PC_0,
+  PC_3_C,
+  PB_1,
+  PC_2_C,
+  PF_10,
+  PF_4,
+  PF_5,
+  PF_6,
+  PF_11,
+  PA_1,
+  PA_2,
+  PA_7,
+  PA_8,
+  PA_9,
+  PA_10,
+  PA_11,
+  PA_12,
+  PA_13,
+  PA_14,
+  PB_14,
+  PC_1,
+  PC_4,
+  PC_5,
+  PC_13,
+  PC_14,
+  PC_15,
+  PD_8,
+  PD_9,
+  PD_10,
+  PE_1,
+  PF_12,
+  PF_13,
+  PF_14,
+  PF_15,
+  PG_4,
+  PG_5,
+  PG_7,
+  PG_8,
+  PG_9,
+  PG_10,
+  PG_11,
+  PG_13,
+  PG_15,
+  PH_0,
+  PH_1
+};
+
+// Analog (Ax) pin number array
+const uint32_t analogInputPin[] = {
+  73,  // A0
+  74,  // A1
+  75,  // A2
+  76,  // A3
+  77,  // A4
+  78,  // A5
+  79,  // A6
+  80,  // A7
+  81,  // A8
+  82,  // A9
+  83,  // A10
+  84,  // A11
+  85,  // A12
+  94,  // A13
+  95,  // A14
+  96,  // A15
+  104, // A16
+  105, // A17
+  106, // A18
+  8,   // A19
+  12,  // A20
+  13,  // A21
+  24,  // A22
+  32,  // A23
+  33,  // A24
+  61,  // A25
+  62,  // A26
+  63   // A27
+};
+
+// ----------------------------------------------------------------------------
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief  System Clock Configuration
+  * @param  None
+  * @retval None
+  */
+WEAK void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {};
+  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {};
+
+  /* Supply configuration update enable */
+  HAL_PWREx_ConfigSupply(PWR_LDO_SUPPLY);
+  /* Configure the main internal regulator output voltage */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE0);
+
+  while (!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {}
+  /* Macro to configure the PLL clock source */
+  __HAL_RCC_PLL_PLLSOURCE_CONFIG(RCC_PLLSOURCE_HSE);
+  /** Initializes the RCC Oscillators according to the specified parameters
+  * in the RCC_OscInitTypeDef structure.
+  */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI48 | RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSEState = RCC_HSE_BYPASS;
+  RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLM = 1;
+  RCC_OscInitStruct.PLL.PLLN = 120;
+  RCC_OscInitStruct.PLL.PLLP = 2;
+  RCC_OscInitStruct.PLL.PLLQ = 8;
+  RCC_OscInitStruct.PLL.PLLR = 2;
+  RCC_OscInitStruct.PLL.PLLRGE = RCC_PLL1VCIRANGE_3;
+  RCC_OscInitStruct.PLL.PLLVCOSEL = RCC_PLL1VCOWIDE;
+  RCC_OscInitStruct.PLL.PLLFRACN = 0;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+  /* Initializes the CPU, AHB and APB buses clocks */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK
+                                | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2
+                                | RCC_CLOCKTYPE_D3PCLK1 | RCC_CLOCKTYPE_D1PCLK1;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.SYSCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_HCLK_DIV2;
+  RCC_ClkInitStruct.APB3CLKDivider = RCC_APB3_DIV2;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_APB1_DIV2;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_APB2_DIV2;
+  RCC_ClkInitStruct.APB4CLKDivider = RCC_APB4_DIV2;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK) {
+    Error_Handler();
+  }
+  PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB | RCC_PERIPHCLK_QSPI
+                                             | RCC_PERIPHCLK_SDMMC | RCC_PERIPHCLK_ADC
+                                             | RCC_PERIPHCLK_LPUART1 | RCC_PERIPHCLK_USART16
+                                             | RCC_PERIPHCLK_USART234578 | RCC_PERIPHCLK_I2C123
+                                             | RCC_PERIPHCLK_I2C4 | RCC_PERIPHCLK_SPI123
+                                             | RCC_PERIPHCLK_SPI45 | RCC_PERIPHCLK_SPI6;
+  PeriphClkInitStruct.PLL2.PLL2M = 1;
+  PeriphClkInitStruct.PLL2.PLL2N = 20;
+  PeriphClkInitStruct.PLL2.PLL2P = 2;
+  PeriphClkInitStruct.PLL2.PLL2Q = 2;
+  PeriphClkInitStruct.PLL2.PLL2R = 2;
+  PeriphClkInitStruct.PLL2.PLL2RGE = RCC_PLL2VCIRANGE_3;
+  PeriphClkInitStruct.PLL2.PLL2VCOSEL = RCC_PLL2VCOMEDIUM;
+  PeriphClkInitStruct.PLL2.PLL2FRACN = 0.0;
+  PeriphClkInitStruct.PLL3.PLL3M = 1;
+  PeriphClkInitStruct.PLL3.PLL3N = 24;
+  PeriphClkInitStruct.PLL3.PLL3P = 2;
+  PeriphClkInitStruct.PLL3.PLL3Q = 6;
+  PeriphClkInitStruct.PLL3.PLL3R = 2;
+  PeriphClkInitStruct.PLL3.PLL3RGE = RCC_PLL3VCIRANGE_3;
+  PeriphClkInitStruct.PLL3.PLL3VCOSEL = RCC_PLL3VCOWIDE;
+  PeriphClkInitStruct.PLL3.PLL3FRACN = 0.0;
+  PeriphClkInitStruct.AdcClockSelection = RCC_ADCCLKSOURCE_PLL2;
+  PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
+  PeriphClkInitStruct.QspiClockSelection = RCC_QSPICLKSOURCE_D1HCLK;
+  PeriphClkInitStruct.SdmmcClockSelection = RCC_SDMMCCLKSOURCE_PLL;
+  PeriphClkInitStruct.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_PLL3;
+  PeriphClkInitStruct.Usart16ClockSelection = RCC_USART16CLKSOURCE_D2PCLK2;
+  PeriphClkInitStruct.Usart234578ClockSelection = RCC_USART234578CLKSOURCE_D2PCLK1;
+  PeriphClkInitStruct.I2c123ClockSelection = RCC_I2C123CLKSOURCE_D2PCLK1;
+  PeriphClkInitStruct.I2c4ClockSelection = RCC_I2C4CLKSOURCE_D3PCLK1;
+  PeriphClkInitStruct.Spi123ClockSelection = RCC_SPI123CLKSOURCE_PLL;
+  PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_D2PCLK1;
+  PeriphClkInitStruct.Spi6ClockSelection = RCC_SPI6CLKSOURCE_D3PCLK1;
+  if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ARDUINO_ */

--- a/variants/STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT/variant_NUCLEO_H753ZI.h
+++ b/variants/STM32H7xx/H742Z(G-I)T_H743Z(G-I)T_H747A(G-I)I_H747I(G-I)T_H750ZBT_H753ZIT_H757AII_H757IIT/variant_NUCLEO_H753ZI.h
@@ -1,0 +1,279 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2023, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#pragma once
+
+/*----------------------------------------------------------------------------
+ *        STM32 pins number
+ *----------------------------------------------------------------------------*/
+#define PB7                     0  // USART_A_RX
+#define PB6                     1  // USART_A_TX
+#define PG14                    2
+#define PE13                    3  // TIMER_A_PWM3
+#define PE14                    4
+#define PE11                    5  // TIMER_A_PWM2
+#define PE9                     6  // TIMER_A_PWM1
+#define PG12                    7
+#define PF3                     PIN_A19
+#define PD15                    9  // TIMER_B_PWM2
+#define PD14                    10 // SPI_A_CS/ TIM_B_PWM3
+#define PB5                     11 // SPI_A_MOSI/ PA7 if SB33 ON and SB35 OFF
+#define PA6                     PIN_A20 // SPI_A_MISO
+#define PA5                     PIN_A21 // SPI_A_SCK
+#define PB9                     14 // I2C_A_SDA
+#define PB8                     15 // I2C_A_SCL
+#define PC6                     16 // I2S_A_MCK
+#define PB15                    17 // I2S_A_SD
+#define PB13                    18 // I2S_A_CK / RMII TXD1 - JP6 ON (default)
+#define PB12                    19 // I2S_A_WS
+#define PA15                    20 // I2S_B_WS
+#define PC7                     21 // I2S_B_MCK
+// 22 is PB5                   (11)
+#define PB3                     23 // I2S_B_CK/SPI_B_SCK - SWO
+#define PA4                     PIN_A22 // SPI_B_NSS
+#define PB4                     25 // SPI_B_MISO
+#define PG6                     26 // QSPI_CS
+#define PB2                     27 // QSPI_CLK
+#define PD13                    28 // QSPI_BK1_IO3
+#define PD12                    29 // QSPI_BK1_IO1
+#define PD11                    30 // QSPI_BK1_IO0
+#define PE2                     31 // SAI_A_MCLK/QSPI_BK1_IO2
+#define PA0                     PIN_A23 // TIMER_C_PWM1
+#define PB0                     PIN_A24 // TIMER_D_PWM1 - LD1 LED_GREEN
+#define PE0                     34 // TIMER_B_ETR
+#define PB11                    35 // TIMER_C_PWM3
+#define PB10                    36 // TIMER_C_PWM2
+#define PE15                    37 // TIMER_A_BKIN1
+#define PE6                     38
+#define PE12                    39 // TIMER_A_PWM3N
+#define PE10                    40 // TIMER_A_PWM2N
+#define PE7                     41 // TIMER_A_ETR
+#define PE8                     42 // TIMER_A_PWM1N
+#define PC8                     43 // SDMMC1_D0
+#define PC9                     44 // SDMMC1_D1/I2S_A_CKIN
+#define PC10                    45 // SDMMC1_D2
+#define PC11                    46 // SDMMC1_D3
+#define PC12                    47 // SDMMC1_CK
+#define PD2                     48 // SDMMC1_CMD
+#define PG2                     49
+#define PG3                     50
+#define PD7                     51 // USART_B_SCLK
+#define PD6                     52 // USART_B_RX
+#define PD5                     53 // USART_B_TX
+#define PD4                     54 // USART_B_RTS
+#define PD3                     55 // USART_B_CTS
+// 56 is PE2                   (31)
+#define PE4                     57 // SAI_A_FS
+#define PE5                     58 // SAI_A_SCK
+// 59 is PE6                   (38)
+#define PE3                     60 // SAI_B_SD
+#define PF8                     PIN_A25 // SAI_B_SCK
+#define PF7                     PIN_A26 // SAI_B_MCLK
+#define PF9                     PIN_A27 // SAI_B_FS
+#define PG1                     64
+#define PG0                     65
+#define PD1                     66 // CAN_TX
+#define PD0                     67 // CAN_RX
+#define PF0                     68 // I2C_B_SDA
+#define PF1                     69 // I2C_B_SCL
+#define PF2                     70 // I2C_B_SMBA
+// 71 is PE9                   (6)
+// 72 is PB2                   (27)
+#define PA3                     PIN_A0
+#define PC0                     PIN_A1
+#define PC3_C                   PIN_A2
+#define PB1                     PIN_A3
+#define PC2_C                   PIN_A4
+#define PF10                    PIN_A5
+#define PF4                     PIN_A6
+#define PF5                     PIN_A7
+#define PF6                     PIN_A8
+#define PF11                    PIN_A9
+#define PA1                     PIN_A10 // RMII Reference Clock - SB57 ON (default)
+#define PA2                     PIN_A11 // RMII MDIO - SB72 ON (default)
+#define PA7                     PIN_A12 // RMII RX Data Valid - SB31 ON (default)
+#define PA8                     86
+#define PA9                     87
+#define PA10                    88
+#define PA11                    89
+#define PA12                    90
+#define PA13                    91
+#define PA14                    92
+#define PB14                    93  // LD3 LED_RED
+#define PC1                     PIN_A13
+#define PC4                     PIN_A14 // RMII RXD0 - SB36 ON (default)
+#define PC5                     PIN_A15 // RMII RXD1 - SB29 ON (default)
+#define PC13                    97
+#define PC14                    98
+#define PC15                    99  // USER_BTN
+#define PD8                     100
+#define PD9                     101
+#define PD10                    102 // Serial Tx
+#define PE1                     103 // Serial Rx
+#define PF12                    PIN_A16
+#define PF13                    PIN_A17 // LD2 LED_BLUE
+#define PF14                    PIN_A18
+#define PF15                    107
+#define PG4                     108
+#define PG5                     109
+#define PG7                     110
+#define PG8                     111
+#define PG9                     112
+#define PG10                    113
+#define PG11                    114 // RMII TX Enable - SB27 ON (default)
+#define PG13                    115 // RXII TXD0 - SB30 ON (default)
+#define PG15                    116
+#define PH0                     117
+#define PH1                     118
+
+// Alternate pins number
+#define PA0_ALT1                (PA0  | ALT1)
+#define PA1_ALT1                (PA1  | ALT1)
+#define PA1_ALT2                (PA1  | ALT2)
+#define PA2_ALT1                (PA2  | ALT1)
+#define PA2_ALT2                (PA2  | ALT2)
+#define PA3_ALT1                (PA3  | ALT1)
+#define PA3_ALT2                (PA3  | ALT2)
+#define PA4_ALT1                (PA4  | ALT1)
+#define PA4_ALT2                (PA4  | ALT2)
+#define PA5_ALT1                (PA5  | ALT1)
+#define PA6_ALT1                (PA6  | ALT1)
+#define PA7_ALT1                (PA7  | ALT1)
+#define PA7_ALT2                (PA7  | ALT2)
+#define PA7_ALT3                (PA7  | ALT3)
+#define PA9_ALT1                (PA9  | ALT1)
+#define PA10_ALT1               (PA10 | ALT1)
+#define PA11_ALT1               (PA11 | ALT1)
+#define PA12_ALT1               (PA12 | ALT1)
+#define PA15_ALT1               (PA15 | ALT1)
+#define PA15_ALT2               (PA15 | ALT2)
+#define PB0_ALT1                (PB0  | ALT1)
+#define PB0_ALT2                (PB0  | ALT2)
+#define PB1_ALT1                (PB1  | ALT1)
+#define PB1_ALT2                (PB1  | ALT2)
+#define PB3_ALT1                (PB3  | ALT1)
+#define PB3_ALT2                (PB3  | ALT2)
+#define PB4_ALT1                (PB4  | ALT1)
+#define PB4_ALT2                (PB4  | ALT2)
+#define PB5_ALT1                (PB5  | ALT1)
+#define PB5_ALT2                (PB5  | ALT2)
+#define PB6_ALT1                (PB6  | ALT1)
+#define PB6_ALT2                (PB6  | ALT2)
+#define PB7_ALT1                (PB7  | ALT1)
+#define PB8_ALT1                (PB8  | ALT1)
+#define PB8_ALT2                (PB8  | ALT2)
+#define PB9_ALT1                (PB9  | ALT1)
+#define PB9_ALT2                (PB9  | ALT2)
+#define PB14_ALT1               (PB14 | ALT1)
+#define PB14_ALT2               (PB14 | ALT2)
+#define PB15_ALT1               (PB15 | ALT1)
+#define PB15_ALT2               (PB15 | ALT2)
+#define PC0_ALT1                (PC0  | ALT1)
+#define PC0_ALT2                (PC0  | ALT2)
+#define PC1_ALT1                (PC1  | ALT1)
+#define PC1_ALT2                (PC1  | ALT2)
+#define PC4_ALT1                (PC4  | ALT1)
+#define PC5_ALT1                (PC5  | ALT1)
+#define PC6_ALT1                (PC6  | ALT1)
+#define PC6_ALT2                (PC6  | ALT2)
+#define PC7_ALT1                (PC7  | ALT1)
+#define PC7_ALT2                (PC7  | ALT2)
+#define PC8_ALT1                (PC8  | ALT1)
+#define PC9_ALT1                (PC9  | ALT1)
+#define PC10_ALT1               (PC10 | ALT1)
+#define PC11_ALT1               (PC11 | ALT1)
+#define PF8_ALT1                (PF8  | ALT1)
+#define PF9_ALT1                (PF9  | ALT1)
+
+#define NUM_DIGITAL_PINS        119
+#define NUM_DUALPAD_PINS        2
+#define NUM_ANALOG_INPUTS       28
+
+// On-board LED pin number
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN           PB0  // LD1
+#endif
+#define LED_GREEN               LED_BUILTIN
+#define LED_BLUE                PB7  // LD2
+#define LED_RED                 PB14 // LD3
+
+// On-board user button
+#ifndef USER_BTN
+  #define USER_BTN              PC13
+#endif
+
+// Timer Definitions
+// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
+#ifndef TIMER_TONE
+  #define TIMER_TONE            TIM6
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO           TIM7
+#endif
+
+// UART Definitions
+#ifndef SERIAL_UART_INSTANCE
+  #define SERIAL_UART_INSTANCE  3 //Connected to ST-Link
+#endif
+
+// Serial pin used for console (ex: ST-Link)
+// Required by Firmata
+#ifndef PIN_SERIAL_RX
+  #define PIN_SERIAL_RX         PD9
+#endif
+#ifndef PIN_SERIAL_TX
+  #define PIN_SERIAL_TX         PD8
+#endif
+
+// HSE default value is 25MHz in HAL
+// HSE_BYPASS is 8MHz
+#ifndef HSE_BYPASS_NOT_USED
+  #define HSE_VALUE             8000000
+#endif
+
+// Extra HAL modules
+#if !defined(HAL_DAC_MODULE_DISABLED)
+  #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_ETH_MODULE_DISABLED)
+  #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_QSPI_MODULE_DISABLED)
+  #define HAL_QSPI_MODULE_ENABLED
+#endif
+#if !defined(HAL_SD_MODULE_DISABLED)
+  #define HAL_SD_MODULE_ENABLED
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+  // These serial port names are intended to allow libraries and architecture-neutral
+  // sketches to automatically default to the correct port name for a particular type
+  // of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+  // the first hardware serial port whose RX/TX pins are not dedicated to another use.
+  //
+  // SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+  //
+  // SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+  //
+  // SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+  //
+  // SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+  //
+  // SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+  //                            pins are NOT connected to anything by default.
+  #define SERIAL_PORT_MONITOR     Serial
+  #define SERIAL_PORT_HARDWARE    Serial
+#endif


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR adds the support for [NUCLEO-H753ZI](https://www.st.com/ja/evaluation-tools/nucleo-h753zi.html) board
This board is same to nucleo-h743zi2, as the user manual is [same](https://www.st.com/resource/en/user_manual/um2407-stm32h7-nucleo144-boards-mb1364-stmicroelectronics.pdf).
And the samples in the official Firmware Package are also [same](https://github.com/STMicroelectronics/STM32CubeH7/tree/master/Projects/NUCLEO-H753ZI), so this board has compatibility with nucleo-h743zi2.

I'm not sure which is better, using existing variant file for H743ZI(2) or create a new one for H753ZI.
(In the first commit, I create a new variant file for H753ZI which is copied from H743ZI)

My board will deliver tomorrow. After the delivery, I can run tests but not sure what should be tested on the real board.

**Validation**

* [x] Ensure CI build is passed.
* [x] Run the [tests](https://github.com/stm32duino/STM32Examples/tree/main/examples/NonReg/CheckVariant) on the board

