### PR TITLE
Update wrong HSE value on variant_B_G431B_ESC1.h

### DIFF
--- a/variants/STM32G4xx/G431C(6-8-B)U_G441CBU/variant_B_G431B_ESC1.h
+++ b/variants/STM32G4xx/G431C(6-8-B)U_G441CBU/variant_B_G431B_ESC1.h
@@ -214,7 +214,7 @@
 #endif
 
 /* HAL configuration */
-#define HSE_VALUE               (24000000UL)
+#define HSE_VALUE               (8000000UL)
 
 /* Extra HAL modules */
 #if !defined(HAL_DAC_MODULE_DISABLED)


### PR DESCRIPTION
HSE was set to 24MHz instead of 8MHz, and was overriding anything else trying to set the HSE speed, causing 1ms to be 3ms. Changing it here fixes everything.

See https://www.st.com/en/evaluation-tools/b-g431b-esc1.html#cad-resources, mb1419-g431cbu6-b01, Crystal is 8MHz in schematic.
