### PR TITLE
HardwareSerial's flush() method to override the method of the base class Print

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -487,6 +487,11 @@ int HardwareSerial::availableForWrite(void)
   return tail - head - 1;
 }
 
+void HardwareSerial::flush()
+{
+  flush(0);
+}
+
 void HardwareSerial::flush(uint32_t timeout)
 {
   // If we have never written a byte, no need to flush. This special
@@ -642,7 +647,7 @@ void HardwareSerial::enableHalfDuplexRx(void)
   if (isHalfDuplex()) {
     // In half-duplex mode we have to wait for all TX characters to
     // be transmitted before we can receive data.
-    flush();
+    flush(0);
     if (!_rx_enabled) {
       _rx_enabled = true;
       uart_enable_rx(&_serial);

--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -647,7 +647,7 @@ void HardwareSerial::enableHalfDuplexRx(void)
   if (isHalfDuplex()) {
     // In half-duplex mode we have to wait for all TX characters to
     // be transmitted before we can receive data.
-    flush(0);
+    flush();
     if (!_rx_enabled) {
       _rx_enabled = true;
       uart_enable_rx(&_serial);

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -126,7 +126,7 @@ class HardwareSerial : public Stream {
     virtual int read(void);
     int availableForWrite(void);
     virtual void flush();
-    void flush(uint32_t timeout = 0);
+    void flush(uint32_t timeout);
     virtual size_t write(uint8_t);
     inline size_t write(unsigned long n)
     {

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -125,7 +125,8 @@ class HardwareSerial : public Stream {
     virtual int peek(void);
     virtual int read(void);
     int availableForWrite(void);
-    virtual void flush(uint32_t timeout = 0);
+    virtual void flush();
+    void flush(uint32_t timeout = 0);
     virtual size_t write(uint8_t);
     inline size_t write(unsigned long n)
     {


### PR DESCRIPTION
<!-- Summary of the PR -->

This PR addresses the following **bugs/features**

* [x] Bug: Fixing issue with base class Print's `void flush()` method not being overridden by derivative HardwareSerial's `void flush(uint32_t timeout = 0)` method.


The base class Print [defines `void flush()`](https://github.com/ilolis/Arduino_Core_STM32/blob/dce241d8ebb6affce38adbeebf34eb6372cfbe9b/cores/arduino/Print.h#L103), while the derivative HardwareSerial[ defines `void flush(uint32_t timeout = 0)`](https://github.com/stm32duino/Arduino_Core_STM32/blob/1863c25025441c8c6dbcea5b8ed496db21c12785/cores/arduino/HardwareSerial.h#L128). The issue was that when using the base class instance pointer, the virtual function of the derivative was not being called. This PR resolves this. 

I might be missing something since I am new to this project, so please feel free to correct me :) 
