### PR TITLE
fix(platform.txt): add default vid/pid definition

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -25,8 +25,8 @@ Nucleo_144.upload.maximum_size=0
 Nucleo_144.upload.maximum_data_size=0
 Nucleo_144.vid.0=0x0483
 Nucleo_144.pid.0=0x5740
-Nucleo_144.vid.1=0x0483
 # STlink V1/V2.1/V3
+Nucleo_144.vid.1=0x0483
 Nucleo_144.pid.1=0x3744
 Nucleo_144.vid.2=0x0483
 Nucleo_144.pid.2=0x3748
@@ -397,6 +397,7 @@ Nucleo_64.upload.maximum_data_size=0
 Nucleo_64.vid.0=0x0483
 Nucleo_64.pid.0=0x5740
 # STlink V1/V2.1/V3
+Nucleo_64.vid.1=0x0483
 Nucleo_64.pid.1=0x3744
 Nucleo_64.vid.2=0x0483
 Nucleo_64.pid.2=0x3748
@@ -876,6 +877,7 @@ Nucleo_32.upload.maximum_data_size=0
 Nucleo_32.vid.0=0x0483
 Nucleo_32.pid.0=0x5740
 # STlink V1/V2.1/V3
+Nucleo_32.vid.1=0x0483
 Nucleo_32.pid.1=0x3744
 Nucleo_32.vid.2=0x0483
 Nucleo_32.pid.2=0x3748
@@ -1038,6 +1040,7 @@ Disco.upload.maximum_data_size=0
 Disco.vid.0=0x0483
 Disco.pid.0=0x5740
 # STlink V1/V2.1/V3
+Disco.vid.1=0x0483
 Disco.pid.1=0x3744
 Disco.vid.2=0x0483
 Disco.pid.2=0x3748
@@ -1358,6 +1361,7 @@ Eval.upload.maximum_data_size=0
 Eval.vid.0=0x0483
 Eval.pid.0=0x5740
 # STlink V1/V2.1/V3
+Eval.vid.1=0x0483
 Eval.pid.1=0x3744
 Eval.vid.2=0x0483
 Eval.pid.2=0x3748
@@ -1420,8 +1424,6 @@ STM32MP1.name=STM32MP1 series coprocessor
 STM32MP1.build.flash_offset=0x0
 STM32MP1.upload.maximum_size=0
 STM32MP1.upload.maximum_data_size=0
-STM32MP1.vid.0=0x0483
-STM32MP1.pid.0=0x5740
 
 STM32MP1.build.core=arduino
 STM32MP1.build.board=STM32MP1
@@ -1469,8 +1471,6 @@ GenC0.build.flash_offset=0x0
 GenC0.upload.maximum_size=0
 GenC0.upload.maximum_data_size=0
 GenC0.debug.server.openocd.scripts.2=target/stm32c0x.cfg
-GenC0.vid.0=0x0483
-GenC0.pid.0=0x5740
 
 # Generic C011D6Yx
 GenC0.menu.pnum.GENERIC_C011D6YX=Generic C011D6Yx
@@ -11855,8 +11855,6 @@ GenWBA.build.flash_offset=0x0
 GenWBA.upload.maximum_size=0
 GenWBA.upload.maximum_data_size=0
 GenWBA.debug.server.openocd.scripts.2=target/stm32wbax.cfg
-GenWBA.vid.0=0x0483
-GenWBA.pid.0=0x5740
 
 # Generic WBA55CEUx
 GenWBA.menu.pnum.GENERIC_WBA55CEUX=Generic WBA55CEUx
@@ -11902,8 +11900,6 @@ GenWL.build.flash_offset=0x0
 GenWL.upload.maximum_size=0
 GenWL.upload.maximum_data_size=0
 GenWL.debug.server.openocd.scripts.2=target/stm32wlx.cfg
-GenWL.vid.0=0x0483
-GenWL.pid.0=0x5740
 
 # Generic WL54CCUx
 GenWL.menu.pnum.GENERIC_WL54CCUX=Generic WL54CCUx
@@ -12646,8 +12642,6 @@ IotContinuum.build.st_extra_flags=-D{build.product_line} {build.xSerial}
 IotContinuum.build.flash_offset=0x0
 IotContinuum.upload.maximum_size=0
 IotContinuum.upload.maximum_data_size=0
-IotContinuum.vid.0=0x0483
-IotContinuum.pid.0=0x5740
 
 # IoT continuum Dev Kit Board
 IotContinuum.menu.pnum.DEVKIT_IOT_CONTINUUM=IoT continuum Dev Kit
@@ -12972,8 +12966,6 @@ ELV_Modular_System.build.board=ELV_Modular_System
 ELV_Modular_System.build.variant_h=variant_{build.board}.h
 ELV_Modular_System.upload.maximum_size=0
 ELV_Modular_System.upload.maximum_data_size=0
-ELV_Modular_System.vid.0=0x0483
-ELV_Modular_System.pid.0=0x5740
 
 # ELV-BM-TRX1 board
 ELV_Modular_System.menu.pnum.ELV_BM_TRX1=ELV-LW-Base ELV_BM_TRX1

--- a/cmake/scripts/update_boarddb.py
+++ b/cmake/scripts/update_boarddb.py
@@ -55,6 +55,8 @@ def platformtxt_filter(key):
 
     if key[0] == "build" and key[1] != "info":
         return False
+    if key[0] == "vid" or key[0] == "pid":
+        return False
     return True
 
 
@@ -104,7 +106,12 @@ if __name__ == "__main__":
     shargs = parser.parse_args()
 
     platformtxt_cfg = parse_file(shargs.platform, reject=platformtxt_filter)
-    platformtxt_cfg = {"build": platformtxt_cfg["build"]}  # whitelist what we need
+    # whitelist what we need
+    platformtxt_cfg = {
+        "build": platformtxt_cfg["build"],
+        "vid": platformtxt_cfg["vid"],
+        "pid": platformtxt_cfg["pid"],
+    }
 
     boardstxt_cfg = parse_file(shargs.boards, reject=boardstxt_filter)
     del boardstxt_cfg["menu"]  # blacklist what we don't need

--- a/platform.txt
+++ b/platform.txt
@@ -109,6 +109,8 @@ build.usb_flags=-DUSBCON {build.usb_speed} -DUSBD_VID={build.vid} -DUSBD_PID={bu
 
 # Specify defaults for vid/pid
 # Boards should specify either both, or neither of these.
+vid.0=0x0483
+pid.0=0x5740
 build.vid={vid.0}
 build.pid={pid.0}
 upload.vid.0=0x0483


### PR DESCRIPTION
this avoids to add them to `boards.txt` if not needed.

cmake updated to get the default value from `platform.txt`.

/cc @massonal 

This fixes this:
https://github.com/stm32duino/Arduino_Core_STM32/issues/2445#issuecomment-2231956589