### PR TITLE
fix(backup): enable RTC clock for TAMP backup registers

### DIFF
--- a/cores/arduino/stm32/backup.h
+++ b/cores/arduino/stm32/backup.h
@@ -86,6 +86,10 @@ static inline void enableBackupDomain(void)
   /* Enable BKPSRAM CLK for backup SRAM */
   __HAL_RCC_BKPSRAM_CLK_ENABLE();
 #endif
+#if defined(TAMP_BKP0R) && defined(__HAL_RCC_RTCAPB_CLK_ENABLE)
+  /* Enable RTC CLK for TAMP backup registers */
+  __HAL_RCC_RTCAPB_CLK_ENABLE();
+#endif
 }
 
 static inline void disableBackupDomain(void)
@@ -101,6 +105,10 @@ static inline void disableBackupDomain(void)
 #ifdef __HAL_RCC_BKP_CLK_DISABLE
   /* Disable BKP CLK for backup registers */
   __HAL_RCC_BKP_CLK_DISABLE();
+#endif
+#if defined(TAMP_BKP0R) && defined(__HAL_RCC_RTCAPB_CLK_DISABLE)
+  /* Disable RTC CLK for TAMP backup registers */
+  __HAL_RCC_RTCAPB_CLK_DISABLE();
 #endif
 }
 


### PR DESCRIPTION
Fixes #2152.

Fix also for STM32U5xx.
