### PR TITLE
feat(debugger): set dapdirect_swd as default transport

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -474,7 +474,6 @@ Nucleo_64.menu.pnum.NUCLEO_C071RB.build.variant=STM32C0xx/C071R(8-B)T
 Nucleo_64.menu.pnum.NUCLEO_C071RB.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 Nucleo_64.menu.pnum.NUCLEO_C071RB.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -D__CORTEX_SC=0
 Nucleo_64.menu.pnum.NUCLEO_C071RB.openocd.target=stm32c0x
-Nucleo_64.menu.pnum.NUCLEO_C071RB.debug.server.openocd.scripts.1={runtime.platform.path}/debugger/select_dapdirect.cfg
 Nucleo_64.menu.pnum.NUCLEO_C071RB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32C0xx/STM32C071.svd
 
 # NUCLEO_F030R8 board
@@ -831,7 +830,6 @@ Nucleo_64.menu.pnum.NUCLEO_U083RC.build.product_line=STM32U083xx
 Nucleo_64.menu.pnum.NUCLEO_U083RC.build.variant=STM32U0xx/U073R(8-B-C)(I-T)_U083RC(I-T)
 Nucleo_64.menu.pnum.NUCLEO_U083RC.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -D__CORTEX_SC=0
 Nucleo_64.menu.pnum.NUCLEO_U083RC.openocd.target=stm32u0x
-Nucleo_64.menu.pnum.NUCLEO_U083RC.debug.server.openocd.scripts.1={runtime.platform.path}/debugger/select_dapdirect.cfg
 Nucleo_64.menu.pnum.NUCLEO_U083RC.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32U0xx/STM32U083.svd
 
 # NUCLEO_WB15CC

--- a/platform.txt
+++ b/platform.txt
@@ -258,5 +258,5 @@ debug.server.openocd.path={openocd_dir}/bin/openocd
 debug.server.openocd.scripts_dir={openocd_dir}/openocd/scripts
 # Common config
 debug.server.openocd.scripts.0=interface/stlink.cfg
-debug.server.openocd.scripts.1={runtime.platform.path}/debugger/select_hla.cfg
+debug.server.openocd.scripts.1={runtime.platform.path}/debugger/select_dapdirect.cfg
 debug.server.openocd.scripts.2=target/{openocd.target}.cfg


### PR DESCRIPTION
hla_swd deprecated since STLink V2 (2015).
https://openocd.org/doc/html/Debug-Adapter-Configuration.html#SWD-Transport

> Unless your adapter uses either [the hla interface driver](https://openocd.org/doc/html/Debug-Adapter-Configuration.html#hla_005finterface) (in which case the command is transport select hla_swd) or [the st-link interface driver](https://openocd.org/doc/html/Debug-Adapter-Configuration.html#st_005flink_005fdap_005finterface) (in which case the command is transport select dapdirect_swd).

https://openocd.org/doc/html/Debug-Adapter-Configuration.html#st_005flink_005fdap_005finterface

> This is a driver that supports STMicroelectronics adapters ST-LINK/V2 (from 2015 firmware V2J24), STLINK-V3 and STLINK-V3PWR, thanks to a new API that provides directly access the arm ADIv5 DAP.
> 
> The older API that requires HLA transport is deprecated and will be dropped from OpenOCD. In mean time it’s still available by using interface/stlink-hla.cfg.