### PR TITLE
chore(usb): cdc_queue now use uint32_t length

### DIFF
--- a/libraries/USBDevice/inc/cdc_queue.h
+++ b/libraries/USBDevice/inc/cdc_queue.h
@@ -53,45 +53,49 @@ extern "C" {
 #else
 #define CDC_QUEUE_MAX_PACKET_SIZE USB_FS_MAX_PACKET_SIZE
 #endif
+
+#define CDC_TRANSMIT_MAX_BUFFER_SIZE    65472       //STM32 USB OTG DIEPTSIZ PKTCNT maximum 0x3ff
+#define CDC_RECEIVE_MAX_BUFFER_SIZE     CDC_QUEUE_MAX_PACKET_SIZE
+
 #ifndef CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER
 #define CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER 2
 #endif
 #ifndef CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER
 #define CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER 3
 #endif
-#define CDC_TRANSMIT_QUEUE_BUFFER_SIZE ((uint16_t)(CDC_QUEUE_MAX_PACKET_SIZE * CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER))
-#define CDC_RECEIVE_QUEUE_BUFFER_SIZE ((uint16_t)(CDC_QUEUE_MAX_PACKET_SIZE * CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER))
+#define CDC_TRANSMIT_QUEUE_BUFFER_SIZE (CDC_QUEUE_MAX_PACKET_SIZE * CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER)
+#define CDC_RECEIVE_QUEUE_BUFFER_SIZE  (CDC_QUEUE_MAX_PACKET_SIZE * CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER )
 
 typedef struct {
   uint8_t buffer[CDC_TRANSMIT_QUEUE_BUFFER_SIZE];
-  volatile uint16_t write;
-  volatile uint16_t read;
-  volatile uint16_t reserved;
+  volatile uint32_t write;
+  volatile uint32_t read;
+  volatile uint32_t reserved;
 } CDC_TransmitQueue_TypeDef;
 
 typedef struct {
   uint8_t buffer[CDC_RECEIVE_QUEUE_BUFFER_SIZE];
-  volatile uint16_t write;
-  volatile uint16_t read;
-  volatile uint16_t length;
+  volatile uint32_t write;
+  volatile uint32_t read;
+  volatile uint32_t length;
 } CDC_ReceiveQueue_TypeDef;
 
 void CDC_TransmitQueue_Init(CDC_TransmitQueue_TypeDef *queue);
 int CDC_TransmitQueue_WriteSize(CDC_TransmitQueue_TypeDef *queue);
 int CDC_TransmitQueue_ReadSize(CDC_TransmitQueue_TypeDef *queue);
 void CDC_TransmitQueue_Enqueue(CDC_TransmitQueue_TypeDef *queue, const uint8_t *buffer, uint32_t size);
-uint8_t *CDC_TransmitQueue_ReadBlock(CDC_TransmitQueue_TypeDef *queue, uint16_t *size);
+uint8_t *CDC_TransmitQueue_ReadBlock(CDC_TransmitQueue_TypeDef *queue, uint32_t *size);
 void CDC_TransmitQueue_CommitRead(CDC_TransmitQueue_TypeDef *queue);
 
 void CDC_ReceiveQueue_Init(CDC_ReceiveQueue_TypeDef *queue);
 int CDC_ReceiveQueue_ReadSize(CDC_ReceiveQueue_TypeDef *queue);
 int CDC_ReceiveQueue_Dequeue(CDC_ReceiveQueue_TypeDef *queue);
 int CDC_ReceiveQueue_Peek(CDC_ReceiveQueue_TypeDef *queue);
-uint16_t CDC_ReceiveQueue_Read(CDC_ReceiveQueue_TypeDef *queue, uint8_t *buffer, uint16_t size);
+uint32_t CDC_ReceiveQueue_Read(CDC_ReceiveQueue_TypeDef *queue, uint8_t *buffer, uint32_t size);
 bool CDC_ReceiveQueue_ReadUntil(CDC_ReceiveQueue_TypeDef *queue, uint8_t terminator, uint8_t *buffer,
-                                uint16_t size, uint16_t *fetched);
+                                uint32_t size, uint32_t *fetched);
 uint8_t *CDC_ReceiveQueue_ReserveBlock(CDC_ReceiveQueue_TypeDef *queue);
-void CDC_ReceiveQueue_CommitBlock(CDC_ReceiveQueue_TypeDef *queue, uint16_t size);
+void CDC_ReceiveQueue_CommitBlock(CDC_ReceiveQueue_TypeDef *queue, uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/libraries/USBDevice/src/USBSerial.cpp
+++ b/libraries/USBDevice/src/USBSerial.cpp
@@ -107,8 +107,8 @@ int USBSerial::read(void)
 
 size_t USBSerial::readBytes(char *buffer, size_t length)
 {
-  uint16_t read;
-  auto rest = static_cast<uint16_t>(length);
+  size_t read;
+  size_t rest = length;
   _startMillis = millis();
   do {
     read = CDC_ReceiveQueue_Read(&ReceiveQueue, reinterpret_cast<uint8_t *>(buffer), rest);
@@ -124,8 +124,8 @@ size_t USBSerial::readBytes(char *buffer, size_t length)
 
 size_t USBSerial::readBytesUntil(char terminator, char *buffer, size_t length)
 {
-  uint16_t read;
-  auto rest = static_cast<uint16_t>(length);
+  uint32_t read;
+  size_t rest = length;
   _startMillis = millis();
   do {
     bool found = CDC_ReceiveQueue_ReadUntil(&ReceiveQueue, static_cast<uint8_t>(terminator),

--- a/libraries/USBDevice/src/cdc/cdc_queue.c
+++ b/libraries/USBDevice/src/cdc/cdc_queue.c
@@ -67,32 +67,34 @@ void CDC_TransmitQueue_Enqueue(CDC_TransmitQueue_TypeDef *queue,
 {
   uint32_t sizeToEnd = CDC_TRANSMIT_QUEUE_BUFFER_SIZE - queue->write;
   if (sizeToEnd > size) {
-    memcpy(&queue->buffer[queue->write], &buffer[0], size);
+    memcpy(queue->buffer + queue->write, buffer, size);
   } else {
-    memcpy(&queue->buffer[queue->write], &buffer[0], sizeToEnd);
-    memcpy(&queue->buffer[0], &buffer[sizeToEnd], size - sizeToEnd);
+    memcpy(queue->buffer + queue->write, buffer, sizeToEnd);
+    memcpy(queue->buffer, buffer + sizeToEnd, size - sizeToEnd);
   }
-  queue->write = (uint16_t)((queue->write + size) %
-                            CDC_TRANSMIT_QUEUE_BUFFER_SIZE);
+  queue->write = (queue->write + size) % CDC_TRANSMIT_QUEUE_BUFFER_SIZE;
 }
 
 // Read flat block from queue biggest as possible, but max QUEUE_MAX_PACKET_SIZE
 uint8_t *CDC_TransmitQueue_ReadBlock(CDC_TransmitQueue_TypeDef *queue,
-                                     uint16_t *size)
+                                     uint32_t *size)
 {
   if (queue->write >= queue->read) {
     *size = queue->write - queue->read;
   } else {
     *size = CDC_TRANSMIT_QUEUE_BUFFER_SIZE - queue->read;
   }
+  if (*size > CDC_TRANSMIT_MAX_BUFFER_SIZE) {
+    *size = CDC_TRANSMIT_MAX_BUFFER_SIZE;
+  }
+
   queue->reserved = *size;
   return &queue->buffer[queue->read];
 }
 
 void CDC_TransmitQueue_CommitRead(CDC_TransmitQueue_TypeDef *queue)
 {
-  queue->read = (queue->read + queue->reserved) %
-                CDC_TRANSMIT_QUEUE_BUFFER_SIZE;
+  queue->read = (queue->read + queue->reserved) % CDC_TRANSMIT_QUEUE_BUFFER_SIZE;
 }
 
 // Initialize read and write position of queue.
@@ -106,9 +108,9 @@ void CDC_ReceiveQueue_Init(CDC_ReceiveQueue_TypeDef *queue)
 // Reserve block in queue and return pointer to it.
 uint8_t *CDC_ReceiveQueue_ReserveBlock(CDC_ReceiveQueue_TypeDef *queue)
 {
-  const uint16_t limit =
-    CDC_RECEIVE_QUEUE_BUFFER_SIZE - CDC_QUEUE_MAX_PACKET_SIZE;
-  volatile uint16_t read = queue->read;
+  const uint32_t limit =
+    CDC_RECEIVE_QUEUE_BUFFER_SIZE - CDC_RECEIVE_MAX_BUFFER_SIZE;
+  volatile uint32_t read = queue->read;
 
   if (read <= queue->write) {
     // if write is limited only by buffer size.
@@ -116,13 +118,13 @@ uint8_t *CDC_ReceiveQueue_ReserveBlock(CDC_ReceiveQueue_TypeDef *queue)
       // if size in the rest of buffer is enough for full packet plus 1 byte
       // or if it tight enough and write position can be set to 0
       return queue->buffer + queue->write;
-    } else if (read > CDC_QUEUE_MAX_PACKET_SIZE) {
+    } else if (read > CDC_RECEIVE_MAX_BUFFER_SIZE) {
       // if size in the rest is not enough, but enough size in head
       queue->length = queue->write;
       queue->write = 0;
       return queue->buffer + queue->write;
     }
-  } else if (queue->write + CDC_QUEUE_MAX_PACKET_SIZE < read) {
+  } else if (queue->write + CDC_RECEIVE_MAX_BUFFER_SIZE < read) {
     // write position must be less than read position
     // after reading largest possible packet
     return queue->buffer + queue->write;
@@ -132,7 +134,7 @@ uint8_t *CDC_ReceiveQueue_ReserveBlock(CDC_ReceiveQueue_TypeDef *queue)
 
 // Commits block in queue and make it available for reading
 void CDC_ReceiveQueue_CommitBlock(CDC_ReceiveQueue_TypeDef *queue,
-                                  uint16_t size)
+                                  uint32_t size)
 {
   queue->write += size;
   if (queue->write >= queue->length) {
@@ -148,8 +150,8 @@ int CDC_ReceiveQueue_ReadSize(CDC_ReceiveQueue_TypeDef *queue)
 {
   // reading length after write make guarantee, that length >= write
   // and determined reading size will be smaller or equal than real one.
-  volatile uint16_t write = queue->write;
-  volatile uint16_t length = queue->length;
+  volatile uint32_t write = queue->write;
+  volatile uint32_t length = queue->length;
   if (write >= queue->read) {
     return write - queue->read;
   }
@@ -159,8 +161,8 @@ int CDC_ReceiveQueue_ReadSize(CDC_ReceiveQueue_TypeDef *queue)
 // Read one byte from queue.
 int CDC_ReceiveQueue_Dequeue(CDC_ReceiveQueue_TypeDef *queue)
 {
-  volatile uint16_t write = queue->write;
-  volatile uint16_t length = queue->length;
+  volatile uint32_t write = queue->write;
+  volatile uint32_t length = queue->length;
   if (queue->read == length) {
     queue->read = 0;
   }
@@ -177,8 +179,8 @@ int CDC_ReceiveQueue_Dequeue(CDC_ReceiveQueue_TypeDef *queue)
 // Peek byte from queue.
 int CDC_ReceiveQueue_Peek(CDC_ReceiveQueue_TypeDef *queue)
 {
-  volatile uint16_t write = queue->write;
-  volatile uint16_t length = queue->length;
+  volatile uint32_t write = queue->write;
+  volatile uint32_t length = queue->length;
   if (queue->read >= length) {
     queue->read = 0;
   }
@@ -188,12 +190,12 @@ int CDC_ReceiveQueue_Peek(CDC_ReceiveQueue_TypeDef *queue)
   return queue->buffer[queue->read];
 }
 
-uint16_t CDC_ReceiveQueue_Read(CDC_ReceiveQueue_TypeDef *queue,
-                               uint8_t *buffer, uint16_t size)
+uint32_t CDC_ReceiveQueue_Read(CDC_ReceiveQueue_TypeDef *queue,
+                               uint8_t *buffer, uint32_t size)
 {
-  volatile uint16_t write = queue->write;
-  volatile uint16_t length = queue->length;
-  uint16_t available;
+  volatile uint32_t write = queue->write;
+  volatile uint32_t length = queue->length;
+  uint32_t available;
 
   if (queue->read >= length) {
     queue->read = 0;
@@ -216,11 +218,11 @@ uint16_t CDC_ReceiveQueue_Read(CDC_ReceiveQueue_TypeDef *queue,
 }
 
 bool CDC_ReceiveQueue_ReadUntil(CDC_ReceiveQueue_TypeDef *queue,
-                                uint8_t terminator, uint8_t *buffer, uint16_t size, uint16_t *fetched)
+                                uint8_t terminator, uint8_t *buffer, uint32_t size, uint32_t *fetched)
 {
-  volatile uint16_t write = queue->write;
-  volatile uint16_t length = queue->length;
-  uint16_t available;
+  volatile uint32_t write = queue->write;
+  volatile uint32_t length = queue->length;
+  uint32_t available;
 
   if (queue->read >= length) {
     queue->read = 0;
@@ -235,10 +237,10 @@ bool CDC_ReceiveQueue_ReadUntil(CDC_ReceiveQueue_TypeDef *queue,
   }
 
   uint8_t *start = &queue->buffer[queue->read];
-  for (uint16_t i = 0; i < size; i++) {
+  for (uint32_t i = 0; i < size; i++) {
     uint8_t ch = start[i];
     if (ch == terminator) {
-      queue->read += (uint16_t)(i + 1);
+      queue->read += (uint32_t)(i + 1);
       if (queue->read >= length) {
         queue->read = 0;
       }

--- a/libraries/USBDevice/src/cdc/usbd_cdc_if.c
+++ b/libraries/USBDevice/src/cdc/usbd_cdc_if.c
@@ -238,7 +238,7 @@ static int8_t USBD_CDC_Receive(uint8_t *Buf, uint32_t *Len)
   UNUSED(Buf);
 #endif
   /* It always contains required amount of free space for writing */
-  CDC_ReceiveQueue_CommitBlock(&ReceiveQueue, (uint16_t)(*Len));
+  CDC_ReceiveQueue_CommitBlock(&ReceiveQueue, *Len);
   receivePended = false;
   /* If enough space in the queue for a full buffer then continue receive */
   if (!CDC_resume_receive()) {
@@ -330,7 +330,7 @@ bool CDC_connected()
 
 void CDC_continue_transmit(void)
 {
-  uint16_t size;
+  uint32_t size;
   uint8_t *buffer;
   USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef *) hUSBD_Device_CDC.pClassData;
   /*


### PR DESCRIPTION
### Summary
remove cdc buffer size 32KB limit due to uint16_t length variables.

This PR fixes bug:
cdc queue limit.
now CDC_TRANSMIT_QUEUE_BUFFER_PACKET_NUMBER and/or CDC_RECEIVE_QUEUE_BUFFER_PACKET_NUMBER both can be greater than 512. which every buffer size is 64B, 64*512=32768
