### PR TITLE
fix(codespell): ignore new words

### DIFF
--- a/CI/codespell/.codespellignore
+++ b/CI/codespell/.codespellignore
@@ -6,4 +6,5 @@ hsi
 noe
 nwe
 ore
-
+shiftin
+socio-economic


### PR DESCRIPTION
socio-economic: see https://github.com/codespell-project/codespell/pull/3353 for

shiftIN is a function name so safe to ignore.

