### PR TITLE
fix(wire): support only 7 bits addressing mode

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -104,7 +104,7 @@ void TwoWire::begin(uint8_t address, bool generalCall, bool NoStretchMode)
 
   recoverBus(); // in case I2C bus (device) is stuck after a reset for example
 
-  i2c_init(&_i2c, 100000, I2C_ADDRESSINGMODE_7BIT, ownAddress);
+  i2c_init(&_i2c, 100000, ownAddress);
 
   if (_i2c.isMaster == 0) {
     // i2c_attachSlaveTxEvent(&_i2c, reinterpret_cast<void(*)(i2c_t*)>(&TwoWire::onRequestService));

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -104,7 +104,7 @@ void TwoWire::begin(uint8_t address, bool generalCall, bool NoStretchMode)
 
   recoverBus(); // in case I2C bus (device) is stuck after a reset for example
 
-  i2c_custom_init(&_i2c, 100000, I2C_ADDRESSINGMODE_7BIT, ownAddress);
+  i2c_init(&_i2c, 100000, I2C_ADDRESSINGMODE_7BIT, ownAddress);
 
   if (_i2c.isMaster == 0) {
     // i2c_attachSlaveTxEvent(&_i2c, reinterpret_cast<void(*)(i2c_t*)>(&TwoWire::onRequestService));

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -638,16 +638,6 @@ static uint32_t i2c_getTiming(i2c_t *obj, uint32_t frequency)
 }
 
 /**
-  * @brief  Default init and setup GPIO and I2C peripheral
-  * @param  obj : pointer to i2c_t structure
-  * @retval none
-  */
-void i2c_init(i2c_t *obj)
-{
-  i2c_custom_init(obj, 100000, I2C_ADDRESSINGMODE_7BIT, 0x33);
-}
-
-/**
   * @brief  Initialize and setup GPIO and I2C peripheral
   * @param  obj : pointer to i2c_t structure
   * @param  timing : one of the i2c_timing_e
@@ -655,7 +645,7 @@ void i2c_init(i2c_t *obj)
   * @param  ownAddress : device address
   * @retval none
   */
-void i2c_custom_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode, uint32_t ownAddress)
+void i2c_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode, uint32_t ownAddress)
 {
   if (obj != NULL) {
 

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -641,11 +641,10 @@ static uint32_t i2c_getTiming(i2c_t *obj, uint32_t frequency)
   * @brief  Initialize and setup GPIO and I2C peripheral
   * @param  obj : pointer to i2c_t structure
   * @param  timing : one of the i2c_timing_e
-  * @param  addressingMode : I2C_ADDRESSINGMODE_7BIT or I2C_ADDRESSINGMODE_10BIT
   * @param  ownAddress : device address
   * @retval none
   */
-void i2c_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode, uint32_t ownAddress)
+void i2c_init(i2c_t *obj, uint32_t timing, uint32_t ownAddress)
 {
   if (obj != NULL) {
 
@@ -761,7 +760,7 @@ void i2c_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode, uint32_t own
 #endif
         handle->Init.OwnAddress1     = ownAddress;
         handle->Init.OwnAddress2     = 0;
-        handle->Init.AddressingMode  = addressingMode;
+        handle->Init.AddressingMode  = I2C_ADDRESSINGMODE_7BIT;
         handle->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
         handle->Init.GeneralCallMode = (obj->generalCall == 0) ? I2C_GENERALCALL_DISABLE : I2C_GENERALCALL_ENABLE;
         handle->Init.NoStretchMode   = (obj->NoStretchMode == 0) ? I2C_NOSTRETCH_DISABLE : I2C_NOSTRETCH_ENABLE;

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -137,8 +137,7 @@ typedef enum {
 } i2c_status_e;
 
 /* Exported functions ------------------------------------------------------- */
-void i2c_init(i2c_t *obj);
-void i2c_custom_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode,
+void i2c_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode,
                      uint32_t ownAddress);
 void i2c_deinit(i2c_t *obj);
 void i2c_setTiming(i2c_t *obj, uint32_t frequency);

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -137,8 +137,7 @@ typedef enum {
 } i2c_status_e;
 
 /* Exported functions ------------------------------------------------------- */
-void i2c_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode,
-                     uint32_t ownAddress);
+void i2c_init(i2c_t *obj, uint32_t timing, uint32_t ownAddress);
 void i2c_deinit(i2c_t *obj);
 void i2c_setTiming(i2c_t *obj, uint32_t frequency);
 i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address, uint8_t *data, uint16_t size);


### PR DESCRIPTION
Arduino does not support 10 bits addressing mode.
The API is limited to an `uint8_t` address:
https://github.com/arduino/ArduinoCore-API/blob/4a02bfc0a924e1fec34c3bb82ffd5dfba7643a0c/api/HardwareI2C.h#L31
https://github.com/arduino/ArduinoCore-API/blob/4a02bfc0a924e1fec34c3bb82ffd5dfba7643a0c/api/HardwareI2C.h#L36

About the hack to use 10 bits on Arduino:

> Normally on arduino, you can communicate with this device simply by doing something like this:
> 
> ```C++
> Wire.begin(0x79);
> Wire.write(0x08);
> //insert additional communication here
> Wire.endTransmission()
> ```
> However, when using the same code on STM32Duino this communication won't succeed.
> First of all, 0xF2 (0x79 << 1) byte will appear twice on the bus (because we are configuring HAL's I2C interface in 7bit mode, however the MCU itself recognizes this address as the beginning of 10 bit address).

This is not possible as it is manage by hardware to follow I2C specification where:
`11110xxx` is reserved for 10-bit Slave Addressing.

Fixes #2468.