### PR TITLE
fix(openocd): update to xpack-openocd v0.12.0-6

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -17,7 +17,7 @@ busybox=
 busybox.windows={runtime.tools.STM32Tools.path}/win/busybox.exe
 
 toolchain_dir={runtime.tools.xpack-arm-none-eabi-gcc-14.2.1-1.1.path}
-openocd_dir={runtime.tools.xpack-openocd-0.12.0-5.path}
+openocd_dir={runtime.tools.xpack-openocd-0.12.0-6.path}
 
 tools_bin_path.windows={runtime.tools.STM32Tools.path}/win
 tools_bin_path.macosx={runtime.tools.STM32Tools.path}/macosx


### PR DESCRIPTION
https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-6

Fixes #2683.

When deploying xpack-openocd v0.12.0-5 issue was found in openocd:
https://github.com/xpack-dev-tools/openocd-xpack/issues/34

A new version was released xpack-openocd v0.12.0-6 with the fix.
Unfortunately when testing it the platform.txt updated was not committed. As xpack-openocd v0.12.0-5 was always installed no issue was seen.
