### PR TITLE
Fix issue with writing inital servo value before min/max is configured

### DIFF
--- a/libraries/Servo/src/stm32/Servo.cpp
+++ b/libraries/Servo/src/stm32/Servo.cpp
@@ -121,10 +121,12 @@ uint8_t Servo::attach(int pin, int min, int max, int value)
   if (this->servoIndex < MAX_SERVOS) {
     pinMode(pin, OUTPUT);                                   // set servo pin to output
     servos[this->servoIndex].Pin.nbr = pin;
-    write(value);
     // todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128
     this->min  = (MIN_PULSE_WIDTH - min) / 4; //resolution of min/max is 4 uS
     this->max  = (MAX_PULSE_WIDTH - max) / 4;
+
+    write(value); // set the initial position
+
     // initialize the timer if it has not already been initialized
     if (isTimerActive() == false) {
       TimerServoInit();


### PR DESCRIPTION
**Summary**

The call to function Servo::write() in Servo::attach() must be done after Servo::min and Servo::max are configured - Servo::write() uses the min/max for mapping the passed value if the value is passed in degrees. Therefore if inital value in attach is set in degress and min/max is not configured when call to Servo::write() is done, the mapping will not be correct.

Fixes: #2308