### PR TITLE
Fixed SPI mode enum in SubGHz library

### DIFF
--- a/libraries/SubGhz/src/SubGhz.h
+++ b/libraries/SubGhz/src/SubGhz.h
@@ -101,7 +101,7 @@ class SubGhzClass {
     // supported by the radio, which should always work (no chance of
     // bad wiring that requires reducing the speed).
     // This value should be passed to `SubGhz.SPI.beginTransaction()`.
-    static constexpr SPISettings spi_settings = {16000000, MSBFIRST, SPI_MODE_0};
+    static constexpr SPISettings spi_settings = {16000000, MSBFIRST, SPI_MODE0};
 
   protected:
     // To access handleIrq()


### PR DESCRIPTION
Hello, I found this issue in the following CI run for RadioLib: https://github.com/jgromes/RadioLib/actions/runs/6914863886/job/18813152408#step:8:28

**Summary**

This PR fixes unknown SPI mode in SubGHz library (changed in 392469a1dc66448dea543119b7258128b5596a03).
