### PR TITLE
Fix compiler warning on HardwareTimer

### DIFF
--- a/libraries/SrcWrapper/src/HardwareTimer.cpp
+++ b/libraries/SrcWrapper/src/HardwareTimer.cpp
@@ -168,7 +168,7 @@ void HardwareTimer::pause()
   */
 void HardwareTimer::pauseChannel(uint32_t channel)
 {
-  if (channel < 1 || channel > TIMER_CHANNELS) {
+  if ((channel < 1) || (channel > TIMER_CHANNELS)) {
     return;
   }
 

--- a/libraries/SrcWrapper/src/HardwareTimer.cpp
+++ b/libraries/SrcWrapper/src/HardwareTimer.cpp
@@ -168,6 +168,10 @@ void HardwareTimer::pause()
   */
 void HardwareTimer::pauseChannel(uint32_t channel)
 {
+  if (channel < 1 || channel > TIMER_CHANNELS) {
+    return;
+  }
+
   int timAssociatedInputChannel;
   int LLChannel = getLLChannel(channel);
   if (LLChannel == -1) {


### PR DESCRIPTION
This PR fixes a compiler warning when compiling with `-O3`. There's no bounds check in `pauseChannel`, which causes this warning. Adding the bounds check fixes the warning.

```
framework-arduinoststm32\libraries\SrcWrapper\src\HardwareTimer.cpp: In member function 'void HardwareTimer::pauseChannel(uint32_t)':
framework-arduinoststm32\libraries\SrcWrapper\src\HardwareTimer.cpp:203:31: warning: array subscript 4 is above array bounds of 'TimerModes_t [4]' [-Warray-bounds]
  203 |   if (_ChannelMode[channel - 1] == TIMER_INPUT_FREQ_DUTY_MEASUREMENT) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~^
In file included from framework-arduinoststm32\cores\arduino\stm32/analog.h:45,
                 from framework-arduinoststm32\cores\arduino/board.h:8,
                 from framework-arduinoststm32\cores\arduino/wiring.h:40,
                 from framework-arduinoststm32\cores\arduino/Arduino.h:36,
                 from framework-arduinoststm32\libraries\SrcWrapper\src\HardwareTimer.cpp:26:
framework-arduinoststm32\cores\arduino/HardwareTimer.h:188:19: note: while referencing 'HardwareTimer::_ChannelMode'
  188 |     TimerModes_t  _ChannelMode[TIMER_CHANNELS];
      |                   ^~~~~~~~~~~~
framework-arduinoststm32\libraries\SrcWrapper\src\HardwareTimer.cpp:203:31: warning: array subscript 4 is above array bounds of 'TimerModes_t [4]' [-Warray-bounds]
  203 |   if (_ChannelMode[channel - 1] == TIMER_INPUT_FREQ_DUTY_MEASUREMENT) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~^
framework-arduinoststm32\cores\arduino/HardwareTimer.h:188:19: note: while referencing 'HardwareTimer::_ChannelMode'
  188 |     TimerModes_t  _ChannelMode[TIMER_CHANNELS];
      |                   ^~~~~~~~~~~~
```