### PR TITLE
Raise Serial/SerialUSB interrupts to user code

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -347,6 +347,12 @@ void HardwareSerial::_rx_complete_irq(serial_t *obj)
       obj->rx_head = i;
     }
   }
+
+  // Raise user event callback if registered
+  if (obj->event_callback)
+  {
+    obj->event_callback(SERIAL_EVENT_RX);
+  }
 }
 
 // Actual interrupt handlers //////////////////////////////////////////////////
@@ -368,7 +374,11 @@ int HardwareSerial::_tx_complete_irq(serial_t *obj)
     uart_attach_tx_callback(obj, _tx_complete_irq, obj->tx_size);
     return -1;
   }
-
+  // Raise user event callback if registered
+  if (obj->event_callback)
+  {
+    obj->event_callback(SERIAL_EVENT_TX);
+  }
   return 0;
 }
 
@@ -652,6 +662,14 @@ void HardwareSerial::enableHalfDuplexRx(void)
       _rx_enabled = true;
       uart_enable_rx(&_serial);
     }
+  }
+}
+
+void HardwareSerial::onEvent(SerialCallback_t callback)
+{
+  if (callback)
+  {
+    _serial.event_callback = callback;
   }
 }
 

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -169,6 +169,7 @@ class HardwareSerial : public Stream {
     void setHalfDuplex(void);
     bool isHalfDuplex(void) const;
     void enableHalfDuplexRx(void);
+    void onEvent(SerialCallback_t event_callback);
 
     friend class STM32LowPower;
 

--- a/cores/arduino/USBSerial.cpp
+++ b/cores/arduino/USBSerial.cpp
@@ -197,4 +197,12 @@ USBSerial::operator bool()
   return dtrState;
 }
 
+void USBSerial::onEvent(USBSerialCallback_t callback)
+{
+  if (callback)
+  {
+    CDC_register_cb(callback);
+  }
+}
+
 #endif // USBCON && USBD_USE_CDC

--- a/cores/arduino/USBSerial.h
+++ b/cores/arduino/USBSerial.h
@@ -22,6 +22,7 @@
 #if defined (USBCON) && defined(USBD_USE_CDC)
 #include "Stream.h"
 #include "usbd_core.h"
+#include "usbd_cdc_if.h"
 
 //================================================================================
 // Serial over CDC
@@ -43,6 +44,7 @@ class USBSerial : public Stream {
     virtual size_t write(const uint8_t *buffer, size_t size);
     using Print::write; // pull in write(str) from Print
     operator bool(void);
+    void onEvent(USBSerialCallback_t callback);
 
     // These return the settings specified by the USB host for the
     // serial port. These aren't really used, but are offered here

--- a/cores/arduino/stm32/uart.h
+++ b/cores/arduino/stm32/uart.h
@@ -59,6 +59,13 @@ extern "C" {
 /* Exported types ------------------------------------------------------------*/
 typedef struct serial_s serial_t;
 
+typedef enum {
+  SERIAL_EVENT_TX,
+  SERIAL_EVENT_RX
+} SerialEvent_t;
+
+typedef void (*SerialCallback_t)(SerialEvent_t event);
+
 struct serial_s {
   /*  The 1st 2 members USART_TypeDef *uart
    *  and UART_HandleTypeDef handle should
@@ -69,6 +76,7 @@ struct serial_s {
   UART_HandleTypeDef handle;
   void (*rx_callback)(serial_t *);
   int (*tx_callback)(serial_t *);
+  SerialCallback_t event_callback;
   PinName pin_tx;
   PinName pin_rx;
   PinName pin_rts;

--- a/cores/arduino/stm32/usb/cdc/usbd_cdc_if.h
+++ b/cores/arduino/stm32/usb/cdc/usbd_cdc_if.h
@@ -37,6 +37,13 @@ extern "C" {
 #define CDC_POLLING_INTERVAL             2 /* in ms. The max is 65 and the min is 1 */
 
 /* Exported types ------------------------------------------------------------*/
+typedef enum {
+  USB_SERIAL_EVENT_TX,
+  USB_SERIAL_EVENT_RX
+} USBSerialEvent_t;
+
+typedef void (*USBSerialCallback_t)(USBSerialEvent_t);
+
 /* Exported constants --------------------------------------------------------*/
 
 extern USBD_CDC_ItfTypeDef  USBD_CDC_fops;
@@ -52,6 +59,7 @@ void CDC_init(void);
 void CDC_deInit(void);
 bool CDC_connected(void);
 void CDC_enableDTR(bool enable);
+int8_t CDC_register_cb(USBSerialCallback_t callback);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This commit Adds the ability for the user to register a callback for Serial/SerialUSB events (TX/RX)

## Pull Request template

Please, Make sure that your PR is not a duplicate.
Search among the [Pull request](https://github.com/stm32duino/Arduino_Core_STM32/pulls) before creating one.

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

Thanks for submitting a pull request.
Please provide enough information so that others can review your pull request:

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Add Serial events callback

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

```c++
#include <Arduino.h>

#define SERIAL_BAUDRATE 115200U

static uint32_t count = 0;

static void onSerialEvent(SerialEvent_t event);

void setup() {
  Serial.begin(SERIAL_BAUDRATE);
  Serial.onEvent(onSerialEvent);
}

void loop() {
  Serial.print("Running(");
  Serial.print(count);
  Serial.println(")...");
  count++;
  delay(1000);
}

static void onSerialEvent(SerialEvent_t event) {
  switch (event) {
    case SERIAL_EVENT_RX:
      __NOP();
      break;
    case SERIAL_EVENT_TX:
      __NOP();
      break;
    default:
      __NOP();
      break;
  }
}
```


**Validation**

* Ensure CI build is passed.
* Demonstrate the code is solid. [e.g. Provide a sketch]

<!-- Make sure tests pass on both CI. -->

**Code formatting**

* Ensure AStyle check is passed thanks CI

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #xxx
