### PR TITLE
Wrap cmake policies in if statements

### DIFF
--- a/cmake/FindArduinoCtags.cmake
+++ b/cmake/FindArduinoCtags.cmake
@@ -6,7 +6,9 @@ function(get_ctags)
 
   # Prevent warnings in CMake>=3.24 regarding ExternalProject_Add()
   # cf. https://cmake.org/cmake/help/latest/policy/CMP0135.html
-  cmake_policy(SET CMP0135 OLD)
+  if (POLICY CMP0135)
+    cmake_policy(SET CMP0135 OLD)
+  endif()
 
   cmake_host_system_information(
     RESULT HOSTINFO

--- a/cmake/ensure_core_deps.cmake
+++ b/cmake/ensure_core_deps.cmake
@@ -61,7 +61,9 @@ function(declare_deps CORE_VERSION)
 
   # Prevent warnings in CMake>=3.24 regarding ExternalProject_Add()
   # cf. https://cmake.org/cmake/help/latest/policy/CMP0135.html
-  cmake_policy(SET CMP0135 OLD)
+  if (POLICY CMP0135)
+    cmake_policy(SET CMP0135 OLD)
+  endif()
 
   file(REAL_PATH "${DL_DIR}/package_stmicroelectronics_index.json" JSONFILE)
   if (NOT EXISTS ${JSONFILE})


### PR DESCRIPTION
**Summary**

The policy statements for CMake policy CMP0135 do not have if statements around them.
As a result, if you have a CMake version less than 3.24 CMake will fail

The policies should have an if statement so that versions between 3.21 and 3.24 can be built.