### PR TITLE
Add single buffer mode option to USB CDC to fix off-by-one corruption

### DIFF
--- a/libraries/USBDevice/src/usbd_ep_conf.c
+++ b/libraries/USBDevice/src/usbd_ep_conf.c
@@ -37,7 +37,11 @@ const ep_desc_t ep_def[] = {
 #else
   {0x00,       PMA_EP0_OUT_ADDR, PCD_SNG_BUF},
   {0x80,       PMA_EP0_IN_ADDR,  PCD_SNG_BUF},
+#ifndef USBD_CDC_USE_SINGLE_BUFFER
   {CDC_OUT_EP, PMA_CDC_OUT_ADDR, PCD_DBL_BUF},
+#else
+  {CDC_OUT_EP, PMA_CDC_OUT_ADDR, PCD_SNG_BUF},
+#endif
   {CDC_IN_EP,  PMA_CDC_IN_ADDR,  PCD_SNG_BUF},
   {CDC_CMD_EP, PMA_CDC_CMD_ADDR, PCD_SNG_BUF}
 #endif


### PR DESCRIPTION
This PR fixes/implements the following **bugs/features**

[Bug]

When using the debug mode, halting the CPU at a breakpoint can create a condition where the HAL USB state machine encounters an off-by-one error in the packet handling. This error is un-recoverable. completely breaks USB communications, and requires you to reset the STM32.

This is caused by an issue with the double-buffering option available in the endpoint hardware.

[Fix] 

Adding the option to disable double buffer mode, and to allow single buffer mode, fixes this issue, and, in my tests, also improves reliability in USB communication with noisy systems, such as motor controllers.

Single buffer mode can now be enabled with -DUSBD_CDC_USE_SINGLE_BUFFER at compile time. 

[Breaking: None] 

This commit does not break any functions of STM32DUINO and is a completely optional command-line option.

