### PR TITLE
spaces-in-path for custom linker script in $PROJECT_DIR

### DIFF
--- a/tools/platformio/platformio-build.py
+++ b/tools/platformio/platformio-build.py
@@ -368,10 +368,10 @@ if not board_config.get("build.ldscript", ""):
         LINKFLAGS=[
             (
                 "-Wl,--default-script",
-                join(
+                ('"'+join(
                     inc_variant_dir,
                     board_config.get("build.arduino.ldscript", "ldscript.ld"),
-                ),
+                )+'"'),
             )
         ]
     )


### PR DESCRIPTION

**Summary**
quick fix for a spaces-in-path error when using a linker script inside $PROJECT_DIR

lines 371~373:
https://github.com/thijses/Arduino_Core_STM32/blob/e7d39cc6ee10d52506fe8f9baff1d0479a1cda6c/tools/platformio/platformio-build.py#L371

produces (in my case) the string:

> $PROJECT_DIR\boards/variants\BKS_H2O_1003400D\ldscript.ld

which later gets translated to a full/absolute path, where the spaces in my windows username are not accounted for.
Adding some quotes around the whole thing fixes it (on my machine).

(some of the other path strings (which include an absolute path early on) do not suffer from this issue, so i suspect that someone has already attempted to prevent spaces-in-path errors by dynamically adding quotes at some point, but has not accounted for unparsed paths ('$PROJECT_DIR') when checking for spaces.)

I came across this while trying to impement the example shown here:
https://github.com/maxgerhardt/pio-custom-stm32duino-variants
