### PR TITLE
cdc_queue.cpp change to uint32_t length, print(0ULL) bugfix

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -375,6 +375,12 @@ size_t Print::printULLNumber(unsigned long long n64, uint8_t base)
   uint8_t i = 0;
   uint8_t innerLoops = 0;
 
+  // Special case workaround https://github.com/arduino/ArduinoCore-API/issues/178
+  if (n64 == 0) {
+    write('0');
+    return 1;
+  }
+
   // prevent crash if called with base == 1
   if (base < 2) {
     base = 10;

--- a/libraries/USBDevice/inc/cdc_queue.h
+++ b/libraries/USBDevice/inc/cdc_queue.h
@@ -53,45 +53,49 @@ extern "C" {
 #else
 #define CDC_QUEUE_MAX_PACKET_SIZE USB_FS_MAX_PACKET_SIZE
 #endif
+
+#define CDC_TRANSMIT_MAX_BUFFER_SIZE    65472       //STM32 USB OTG DIEPTSIZ PKTCNT maximum 0x3ff
+#define CDC_RECEIVE_MAX_BUFFER_SIZE     CDC_QUEUE_MAX_PACKET_SIZE
+
 #ifndef CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER
 #define CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER 2
 #endif
 #ifndef CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER
 #define CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER 3
 #endif
-#define CDC_TRANSMIT_QUEUE_BUFFER_SIZE ((uint16_t)(CDC_QUEUE_MAX_PACKET_SIZE * CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER))
-#define CDC_RECEIVE_QUEUE_BUFFER_SIZE ((uint16_t)(CDC_QUEUE_MAX_PACKET_SIZE * CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER))
+#define CDC_TRANSMIT_QUEUE_BUFFER_SIZE (CDC_QUEUE_MAX_PACKET_SIZE * CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER)
+#define CDC_RECEIVE_QUEUE_BUFFER_SIZE  (CDC_QUEUE_MAX_PACKET_SIZE * CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER )
 
 typedef struct {
   uint8_t buffer[CDC_TRANSMIT_QUEUE_BUFFER_SIZE];
-  volatile uint16_t write;
-  volatile uint16_t read;
-  volatile uint16_t reserved;
+  volatile uint32_t write;
+  volatile uint32_t read;
+  volatile uint32_t reserved;
 } CDC_TransmitQueue_TypeDef;
 
 typedef struct {
   uint8_t buffer[CDC_RECEIVE_QUEUE_BUFFER_SIZE];
-  volatile uint16_t write;
-  volatile uint16_t read;
-  volatile uint16_t length;
+  volatile uint32_t write;
+  volatile uint32_t read;
+  volatile uint32_t length;
 } CDC_ReceiveQueue_TypeDef;
 
 void CDC_TransmitQueue_Init(CDC_TransmitQueue_TypeDef *queue);
 int CDC_TransmitQueue_WriteSize(CDC_TransmitQueue_TypeDef *queue);
 int CDC_TransmitQueue_ReadSize(CDC_TransmitQueue_TypeDef *queue);
 void CDC_TransmitQueue_Enqueue(CDC_TransmitQueue_TypeDef *queue, const uint8_t *buffer, uint32_t size);
-uint8_t *CDC_TransmitQueue_ReadBlock(CDC_TransmitQueue_TypeDef *queue, uint16_t *size);
+uint8_t *CDC_TransmitQueue_ReadBlock(CDC_TransmitQueue_TypeDef *queue, uint32_t *size);
 void CDC_TransmitQueue_CommitRead(CDC_TransmitQueue_TypeDef *queue);
 
 void CDC_ReceiveQueue_Init(CDC_ReceiveQueue_TypeDef *queue);
 int CDC_ReceiveQueue_ReadSize(CDC_ReceiveQueue_TypeDef *queue);
 int CDC_ReceiveQueue_Dequeue(CDC_ReceiveQueue_TypeDef *queue);
 int CDC_ReceiveQueue_Peek(CDC_ReceiveQueue_TypeDef *queue);
-uint16_t CDC_ReceiveQueue_Read(CDC_ReceiveQueue_TypeDef *queue, uint8_t *buffer, uint16_t size);
+uint32_t CDC_ReceiveQueue_Read(CDC_ReceiveQueue_TypeDef *queue, uint8_t *buffer, uint32_t size);
 bool CDC_ReceiveQueue_ReadUntil(CDC_ReceiveQueue_TypeDef *queue, uint8_t terminator, uint8_t *buffer,
-                                uint16_t size, uint16_t *fetched);
+                                uint32_t size, uint32_t *fetched);
 uint8_t *CDC_ReceiveQueue_ReserveBlock(CDC_ReceiveQueue_TypeDef *queue);
-void CDC_ReceiveQueue_CommitBlock(CDC_ReceiveQueue_TypeDef *queue, uint16_t size);
+void CDC_ReceiveQueue_CommitBlock(CDC_ReceiveQueue_TypeDef *queue, uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/libraries/USBDevice/src/USBSerial.cpp
+++ b/libraries/USBDevice/src/USBSerial.cpp
@@ -107,8 +107,8 @@ int USBSerial::read(void)
 
 size_t USBSerial::readBytes(char *buffer, size_t length)
 {
-  uint16_t read;
-  auto rest = static_cast<uint16_t>(length);
+  size_t read;
+  size_t rest = length;
   _startMillis = millis();
   do {
     read = CDC_ReceiveQueue_Read(&ReceiveQueue, reinterpret_cast<uint8_t *>(buffer), rest);
@@ -124,8 +124,8 @@ size_t USBSerial::readBytes(char *buffer, size_t length)
 
 size_t USBSerial::readBytesUntil(char terminator, char *buffer, size_t length)
 {
-  uint16_t read;
-  auto rest = static_cast<uint16_t>(length);
+  size_t read;
+  size_t rest = length;
   _startMillis = millis();
   do {
     bool found = CDC_ReceiveQueue_ReadUntil(&ReceiveQueue, static_cast<uint8_t>(terminator),

--- a/libraries/USBDevice/src/cdc/usbd_cdc_if.c
+++ b/libraries/USBDevice/src/cdc/usbd_cdc_if.c
@@ -238,7 +238,7 @@ static int8_t USBD_CDC_Receive(uint8_t *Buf, uint32_t *Len)
   UNUSED(Buf);
 #endif
   /* It always contains required amount of free space for writing */
-  CDC_ReceiveQueue_CommitBlock(&ReceiveQueue, (uint16_t)(*Len));
+  CDC_ReceiveQueue_CommitBlock(&ReceiveQueue, *Len);
   receivePended = false;
   /* If enough space in the queue for a full buffer then continue receive */
   if (!CDC_resume_receive()) {
@@ -330,7 +330,7 @@ bool CDC_connected()
 
 void CDC_continue_transmit(void)
 {
-  uint16_t size;
+  uint32_t size;
   uint8_t *buffer;
   USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef *) hUSBD_Device_CDC.pClassData;
   /*


### PR DESCRIPTION
## Pull Request template
**Summary**
raise cdc buffer size 32KB limit due to uint16_t length variables.

This PR fixes bug:
* cdc queue limited
now CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER  and/or CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER both can be greater than 512. which every buffer size is 64B, 64*512=32768

* print(0ULL) no output 
https://github.com/arduino/ArduinoCore-API/issues/178

