### PR TITLE
Only apply VID-only port property association to compatible dev tools

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -12463,7 +12463,7 @@ Blues.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSer
 Blues.build.flash_offset=0x0
 Blues.upload.maximum_size=0
 Blues.upload.maximum_data_size=0
-Blues.vid.0=0x30A4
+Blues.upload_port.0.vid=0x30A4
 
 # Swan R5 board
 Blues.menu.pnum.SWAN_R5=Swan R5


### PR DESCRIPTION
### Summary

The Arduino boards platform framework allows properties of a port to be [associated with a board definition](https://arduino.github.io/arduino-cli/dev/platform-specification/#properties-from-pluggable-discovery:~:text=upload_port.vid%20and%20upload_port.pid%20properties). The Arduino development software will identify a port having the associated properties as that board.

The "Blues boards" board definition contains an association for the `vid` port property value of `0x30A4`:

https://github.com/stm32duino/Arduino_Core_STM32/blob/89a29516cca7b50c6aef17a52e0e6e4afe78aeb7/boards.txt#L12466

Typically, in addition to the `vid` property, a companion `pid` property will also be associated so that the association is specific to devices with that VID/PID pair. However, this board definition only associates a `vid` property. Although unusual, this is reasonable in this case where the board definition provides support for all models of the **Blues** boards (rather than one specific model as is typically the case).

Unfortunately it seems that the Arduino IDE 1.x codebase is written in a way that assumes a PID association will always be provided along with a VID association. When a platform is installed that contains a board definition that associates a `vid` property without also associating a `pid` property, it breaks port discovery entirely, causing no ports to be discovered for any board.

The port discovery and port properties association system has been completely reworked since the time of Arduino IDE 1.x. The modern system, which is used by Arduino IDE 2.x and Arduino CLI, doesn't have any problem with this VID-only association. This means that it would be possible to define this association without breaking Arduino IDE 1.x if the association could be applied exclusively for the modern Arduino development software versions. Arduino IDE 1.x only uses the port property association for the convenience feature of labeling the port in the **Tools > Port** menu, so the lack of an association doesn't cause any meaningful impact.

At the time the port discovery and port properties association system was reworked, the port property association properties were renamed to support association with any arbitrary properties:

https://arduino.github.io/arduino-cli/latest/pluggable-discovery-specification/#board-identification

(while retaining support for [the old property names](https://arduino.github.io/arduino-cli/latest/platform-specification/#board-vidpid)). The new property names are only recognized by the modern Arduino development software and have no effect on Arduino IDE 1.x.

The port association properties for the "Blues boards" board definition are migrated from the old property names previously in use to the new names. This causes the port property association to no longer be recognized by Arduino IDE 1.x, fixing the breakage of its port discovery system. The association will still be recognized by the modern versions of Arduino development software just as before.

---

This PR fixes/implements the following **bugs/features**

* [x] https://github.com/stm32duino/Arduino_Core_STM32/issues/2469

### Validation

1. Install the version of the platform without this patch.
1. Start Arduino IDE 1.8.19
1. Connect any device to your computer that produces a serial port.
1. Open the **Tools** menu in Arduino IDE.
   🐛 The **Port** menu item is grayed out, indicating no ports were discovered even though a port is present.
1. Select **File > Quit** (or **Arduino > Quit Arduino** for macOS users) from the Arduino IDE menus.
1. Apply the patch proposed here.
1. Start Arduino IDE 1.8.19
1. Select **Tools > Port** from the Arduino IDE menus.
   🙂 All serial ports are listed in the menu.
1. Start Arduino IDE 2.3.2
1. Connect a device that produces a port with VID of `0x30A4` to your computer.
1. Select **Tools > Port** from the Arduino IDE menus.
   🙂 All serial ports are listed in the menu.
   🙂 The port of the device with VID of `0x30A4` is labeled "**(Blues boards)**

### Additional context

Even though, from a technical standpoint, this change restores the platform's support for Arduino IDE 1.x, my impression is that maintainability was also a factor in the decision to drop 1.x support (which is quite understandable). For this reason, [the "only Arduino IDE 2 is supported" statement](https://github.com/stm32duino/Arduino_Core_STM32/blob/89a29516cca7b50c6aef17a52e0e6e4afe78aeb7/README.md?plain=1#L41-L42) was not removed from the readme.

### Closing issues

- Fixes https://github.com/stm32duino/Arduino_Core_STM32/issues/2469
- Fixes https://github.com/stm32duino/Arduino_Core_STM32/issues/2511