### PR TITLE
fix(spi): ensure spi_t structure properly init

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -14,26 +14,18 @@
 SPIClass SPI;
 
 /**
-  * @brief  Default constructor. Uses pin configuration of variant.h.
-  */
-SPIClass::SPIClass()
-{
-  _spi.pin_miso = digitalPinToPinName(MISO);
-  _spi.pin_mosi = digitalPinToPinName(MOSI);
-  _spi.pin_sclk = digitalPinToPinName(SCK);
-  _spi.pin_ssel = NC;
-}
-
-/**
-  * @brief  Constructor to create another SPI instance attached to another SPI
-  *         peripheral different of the default SPI. All pins must be attached to
-  *         the same SPI peripheral. See datasheet of the microcontroller.
+  * @brief  Default Constructor. Uses pin configuration of default SPI
+  *         defined in the variant*.h.
+  *         To create another SPI instance attached to another SPI
+  *         peripheral gave the pins as parameters to the constructor.
+  * @note   All pins must be attached to the same SPI peripheral.
+  *         See datasheet of the microcontroller.
   * @param  mosi: SPI mosi pin. Accepted format: number or Arduino format (Dx)
-  *         or ST format (Pxy).
+  *         or ST format (Pxy). Default is MOSI pin of the default SPI peripheral.
   * @param  miso: SPI miso pin. Accepted format: number or Arduino format (Dx)
-  *         or ST format (Pxy).
+  *         or ST format (Pxy). Default is MISO pin of the default SPI peripheral.
   * @param  sclk: SPI clock pin. Accepted format: number or Arduino format (Dx)
-  *         or ST format (Pxy).
+  *         or ST format (Pxy). Default is SCK pin of the default SPI peripheral.
   * @param  ssel: SPI ssel pin (optional). Accepted format: number or
   *         Arduino format (Dx) or ST format (Pxy). By default is set to NC.
   *         This pin must correspond to a hardware CS pin which can be managed

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -37,6 +37,7 @@ SPIClass SPI;
   */
 SPIClass::SPIClass(uint32_t mosi, uint32_t miso, uint32_t sclk, uint32_t ssel)
 {
+  memset((void *)&_spi, 0, sizeof(_spi));
   _spi.pin_miso = digitalPinToPinName(miso);
   _spi.pin_mosi = digitalPinToPinName(mosi);
   _spi.pin_sclk = digitalPinToPinName(sclk);

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -84,8 +84,7 @@ class SPISettings {
 
 class SPIClass {
   public:
-    SPIClass();
-    SPIClass(uint32_t mosi, uint32_t miso, uint32_t sclk, uint32_t ssel = PNUM_NOT_DEFINED);
+    SPIClass(uint32_t mosi = MISO, uint32_t miso = MOSI, uint32_t sclk = SCK, uint32_t ssel = PNUM_NOT_DEFINED);
 
     // setMISO/MOSI/SCLK/SSEL have to be called before begin()
     void setMISO(uint32_t miso)


### PR DESCRIPTION
Fixes #2543 

`SPIClass` constructor was factorized.