### PR TITLE
Fix dead lock with pin above NUM_DIGITAL_PINS

### DIFF
--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -88,10 +88,7 @@ int digitalRead(uint32_t ulPin)
 {
   PinName p = digitalPinToPinName(ulPin);
 
-  if (p == NC) {
-    return 0;
-  }
-  return digitalReadFast(p);
+  return (p == NC) ? 0 : digitalReadFast(p);
 }
 
 void digitalToggle(uint32_t ulPin)

--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -78,17 +78,28 @@ void pinMode(uint32_t ulPin, uint32_t ulMode)
 
 void digitalWrite(uint32_t ulPin, uint32_t ulVal)
 {
-  digitalWriteFast(digitalPinToPinName(ulPin), ulVal);
+  PinName p = digitalPinToPinName(ulPin);
+  if (p != NC) {
+    digitalWriteFast(p, ulVal);
+  }
 }
 
 int digitalRead(uint32_t ulPin)
 {
-  return digitalReadFast(digitalPinToPinName(ulPin));
+  PinName p = digitalPinToPinName(ulPin);
+
+  if (p == NC) {
+    return 0;
+  }
+  return digitalReadFast(p);
 }
 
 void digitalToggle(uint32_t ulPin)
 {
-  digitalToggleFast(digitalPinToPinName(ulPin));
+  PinName p = digitalPinToPinName(ulPin);
+  if (p != NC) {
+    digitalToggleFast(digitalPinToPinName(ulPin));
+  }
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Penalty for the check should be a single instruction for pin numbers below NUM_DIGITAL_PINS, 9 for pin numbers between PNUM_ANALOG_BASE and NUM_ANALOG_INTERNAL_FIRST.

Tests done on a Black F407VE board

Fixes #2612 
