### PR TITLE
Optimize flash accesses to reduce wear and increase speed

### DIFF
--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -241,14 +241,14 @@ struct EEPROMClass {
     EEPtr e = idx;
     const uint8_t *ptr = (const uint8_t *) &t;
 #if !defined(DATA_EEPROM_BASE)
-    eeprom_disable_auto_flush();
+    eeprom_auto_flush(false);
 #endif
     for (int count = sizeof(T) ; count ; --count, ++e) {
       (*e).update(*ptr++);
     }
 #if !defined(DATA_EEPROM_BASE)
     eeprom_buffer_flush();
-    eeprom_enable_auto_flush();
+    eeprom_auto_flush(true);
 #endif
     return t;
   }

--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -240,9 +240,16 @@ struct EEPROMClass {
   {
     EEPtr e = idx;
     const uint8_t *ptr = (const uint8_t *) &t;
+#if !defined(DATA_EEPROM_BASE)
+    eeprom_disable_auto_flush();
+#endif
     for (int count = sizeof(T) ; count ; --count, ++e) {
       (*e).update(*ptr++);
     }
+#if !defined(DATA_EEPROM_BASE)
+    eeprom_buffer_flush();
+    eeprom_enable_auto_flush();
+#endif
     return t;
   }
 };

--- a/libraries/EEPROM/src/utility/stm32_eeprom.c
+++ b/libraries/EEPROM/src/utility/stm32_eeprom.c
@@ -150,24 +150,14 @@ void eeprom_write_byte(uint32_t pos, uint8_t value)
 #if !defined(DATA_EEPROM_BASE)
 
 /**
-  * @brief  This function disables the auto flush in eeprom_write_byte - user will need to call eeprom_buffer_flush() explicitly
+  * @brief  This function controls the auto flush in eeprom_write_byte - user will need to call eeprom_buffer_flush() explicitly if disabled
   *         It affects write operations through eeprom_write_byte() explicit call, EEPtr, EERef and EEPROMClass classes
   * @param  none
   * @retval none
   */
-void disable_auto_flush(void)
+void eeprom_auto_flush(bool enable)
 {
-  do_auto_flush = false;
-}
-
-/**
-  * @brief  This function enables the auto flush in eeprom_write_byte - it is enabled by default
-  * @param  none
-  * @retval none
-  */
-void enable_auto_flush(void)
-{
-  do_auto_flush = true;
+  do_auto_flush = enable;
 }
 
 /**

--- a/libraries/EEPROM/src/utility/stm32_eeprom.c
+++ b/libraries/EEPROM/src/utility/stm32_eeprom.c
@@ -100,6 +100,7 @@ extern "C" {
 #endif /* FLASH_BASE_ADDRESS */
 
 #if !defined(DATA_EEPROM_BASE)
+static bool is_buffer_filled = false, is_buffer_dirty = false;
 static uint8_t eeprom_buffer[E2END + 1] __attribute__((aligned(8))) = {0};
 #endif
 
@@ -166,6 +167,7 @@ uint8_t eeprom_buffered_read_byte(const uint32_t pos)
 void eeprom_buffered_write_byte(uint32_t pos, uint8_t value)
 {
   eeprom_buffer[pos] = value;
+  is_buffer_dirty = true;
 }
 
 /**
@@ -175,6 +177,8 @@ void eeprom_buffered_write_byte(uint32_t pos, uint8_t value)
   */
 void eeprom_buffer_fill(void)
 {
+  if(is_buffer_filled)
+    return;
 #if defined(ICACHE) && defined (HAL_ICACHE_MODULE_ENABLED) && !defined(HAL_ICACHE_MODULE_DISABLED)
   bool icache_enabled = false;
   if (HAL_ICACHE_IsEnabled() == 1) {
@@ -194,6 +198,7 @@ void eeprom_buffer_fill(void)
     }
   }
 #endif /* ICACHE && HAL_ICACHE_MODULE_ENABLED && !HAL_ICACHE_MODULE_DISABLED */
+  is_buffer_filled = true;
 }
 
 #if defined(EEPROM_RETRAM_MODE)
@@ -217,6 +222,8 @@ void eeprom_buffer_flush(void)
   */
 void eeprom_buffer_flush(void)
 {
+  if(!is_buffer_dirty)
+    return;
 #if defined(ICACHE) && defined (HAL_ICACHE_MODULE_ENABLED) && !defined(HAL_ICACHE_MODULE_DISABLED)
   bool icache_enabled = false;
   if (HAL_ICACHE_IsEnabled() == 1) {
@@ -337,6 +344,7 @@ void eeprom_buffer_flush(void)
     }
   }
 #endif /* ICACHE && HAL_ICACHE_MODULE_ENABLED && !HAL_ICACHE_MODULE_DISABLED */
+  is_buffer_dirty = false;
 }
 
 #endif /* defined(EEPROM_RETRAM_MODE) */

--- a/libraries/EEPROM/src/utility/stm32_eeprom.c
+++ b/libraries/EEPROM/src/utility/stm32_eeprom.c
@@ -189,7 +189,6 @@ uint8_t eeprom_buffered_read_byte(const uint32_t pos)
 void eeprom_buffered_write_byte(uint32_t pos, uint8_t value)
 {
   eeprom_buffer[pos] = value;
-  is_buffer_dirty = true;
 }
 
 /**

--- a/libraries/EEPROM/src/utility/stm32_eeprom.h
+++ b/libraries/EEPROM/src/utility/stm32_eeprom.h
@@ -116,8 +116,7 @@ void eeprom_write_byte(uint32_t pos, uint8_t value);
 #if !defined(DATA_EEPROM_BASE)
 void eeprom_buffer_fill();
 void eeprom_buffer_flush();
-void eeprom_disable_auto_flush();
-void eeprom_enable_auto_flush();
+void eeprom_auto_flush(bool enable);
 uint8_t eeprom_buffered_read_byte(const uint32_t pos);
 void eeprom_buffered_write_byte(uint32_t pos, uint8_t value);
 #endif /* ! DATA_EEPROM_BASE */

--- a/libraries/EEPROM/src/utility/stm32_eeprom.h
+++ b/libraries/EEPROM/src/utility/stm32_eeprom.h
@@ -116,6 +116,8 @@ void eeprom_write_byte(uint32_t pos, uint8_t value);
 #if !defined(DATA_EEPROM_BASE)
 void eeprom_buffer_fill();
 void eeprom_buffer_flush();
+void eeprom_disable_auto_flush();
+void eeprom_enable_auto_flush();
 uint8_t eeprom_buffered_read_byte(const uint32_t pos);
 void eeprom_buffered_write_byte(uint32_t pos, uint8_t value);
 #endif /* ! DATA_EEPROM_BASE */


### PR DESCRIPTION
**Summary**

This PR introduces two bool flags to avoid unnecessary flash rereads to buffer and flash page erases when writing big objects in EEPROMClass::put.

This will improve the flash memory lifetime and access speed by skipping flash reads or erases when unnecessary.

This PR is based on the results of the discussion https://github.com/orgs/stm32duino/discussions/2161.