### PR TITLE
Remove atomicity warning that does not apply to STM32

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 Please, Make sure that your PR is not a duplicate.
 Search among the [Pull request](https://github.com/stm32duino/Arduino_Core_STM32/pulls) before creating one.
 
-IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
+IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/stm32duino/Arduino_Core_STM32/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.
 
 Thanks for submitting a pull request.
 Please provide enough information so that others can review your pull request:

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -35,11 +35,6 @@
 // location from which to read.
 // NOTE: a "power of 2" buffer size is recommended to dramatically
 //       optimize all the modulo operations for ring buffers.
-// WARNING: When buffer sizes are increased to > 256, the buffer index
-// variables are automatically increased in size, but the extra
-// atomicity guards needed for that are not implemented. This will
-// often work, but occasionally a race condition can occur that makes
-// Serial behave erratically. See https://github.com/arduino/Arduino/issues/2405
 #if !defined(SERIAL_TX_BUFFER_SIZE)
   #define SERIAL_TX_BUFFER_SIZE 64
 #endif


### PR DESCRIPTION
**Summary**

Removes an atomicity warning in `HardwareSerial.h` that does not apply to (32-bit) STM32. Based on a review on [this response](https://stackoverflow.com/a/52785864/471839) and my own testing, I'm convinced that the atomicity warning and link to an ArduinoCore-avr issue is not relevant.