### PR TITLE
Add support for setting the channel input filter

### DIFF
--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -91,7 +91,7 @@ typedef enum {
 } TimerCompareFormat_t;
 
 typedef enum {
-  FILTER_NONE = 1,  // No filter
+  FILTER_NONE = 0,  // No filter
   FILTER_CKINT_N2,  // Sampling rate is same as clock interrupt, n=2 events
   FILTER_CKINT_N4,  // Sampling rate is same as clock interrupt, n=4 events
   FILTER_CKINT_N8,  // Sampling rate is same as clock interrupt, n=8 events

--- a/cores/arduino/HardwareTimer.h
+++ b/cores/arduino/HardwareTimer.h
@@ -90,6 +90,25 @@ typedef enum {
   PERCENT_COMPARE_FORMAT, // used for Dutycycle
 } TimerCompareFormat_t;
 
+typedef enum {
+  FILTER_NONE = 1,  // No filter
+  FILTER_CKINT_N2,  // Sampling rate is same as clock interrupt, n=2 events
+  FILTER_CKINT_N4,  // Sampling rate is same as clock interrupt, n=4 events
+  FILTER_CKINT_N8,  // Sampling rate is same as clock interrupt, n=8 events
+  FILTER_DTS2_N6,   // Sampling rate is DTS/2, n=6 events
+  FILTER_DTS2_N8,   // Sampling rate is DTS/2, n=8 events
+  FILTER_DTS4_N6,   // Sampling rate is DTS/4, n=6 events
+  FILTER_DTS4_N8,   // Sampling rate is DTS/4, n=8 events
+  FILTER_DTS8_N6,   // Sampling rate is DTS/8, n=6 events
+  FILTER_DTS8_N8,   // Sampling rate is DTS/8, n=8 events
+  FILTER_DTS16_N5,  // Sampling rate is DTS/16, n=5 events
+  FILTER_DTS16_N6,  // Sampling rate is DTS/16, n=6 events
+  FILTER_DTS16_N8,  // Sampling rate is DTS/16, n=8 events
+  FILTER_DTS32_N5,  // Sampling rate is DTS/32, n=5 events
+  FILTER_DTS32_N6,  // Sampling rate is DTS/32, n=6 events
+  FILTER_DTS32_N8,  // Sampling rate is DTS/32, n=8 events
+} ChannelInputFilter_t;
+
 #ifdef __cplusplus
 
 #include <functional>
@@ -121,8 +140,8 @@ class HardwareTimer {
     void setCount(uint32_t val, TimerFormat_t format = TICK_FORMAT); // set timer counter to value 'val' depending on format provided
     uint32_t getCount(TimerFormat_t format = TICK_FORMAT);  // return current counter value of timer depending on format provided
 
-    void setMode(uint32_t channel, TimerModes_t mode, PinName pin = NC); // Configure timer channel with specified mode on specified pin if available
-    void setMode(uint32_t channel, TimerModes_t mode, uint32_t pin);
+    void setMode(uint32_t channel, TimerModes_t mode, PinName pin = NC, ChannelInputFilter_t filter = FILTER_NONE); // Configure timer channel with specified mode on specified pin if available
+    void setMode(uint32_t channel, TimerModes_t mode, uint32_t pin, ChannelInputFilter_t filter = FILTER_NONE);
 
     TimerModes_t getMode(uint32_t channel);  // Retrieve configured mode
 

--- a/libraries/SrcWrapper/src/HardwareTimer.cpp
+++ b/libraries/SrcWrapper/src/HardwareTimer.cpp
@@ -624,61 +624,6 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, uint32_t pin, C
   setMode(channel, mode, digitalPinToPinName(pin), filter);
 }
 
-inline uint8_t getICFBitsFromFilterMode(ChannelInputFilter_t filter)
-{
-  switch (filter) {
-    case FILTER_NONE:
-      return 0;
-      break;
-    case FILTER_CKINT_N2:
-      return 1;
-      break;
-    case FILTER_CKINT_N4:
-      return 2;
-      break;
-    case FILTER_CKINT_N8:
-      return 3;
-      break;
-    case FILTER_DTS2_N6:
-      return 4;
-      break;
-    case FILTER_DTS2_N8:
-      return 5;
-      break;
-    case FILTER_DTS4_N6:
-      return 6;
-      break;
-    case FILTER_DTS4_N8:
-      return 7;
-      break;
-    case FILTER_DTS8_N6:
-      return 8;
-      break;
-    case FILTER_DTS8_N8:
-      return 9;
-      break;
-    case FILTER_DTS16_N5:
-      return 10;
-      break;
-    case FILTER_DTS16_N6:
-      return 11;
-      break;
-    case FILTER_DTS16_N8:
-      return 12;
-      break;
-    case FILTER_DTS32_N5:
-      return 13;
-      break;
-    case FILTER_DTS32_N6:
-      return 14;
-      break;
-    case FILTER_DTS32_N8:
-      return 15;
-      break;
-  }
-  return 0;
-}
-
 /**
   * @brief  Set channel mode
   * @param  channel: Arduino channel [1..4]
@@ -714,7 +659,7 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin, Ch
   channelIC.ICPolarity = TIM_ICPOLARITY_RISING;
   channelIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
   channelIC.ICPrescaler = TIM_ICPSC_DIV1;
-  channelIC.ICFilter = getICFBitsFromFilterMode(filter);
+  channelIC.ICFilter = filter;
 
   switch (mode) {
     case TIMER_DISABLED:

--- a/libraries/SrcWrapper/src/HardwareTimer.cpp
+++ b/libraries/SrcWrapper/src/HardwareTimer.cpp
@@ -619,9 +619,62 @@ void HardwareTimer::setCount(uint32_t counter, TimerFormat_t format)
   * @param  pin: Arduino pin number, ex: D1, 1 or PA1
   * @retval None
   */
-void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, uint32_t pin)
+void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, uint32_t pin, ChannelInputFilter_t filter)
 {
-  setMode(channel, mode, digitalPinToPinName(pin));
+  setMode(channel, mode, digitalPinToPinName(pin), filter);
+}
+
+inline uint8_t  getICFBitsFromFilterMode(ChannelInputFilter_t filter) {
+  switch (filter) {
+  case FILTER_NONE:
+      return 0;
+      break;
+  case FILTER_CKINT_N2:
+      return 1;
+      break;
+  case FILTER_CKINT_N4:
+      return 2;
+      break;
+  case FILTER_CKINT_N8:
+      return 3;
+      break;
+  case FILTER_DTS2_N6:
+      return 4;
+      break;
+  case FILTER_DTS2_N8:
+      return 5;
+      break;
+  case FILTER_DTS4_N6:
+      return 6;
+      break;
+  case FILTER_DTS4_N8:
+      return 7;
+      break;
+  case FILTER_DTS8_N6:
+      return 8;
+      break;
+  case FILTER_DTS8_N8:
+      return 9;
+      break;
+  case FILTER_DTS16_N5:
+      return 10;
+      break;
+  case FILTER_DTS16_N6:
+      return 11;
+      break;
+  case FILTER_DTS16_N8:
+      return 12;
+      break;
+  case FILTER_DTS32_N5:
+      return 13;
+      break;
+  case FILTER_DTS32_N6:
+      return 14;
+      break;
+  case FILTER_DTS32_N8:
+      return 15;
+      break;
+  }
 }
 
 /**
@@ -631,7 +684,7 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, uint32_t pin)
   * @param  pin: pin name, ex: PB_0
   * @retval None
   */
-void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin)
+void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin, ChannelInputFilter_t filter)
 {
   int timChannel = getChannel(channel);
   int timAssociatedInputChannel;
@@ -659,7 +712,7 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin)
   channelIC.ICPolarity = TIM_ICPOLARITY_RISING;
   channelIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
   channelIC.ICPrescaler = TIM_ICPSC_DIV1;
-  channelIC.ICFilter = 0;
+  channelIC.ICFilter = getICFBitsFromFilterMode(filter);
 
   switch (mode) {
     case TIMER_DISABLED:

--- a/libraries/SrcWrapper/src/HardwareTimer.cpp
+++ b/libraries/SrcWrapper/src/HardwareTimer.cpp
@@ -624,57 +624,59 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, uint32_t pin, C
   setMode(channel, mode, digitalPinToPinName(pin), filter);
 }
 
-inline uint8_t  getICFBitsFromFilterMode(ChannelInputFilter_t filter) {
+inline uint8_t getICFBitsFromFilterMode(ChannelInputFilter_t filter)
+{
   switch (filter) {
-  case FILTER_NONE:
+    case FILTER_NONE:
       return 0;
       break;
-  case FILTER_CKINT_N2:
+    case FILTER_CKINT_N2:
       return 1;
       break;
-  case FILTER_CKINT_N4:
+    case FILTER_CKINT_N4:
       return 2;
       break;
-  case FILTER_CKINT_N8:
+    case FILTER_CKINT_N8:
       return 3;
       break;
-  case FILTER_DTS2_N6:
+    case FILTER_DTS2_N6:
       return 4;
       break;
-  case FILTER_DTS2_N8:
+    case FILTER_DTS2_N8:
       return 5;
       break;
-  case FILTER_DTS4_N6:
+    case FILTER_DTS4_N6:
       return 6;
       break;
-  case FILTER_DTS4_N8:
+    case FILTER_DTS4_N8:
       return 7;
       break;
-  case FILTER_DTS8_N6:
+    case FILTER_DTS8_N6:
       return 8;
       break;
-  case FILTER_DTS8_N8:
+    case FILTER_DTS8_N8:
       return 9;
       break;
-  case FILTER_DTS16_N5:
+    case FILTER_DTS16_N5:
       return 10;
       break;
-  case FILTER_DTS16_N6:
+    case FILTER_DTS16_N6:
       return 11;
       break;
-  case FILTER_DTS16_N8:
+    case FILTER_DTS16_N8:
       return 12;
       break;
-  case FILTER_DTS32_N5:
+    case FILTER_DTS32_N5:
       return 13;
       break;
-  case FILTER_DTS32_N6:
+    case FILTER_DTS32_N6:
       return 14;
       break;
-  case FILTER_DTS32_N8:
+    case FILTER_DTS32_N8:
       return 15;
       break;
   }
+  return 0;
 }
 
 /**


### PR DESCRIPTION
## Pull Request template

Please, Make sure that your PR is not a duplicate.
Search among the [Pull request](https://github.com/stm32duino/Arduino_Core_STM32/pulls) before creating one.

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

Thanks for submitting a pull request.
Please provide enough information so that others can review your pull request:

**Summary**

<!-- Summary of the PR -->

This PR implements the following **feature**

- Support for input channel filtering in HardwareTimer

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Currently, HardwareTimer sets the input channel filter to none, any time the mode of the timer is set.
This PR enables the input filter to be set along with the mode.

It is possible to enable setting the input filter separately from the mode if wanted.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Validation**

Tested with a waveform generator vs sketch outputting pulse widths + levels

<!-- Make sure tests pass on both CI. -->
