### PR TITLE
fix(SubGhz): SPISettings not properly defined

### DIFF
--- a/libraries/SubGhz/src/SubGhz.cpp
+++ b/libraries/SubGhz/src/SubGhz.cpp
@@ -21,8 +21,6 @@ extern "C" void SUBGHZ_Radio_IRQHandler(void)
   SubGhz.handleIrq();
 }
 
-constexpr SPISettings SubGhzClass::spi_settings;
-
 void SubGhzClass::handleIrq()
 {
   if (callback) {

--- a/libraries/SubGhz/src/SubGhz.h
+++ b/libraries/SubGhz/src/SubGhz.h
@@ -101,7 +101,7 @@ class SubGhzClass {
     // supported by the radio, which should always work (no chance of
     // bad wiring that requires reducing the speed).
     // This value should be passed to `SubGhz.SPI.beginTransaction()`.
-    static constexpr SPISettings spi_settings = {16000000, MSBFIRST, SPI_MODE0};
+    const SPISettings spi_settings = {16000000, MSBFIRST, SPI_MODE0};
 
   protected:
     // To access handleIrq()


### PR DESCRIPTION
after SPI rework.

#2191 is not enough to fix `SPISettings` of the SubGhz library.

/cc @jgromes 



