### PR TITLE
Fixed memory on Wire instance

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -35,12 +35,14 @@ static const uint8_t MASTER_ADDRESS = 0x01;
 
 TwoWire::TwoWire()
 {
+  memset((void *)&_i2c, 0, sizeof(_i2c));
   _i2c.sda = digitalPinToPinName(SDA);
   _i2c.scl = digitalPinToPinName(SCL);
 }
 
 TwoWire::TwoWire(uint32_t sda, uint32_t scl)
 {
+  memset((void *)&_i2c, 0, sizeof(_i2c));
   _i2c.sda = digitalPinToPinName(sda);
   _i2c.scl = digitalPinToPinName(scl);
 }


### PR DESCRIPTION

## Fixing memory cleanup on Wire instance

**Summary**

<!-- Summary of the PR -->
The constructor doesn't cleanup memory for a wire instance.

Issues could happen, such as wrong initialization.

This PR fixes/implements the following **bugs/features**

* [x] Issue on locked/bad allocated i2c on turning on

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
Example of bad behaviour using a STM32F411 and an APDS9960 sensor:
```C++
#include "Arduino_APDS9960.h"

APDS9960 * apds;
TwoWire * wire;

void setup() {
  Serial.begin(115200);

  wire=new TwoWire(PB7,PB8);
  wire->begin();
  apds = new APDS9960(*wire,PC10);
  apds->begin();
}

void loop() {
  if (apds->proximityAvailable()) {
    int value = apds->readProximity();
    Serial.println(value);
  }
}
```

The bad behaviour is that after turn off and on the board, wire locks.
Note: it works if you go from boot mode to running mode

This pull request solve this issue adding the following line in TwoWire constructors.
```C++
memset((void*)&_i2c, 0, sizeof(_i2c));
```
