### PR TITLE
Fix for issue 2438: Error uploading with stm32CubeProgrammer (DFU)

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -198,6 +198,8 @@ tools.massStorageCopy.upload.params.quiet=
 tools.massStorageCopy.upload.pattern="{tools_bin_path}/{cmd}" {upload.verbose} -I "{build.path}/{build.project_name}.bin" -O "{node}"
 
 # STM32CubeProgrammer upload
+tools.stm32CubeProg.busybox=
+tools.stm32CubeProg.busybox.windows={path}/win/busybox.exe
 tools.stm32CubeProg.path={runtime.tools.STM32Tools.path}
 tools.stm32CubeProg.cmd=stm32CubeProg.sh
 tools.stm32CubeProg.upload.params.verbose=


### PR DESCRIPTION
## Pull Request template

**Summary**

This PR fixes/implements the following  bug:

* [Issue 2438: Error uploading with stm32CubeProgrammer (DFU) since v2.8.0](https://github.com/stm32duino/Arduino_Core_STM32/issues/2438) 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Fix v2.8.0 regression that breaks uploads by reverting two lines that changed in `platform.txt` back to the 2.7.1 version.

**Validation**

Validated uploading works again.
