### PR TITLE
feat(usb): allow USB PID to be 0x0000

### DIFF
--- a/cores/arduino/stm32/usb/usbd_desc.c
+++ b/cores/arduino/stm32/usb/usbd_desc.c
@@ -26,24 +26,43 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 
-/* USB VID and PID: Either both or neither must be specified. If not
- * specified, default to the ST VID, with a PID assigned to HID or a PID
- * assigned to CDC devices. */
-#if !USBD_PID && !USBD_VID
-  // Undef the default zero values
-  #undef USBD_PID
+/* USB VID and PID have to be specified to correct values.
+ * They can be defined thanks:
+ *   - boards.txt: *.build.vid or *.build.pid
+ *   - build_opt.h: define CUSTOM_USBD_VID or CUSTOM_USBD_PID
+ * Else if not defined or specified, default to the ST VID,
+ * with PID assigned to HID or CDC devices.
+ */
+#if !defined(USBD_VID) || USBD_VID == 0
+  // Undef the default definition
   #undef USBD_VID
-  // Define default values, based on the USB class used
-  #define USBD_VID 0x0483
-  #if defined(USBD_USE_HID_COMPOSITE)
-    #define USBD_PID                      0x5711
-  #elif defined(USBD_USE_CDC)
-    #define USBD_PID                      0x5740
+  #if defined(CUSTOM_USBD_VID)
+    #define USBD_VID    CUSTOM_USBD_VID
+  #else
+    // Define default values
+    #define USBD_VID    0x0483
   #endif
-#endif /* !USBD_PID && !USBD_VID */
+#endif /* USBD_VID */
 
-#if !USBD_VID || !USBD_PID
-  #error "USB VID or PID not specified"
+#if !defined(USBD_PID) || USBD_PID == -1
+  // Undef the default definition
+  #undef USBD_PID
+  #if defined(CUSTOM_USBD_PID)
+    #define USBD_PID    CUSTOM_USBD_PID
+  #else
+    // Define default values, based on the USB class used
+    #if defined(USBD_USE_HID_COMPOSITE)
+      #define USBD_PID  0x5711
+    #elif defined(USBD_USE_CDC)
+      #define USBD_PID  0x5740
+    #else
+      #error "USB PID not specified"
+    #endif
+  #endif
+#endif /* USBD_VID */
+
+#if USBD_VID == 0
+  #error "USB VID not properly specified"
 #endif
 
 /* Manufacturer string: Use the specified string if specified, guess

--- a/platform.txt
+++ b/platform.txt
@@ -82,10 +82,11 @@ compiler.arm.cmsis.c.flags="-I{runtime.tools.CMSIS-5.9.0.path}/CMSIS/Core/Includ
 build.usb_flags=-DUSBCON {build.usb_speed} -DUSBD_VID={build.vid} -DUSBD_PID={build.pid} -DHAL_PCD_MODULE_ENABLED
 
 # Specify defaults for vid/pid, since an empty value is impossible to
-# detect in the preprocessor, but a 0 can be checked for.
+# detect in the preprocessor, but a 0 can be checked for vid and -1
+# for pid (can be 0).
 # Boards should specify either both, or neither of these.
 build.vid=0
-build.pid=0
+build.pid=-1
 
 # To customize the USB manufacturer or product string, must add defines
 # for them, e.g.:


### PR DESCRIPTION
USB device VID and PID can be defined thanks:
 - `boards.txt`: `*.build.vid` or `*.build.pid`
 - `build_opt.h`: define `CUSTOM_USBD_VID` or `CUSTOM_USBD_PID`

Else if not defined or specified, default to the ST VID, with PID assigned to HID or CDC devices.

> [!Note]
> if value is specified in the `boards.txt` then `CUSTOM_USBD_*` is ignored.

Fixes #2215


