### PR TITLE
fix(nucleo_f722ze): remove duplicate PE2 definition

### DIFF
--- a/variants/STM32F7xx/F722Z(C-E)T_F732ZET/variant_NUCLEO_F722ZE.h
+++ b/variants/STM32F7xx/F722Z(C-E)T_F732ZET/variant_NUCLEO_F722ZE.h
@@ -71,7 +71,7 @@
 #define PD5                     53
 #define PD4                     54
 #define PD3                     55
-#define PE2                     56
+// 56 is PE2                   (31)
 #define PE4                     57
 #define PE5                     58
 #define PE6                     59


### PR DESCRIPTION
Fixes #2199