### PR TITLE
chore: allow to not disable UCPD dead battery

### DIFF
--- a/libraries/SrcWrapper/src/stm32/hw_config.c
+++ b/libraries/SrcWrapper/src/stm32/hw_config.c
@@ -45,6 +45,7 @@ void hw_config_init(void)
 {
   configIPClock();
 
+#if !defined (SKIP_DISABLING_UCPD_DEAD_BATTERY)
 #if defined(PWR_CR3_UCPD_DBDIS) || defined(PWR_UCPDR_UCPD_DBDIS)
   /* Disable the internal Pull-Up in Dead Battery pins of UCPD peripheral */
   HAL_PWREx_DisableUCPDDeadBattery();
@@ -53,6 +54,7 @@ void hw_config_init(void)
   /* Disable the internal Pull-Up in Dead Battery pins of UCPD peripheral */
   HAL_SYSCFG_StrobeDBattpinsConfig(SYSCFG_CFGR1_UCPD1_STROBE | SYSCFG_CFGR1_UCPD2_STROBE);
 #endif /* SYSCFG_CFGR1_UCPD1_STROBE || SYSCFG_CFGR1_UCPD2_STROBE */
+#endif /* !SKIP_DISABLING_UCPD_DEAD_BATTERY */
 
 #if defined(PWR_SVMCR_ASV)
   HAL_PWREx_EnableVddA();


### PR DESCRIPTION
Closes #2576.

Wiki will be updated to reference it:

> ## Enable UCPD dead battery behavior
> 
> > [!NOTE]
> > Available with STM32 core version higher than 2.9.0.
> 
> By default, UCPD dead battery behavior is disabled after reset.
> After user request to be able to not disable it, user can use this definition to
> not disable it:
> 
> `SKIP_DISABLING_UCPD_DEAD_BATTERY`
> 
> It can be defined thanks the `variant.h`, `build_opt.h` or `hal_conf_extra.h`
> 
> > [!WARNING]
> > Enable it is under user responsability.