### PR TITLE
chore(c0): enable usb

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -14013,6 +14013,14 @@ Eval.menu.xusb.HS.build.usb_speed=-DUSE_USB_HS
 Eval.menu.xusb.HSFS=High Speed in Full Speed mode
 Eval.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 
+GenC0.menu.usb.none=None
+GenC0.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
+GenC0.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
+GenC0.menu.usb.CDC=CDC (no generic 'Serial')
+GenC0.menu.usb.CDC.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC -DDISABLE_GENERIC_SERIALUSB
+GenC0.menu.usb.HID=HID (keyboard and mouse)
+GenC0.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
+
 GenF0.menu.usb.none=None
 GenF0.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenF0.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
@@ -14086,6 +14094,14 @@ GenF7.menu.xusb.HS.build.usb_speed=-DUSE_USB_HS
 GenF7.menu.xusb.HSFS=High Speed in Full Speed mode
 GenF7.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 
+GenG0.menu.usb.none=None
+GenG0.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
+GenG0.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
+GenG0.menu.usb.CDC=CDC (no generic 'Serial')
+GenG0.menu.usb.CDC.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC -DDISABLE_GENERIC_SERIALUSB
+GenG0.menu.usb.HID=HID (keyboard and mouse)
+GenG0.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
+
 GenG4.menu.usb.none=None
 GenG4.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenG4.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
@@ -14098,14 +14114,6 @@ GenG4.menu.xusb.HS=High Speed
 GenG4.menu.xusb.HS.build.usb_speed=-DUSE_USB_HS
 GenG4.menu.xusb.HSFS=High Speed in Full Speed mode
 GenG4.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
-
-GenG0.menu.usb.none=None
-GenG0.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
-GenG0.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
-GenG0.menu.usb.CDC=CDC (no generic 'Serial')
-GenG0.menu.usb.CDC.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC -DDISABLE_GENERIC_SERIALUSB
-GenG0.menu.usb.HID=HID (keyboard and mouse)
-GenG0.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
 
 GenH5.menu.usb.none=None
 GenH5.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)

--- a/variants/STM32C0xx/C071R(8-B)T/generic_clock.c
+++ b/variants/STM32C0xx/C071R(8-B)T/generic_clock.c
@@ -27,6 +27,9 @@ WEAK void SystemClock_Config(void)
   LL_RCC_HSI_Enable();
   while (LL_RCC_HSI_IsReady() != 1) {
   }
+  LL_RCC_HSI48_Enable();
+  while (LL_RCC_HSI48_IsReady() != 1) {
+  }
 
   LL_RCC_HSI_SetCalibTrimming(64);
   LL_RCC_SetHSIDiv(LL_RCC_HSI_DIV_1);

--- a/variants/STM32C0xx/C071R(8-B)T/variant_NUCLEO_C071RB.cpp
+++ b/variants/STM32C0xx/C071R(8-B)T/variant_NUCLEO_C071RB.cpp
@@ -116,6 +116,9 @@ WEAK void SystemClock_Config(void)
   LL_RCC_HSI_Enable();
   while (LL_RCC_HSI_IsReady() != 1) {
   }
+  LL_RCC_HSI48_Enable();
+  while (LL_RCC_HSI48_IsReady() != 1) {
+  }
 
   LL_RCC_HSI_SetCalibTrimming(64);
   LL_RCC_SetHSIDiv(LL_RCC_HSI_DIV_1);


### PR DESCRIPTION
Enable the HSI48 for USB (not done thanks CubeMX code generation). Add GenC0 USB menu.
Moved G0 one in alphabetical order.

Fixes #2582.

Tested with Nucleo C071RB.