### PR TITLE
fix(Wire): avoid memory leaks

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -45,6 +45,15 @@ TwoWire::TwoWire(uint32_t sda, uint32_t scl)
   _i2c.scl = digitalPinToPinName(scl);
 }
 
+/**
+  * @brief  TwoWire destructor
+  * @retval None
+  */
+TwoWire::~TwoWire()
+{
+  end();
+}
+
 // Public Methods //////////////////////////////////////////////////////////////
 
 void TwoWire::begin(uint32_t sda, uint32_t scl)
@@ -106,11 +115,15 @@ void TwoWire::begin(int address, bool generalCall, bool NoStretchMode)
 void TwoWire::end(void)
 {
   i2c_deinit(&_i2c);
-  free(txBuffer);
-  txBuffer = nullptr;
+  if (txBuffer != nullptr) {
+    free(txBuffer);
+    txBuffer = nullptr;
+  }
   txBufferAllocated = 0;
-  free(rxBuffer);
-  rxBuffer = nullptr;
+  if (rxBuffer != nullptr) {
+    free(rxBuffer);
+    rxBuffer = nullptr;
+  }
   rxBufferAllocated = 0;
 }
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -78,6 +78,7 @@ class TwoWire : public Stream {
   public:
     TwoWire();
     TwoWire(uint32_t sda, uint32_t scl);
+    ~TwoWire();
     // setSCL/SDA have to be called before begin()
     void setSCL(uint32_t scl)
     {


### PR DESCRIPTION
add destructor to call end().
Fixes #2142

<details>
  <summary>Tested with this example:</summary>

```C++
#include <Wire.h>
#include <malloc.h>

extern "C" char *sbrk(int i);
/* Use linker definition */
extern char _end;
extern char _sdata;
extern char _estack;
extern char _Min_Stack_Size;

static char *ramstart = &_sdata;
static char *ramend = &_estack;
static char *minSP = (char *)(ramend - &_Min_Stack_Size);

void display_mallinfo(void) {
  char *heapend = (char *)sbrk(0);
  char *stack_ptr = (char *)__get_MSP();
  struct mallinfo mi = mallinfo();

  Serial.print("Total non-mmapped bytes (arena):       ");
  Serial.println(mi.arena);
  Serial.print("# of free chunks (ordblks):            ");
  Serial.println(mi.ordblks);
  Serial.print("# of free fastbin blocks (smblks):     ");
  Serial.println(mi.smblks);
  Serial.print("# of mapped regions (hblks):           ");
  Serial.println(mi.hblks);
  Serial.print("Bytes in mapped regions (hblkhd):      ");
  Serial.println(mi.hblkhd);
  Serial.print("Max. total allocated space (usmblks):  ");
  Serial.println(mi.usmblks);
  Serial.print("Free bytes held in fastbins (fsmblks): ");
  Serial.println(mi.fsmblks);
  Serial.print("Total allocated space (uordblks):      ");
  Serial.println(mi.uordblks);
  Serial.print("Total free space (fordblks):           ");
  Serial.println(mi.fordblks);
  Serial.print("Topmost releasable block (keepcost):   ");
  Serial.println(mi.keepcost);

  Serial.print("RAM Start at:       0x");
  Serial.println((unsigned long)ramstart, HEX);
  Serial.print("Data/Bss end at:    0x");
  Serial.println((unsigned long)&_end, HEX);
  Serial.print("Heap end at:        0x");
  Serial.println((unsigned long)heapend, HEX);
  Serial.print("Stack Ptr end at:   0x");
  Serial.println((unsigned long)stack_ptr, HEX);
  Serial.print("RAM End at:         0x");
  Serial.println((unsigned long)ramend, HEX);

  Serial.print("Heap RAM Used:      ");
  Serial.println(mi.uordblks);
  Serial.print("Program RAM Used:   ");
  Serial.println(&_end - ramstart);
  Serial.print("Stack RAM Used:     ");
  Serial.println(ramend - stack_ptr);
  Serial.print("Estimated Free RAM: ");
  Serial.println(((stack_ptr < minSP) ? stack_ptr : minSP) - heapend + mi.fordblks);
}

void setup() {
  // initialize serial communication at 115200 bits per second:
  Serial.begin(115200);
  delay(1000);
}
#define DATA_SIZE WIRE_MAX_TX_BUFF_LENGTH
const uint8_t data[DATA_SIZE] = { 0xFF };
void loop() {

  Serial.println("============== Before allocating blocks ==============");
  display_mallinfo();
  // Instantiate Wire
  TwoWire Wire1 = TwoWire();
  Wire1.begin();
  Wire1.beginTransmission(0x38);
  Wire1.write(data, DATA_SIZE);

  Serial.println("============== After allocating blocks ==============");
  display_mallinfo();
  delay(1000);
}
```

</details>