### PR TITLE
feat(spi): add transfer api with tx and rx buffer

### DIFF
--- a/libraries/SPI/README.md
+++ b/libraries/SPI/README.md
@@ -7,16 +7,18 @@ User have 2 possibilities about the management of the CS pin:
 * the CS pin is managed directly by the user code before to transfer the data (like the Arduino SPI library)
 * the user uses a hardware CS pin linked to the SPI peripheral
 
-### New API functions
+## New API functions
 
-* `SPIClass::SPIClass(uint8_t mosi, uint8_t miso, uint8_t sclk, uint8_t ssel)`: alternative class constructor
-_Params_ SPI `mosi` pin
-_Params_ SPI `miso` pin
-_Params_ SPI `sclk` pin
+#### Alternative class constructor
+* `SPIClass::SPIClass(uint8_t mosi, uint8_t miso, uint8_t sclk, uint8_t ssel)`
+
+_Param_ SPI `mosi` pin
+
+_Param_ SPI `miso` pin
+
+_Param_ SPI `sclk` pin
+
 _Params_ (optional) SPI `ssel` pin. This pin must be an hardware CS pin. If you configure this pin, the chip select will be managed by the SPI peripheral.
-
- * `SPI_HandleTypeDef *getHandle(void)`: Could be used to mix Arduino API and STM32Cube HAL API (ex: DMA). **Use at your own risk.**
-
 
 ##### Example
 
@@ -35,9 +37,15 @@ void setup() {
 }
 ```
 
-### Extended API
+#### Transfer with Tx/Rx buffer
 
-* All `transfer()` API's have a new bool argument `skipReceive`. It allows to skip receive data after transmitting. Value can be `SPI_TRANSMITRECEIVE` or `SPI_TRANSMITONLY`. Default `SPI_TRANSMITRECEIVE`.
+* `void transfer(const void *tx_buf, void *rx_buf, size_t count)` :Transfer several bytes. One constant buffer used to send and one to receive data.
+
+  _Param_  `tx_buf`: constant array of Tx bytes that is filled by the user before starting the SPI transfer. If NULL, default dummy 0xFF bytes will be clocked out.
+
+  _Param_  `rx_buf`: array of Rx bytes that will be filled by the slave during the SPI transfer. If NULL, the received data will be discarded.
+
+  _Param_ `count`: number of bytes to send/receive.
 
 #### Change default `SPI` instance pins
 It is also possible to change the default pins used by the `SPI` instance using above API:
@@ -63,3 +71,9 @@ It is also possible to change the default pins used by the `SPI` instance using 
     SPI.setMOSI(PC2); // using pin number PYn
     SPI.begin(2);
 ```
+
+* `SPI_HandleTypeDef *getHandle(void)`: Could be used to mix Arduino API and STM32Cube HAL API (ex: DMA). **Use at your own risk.**
+
+## Extended API
+
+* All defaustatndard `transfer()` API's have a new bool argument `skipReceive`. It allows to skip receive data after transmitting. Value can be `SPI_TRANSMITRECEIVE` or `SPI_TRANSMITONLY`. Default `SPI_TRANSMITRECEIVE`.

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -163,7 +163,7 @@ void SPIClass::setClockDivider(uint8_t divider)
   */
 uint8_t SPIClass::transfer(uint8_t data, bool skipReceive)
 {
-  spi_transfer(&_spi, &data, sizeof(uint8_t), SPI_TRANSFER_TIMEOUT, skipReceive);
+  spi_transfer(&_spi, &data, sizeof(uint8_t), skipReceive);
   return data;
 }
 
@@ -184,8 +184,7 @@ uint16_t SPIClass::transfer16(uint16_t data, bool skipReceive)
     tmp = ((data & 0xff00) >> 8) | ((data & 0xff) << 8);
     data = tmp;
   }
-  spi_transfer(&_spi, (uint8_t *)&data, sizeof(uint16_t),
-               SPI_TRANSFER_TIMEOUT, skipReceive);
+  spi_transfer(&_spi, (uint8_t *)&data, sizeof(uint16_t), skipReceive);
 
   if (_spiSettings.bitOrder) {
     tmp = ((data & 0xff00) >> 8) | ((data & 0xff) << 8);
@@ -208,8 +207,7 @@ uint16_t SPIClass::transfer16(uint16_t data, bool skipReceive)
 void SPIClass::transfer(void *buf, size_t count, bool skipReceive)
 {
   if ((count != 0) && (buf != NULL)) {
-    spi_transfer(&_spi, ((uint8_t *)buf), count,
-                 SPI_TRANSFER_TIMEOUT, skipReceive);
+    spi_transfer(&_spi, ((uint8_t *)buf), count, skipReceive);
   }
 }
 

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -163,7 +163,7 @@ void SPIClass::setClockDivider(uint8_t divider)
   */
 uint8_t SPIClass::transfer(uint8_t data, bool skipReceive)
 {
-  spi_transfer(&_spi, &data, sizeof(uint8_t), skipReceive);
+  spi_transfer(&_spi, &data, (!skipReceive) ? &data : NULL, sizeof(uint8_t));
   return data;
 }
 
@@ -184,7 +184,7 @@ uint16_t SPIClass::transfer16(uint16_t data, bool skipReceive)
     tmp = ((data & 0xff00) >> 8) | ((data & 0xff) << 8);
     data = tmp;
   }
-  spi_transfer(&_spi, (uint8_t *)&data, sizeof(uint16_t), skipReceive);
+  spi_transfer(&_spi, (uint8_t *)&data, (!skipReceive) ? (uint8_t *)&data : NULL, sizeof(uint16_t));
 
   if (_spiSettings.bitOrder) {
     tmp = ((data & 0xff00) >> 8) | ((data & 0xff) << 8);
@@ -206,10 +206,26 @@ uint16_t SPIClass::transfer16(uint16_t data, bool skipReceive)
   */
 void SPIClass::transfer(void *buf, size_t count, bool skipReceive)
 {
-  if ((count != 0) && (buf != NULL)) {
-    spi_transfer(&_spi, ((uint8_t *)buf), count, skipReceive);
-  }
+  spi_transfer(&_spi, (uint8_t *)buf, (!skipReceive) ? (uint8_t *)buf : NULL, count);
+
 }
+
+/**
+  * @brief  Transfer several bytes. One constant buffer used to send and
+  *         one to receive data.
+  *         begin() or beginTransaction() must be called at least once before.
+  * @param  tx_buf: array of Tx bytes that is filled by the user before starting
+  *                 the SPI transfer. If NULL, default dummy 0xFF bytes will be
+  *                 clocked out.
+  * @param  rx_buf: array of Rx bytes that will be filled by the slave during
+  *                 the SPI transfer. If NULL, the received data will be discarded.
+  * @param  count: number of bytes to send/receive.
+  */
+void SPIClass::transfer(const void *tx_buf, void *rx_buf, size_t count)
+{
+  spi_transfer(&_spi, ((const uint8_t *)tx_buf), ((uint8_t *)rx_buf), count);
+}
+
 
 /**
   * @brief  Not implemented.

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -41,11 +41,6 @@ extern "C" {
 #define SPI_TRANSMITRECEIVE false
 #define SPI_TRANSMITONLY true
 
-// Defines a default timeout delay in milliseconds for the SPI transfer
-#ifndef SPI_TRANSFER_TIMEOUT
-  #define SPI_TRANSFER_TIMEOUT 1000
-#endif
-
 class SPISettings {
   public:
     constexpr SPISettings(uint32_t clock, BitOrder bitOrder, uint8_t dataMode)

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -138,6 +138,11 @@ class SPIClass {
     uint16_t transfer16(uint16_t data, bool skipReceive = SPI_TRANSMITRECEIVE);
     void transfer(void *buf, size_t count, bool skipReceive = SPI_TRANSMITRECEIVE);
 
+    /* Expand SPI API
+     * https://github.com/arduino/ArduinoCore-API/discussions/189
+     */
+    void transfer(const void *tx_buf, void *rx_buf, size_t count);
+
     /* These methods are deprecated and kept for compatibility.
      * Use SPISettings with SPI.beginTransaction() to configure SPI parameters.
      */

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -122,21 +122,21 @@ class SPIClass {
       _spi.pin_ssel = (ssel);
     };
 
-    virtual void begin(void);
+    void begin(void);
     void end(void);
 
     /* This function should be used to configure the SPI instance in case you
      * don't use default parameters.
      */
     void beginTransaction(SPISettings settings);
-    virtual void endTransaction(void);
+    void endTransaction(void);
 
     /* Transfer functions: must be called after initialization of the SPI
      * instance with begin() or beginTransaction().
      */
-    virtual uint8_t transfer(uint8_t data, bool skipReceive = SPI_TRANSMITRECEIVE);
-    virtual uint16_t transfer16(uint16_t data, bool skipReceive = SPI_TRANSMITRECEIVE);
-    virtual void transfer(void *buf, size_t count, bool skipReceive = SPI_TRANSMITRECEIVE);
+    uint8_t transfer(uint8_t data, bool skipReceive = SPI_TRANSMITRECEIVE);
+    uint16_t transfer16(uint16_t data, bool skipReceive = SPI_TRANSMITRECEIVE);
+    void transfer(void *buf, size_t count, bool skipReceive = SPI_TRANSMITRECEIVE);
 
     /* These methods are deprecated and kept for compatibility.
      * Use SPISettings with SPI.beginTransaction() to configure SPI parameters.

--- a/libraries/SPI/src/utility/spi_com.h
+++ b/libraries/SPI/src/utility/spi_com.h
@@ -78,6 +78,13 @@ typedef struct spi_s spi_t;
 #define SPI_SPEED_CLOCK_DIV128_MHZ  ((uint32_t)128)
 #define SPI_SPEED_CLOCK_DIV256_MHZ  ((uint32_t)256)
 
+// Defines a default timeout delay in milliseconds for the SPI transfer
+#ifndef SPI_TRANSFER_TIMEOUT
+#define SPI_TRANSFER_TIMEOUT 1000
+#elif SPI_TRANSFER_TIMEOUT <= 0
+#error "SPI_TRANSFER_TIMEOUT cannot be less or equal to 0!"
+#endif
+
 ///@brief specifies the SPI mode to use
 //Mode          Clock Polarity (CPOL)       Clock Phase (CPHA)
 //SPI_MODE0             0                         0
@@ -103,8 +110,7 @@ typedef enum {
 /* Exported functions ------------------------------------------------------- */
 void spi_init(spi_t *obj, uint32_t speed, SPIMode mode, uint8_t msb);
 void spi_deinit(spi_t *obj);
-spi_status_e spi_transfer(spi_t *obj, uint8_t *buffer, uint16_t len,
-                          uint32_t Timeout, bool skipReceive);
+spi_status_e spi_transfer(spi_t *obj, uint8_t *buffer, uint16_t len, bool skipReceive);
 uint32_t spi_getClkFreq(spi_t *obj);
 
 #ifdef __cplusplus

--- a/libraries/SPI/src/utility/spi_com.h
+++ b/libraries/SPI/src/utility/spi_com.h
@@ -110,7 +110,7 @@ typedef enum {
 /* Exported functions ------------------------------------------------------- */
 void spi_init(spi_t *obj, uint32_t speed, SPIMode mode, uint8_t msb);
 void spi_deinit(spi_t *obj);
-spi_status_e spi_transfer(spi_t *obj, uint8_t *buffer, uint16_t len, bool skipReceive);
+spi_status_e spi_transfer(spi_t *obj, const uint8_t *tx_buffer, uint8_t *rx_buffer, uint16_t len);
 uint32_t spi_getClkFreq(spi_t *obj);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes #2205

For ref: https://github.com/arduino/ArduinoCore-API/discussions/189

Tested with SdFat  patched with:
```patch
index 8b7da94..296a752 100644
@@ -44,9 +44,13 @@ void SdSpiArduinoDriver::end() { m_spi->end(); }
 uint8_t SdSpiArduinoDriver::receive() { return m_spi->transfer(0XFF); }
 //------------------------------------------------------------------------------
 uint8_t SdSpiArduinoDriver::receive(uint8_t* buf, size_t count) {
+#if defined(STM32_CORE_VERSION) && STM32_CORE_VERSION > 0x02070000
+  m_spi->transfer(NULL, buf, count);
+#else
   // Must send 0XFF - SD looks at send data for command.
   memset(buf, 0XFF, count);
   m_spi->transfer(buf, count);
+#endif
   return 0;
 }
 //------------------------------------------------------------------------------
@@ -57,9 +61,17 @@ void SdSpiArduinoDriver::send(const uint8_t* buf, size_t count) {
   if (count > 512) {
     return;
   }
+#if defined(STM32_CORE_VERSION)
+#if STM32_CORE_VERSION > 0x02070000
+  m_spi->transfer(buf, NULL, count);
+#elif STM32_CORE_VERSION == 0x02070000
+  #error "STM32 core version 2.7.0 is not compatible due to SPI API changes."
+#endif
+#else
   // Not easy to avoid receive so use tmp RX buffer.
   uint8_t rxBuf[512];
   // Discard const - STM32 not const correct.
   m_spi->transfer(const_cast<uint8_t*>(buf), rxBuf, count);
+#endif
 }
 #endif  // defined(SD_USE_CUSTOM_SPI) && defined(STM32_CORE_VERSION)
```
