### PR TITLE
fix(platform): core reference broken

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -28,9 +28,10 @@ hal_dir={build.system.path}/Drivers/{build.series}_HAL_Driver
 cmsis_dir={runtime.tools.CMSIS-5.9.0.path}/CMSIS
 cmsis_dev_dir={build.system.path}/Drivers/CMSIS/Device/ST/{build.series}
 usbd_core_dir={build.system.path}/Middlewares/ST/STM32_USB_Device_Library/Core
-SrcWrapper_include_dir={runtime.platform.path}/libraries/SrcWrapper/inc
-VirtIO_include_dir={runtime.platform.path}/libraries/VirtIO/inc
-USBDevice_include_dir={runtime.platform.path}/libraries/USBDevice/inc
+builtin_library_dir={build.core.path}/../../libraries
+SrcWrapper_include_dir={builtin_library_dir}/SrcWrapper/inc
+VirtIO_include_dir={builtin_library_dir}/VirtIO/inc
+USBDevice_include_dir={builtin_library_dir}/USBDevice/inc
 
 
 # STM compile variables


### PR DESCRIPTION
due to {runtime.platform.path} usage when other platform reference the core.

- {runtime.platform.path}:
  The absolute path of the board platform folder (i.e. the folder containing boards.txt)
- {build.core.path}:
  The path to the selected board's core folder (inside the  core platform, for example hardware/STMicroelectronics/stm32/core/arduino)
    
Ref:
  https://arduino.github.io/arduino-cli/1.0/platform-specification/#referencing-another-core-variant-or-tool
    
Fixes #2445
    