### PR TITLE
feat (uart): implement proper operator bool()

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -446,13 +446,17 @@ void HardwareSerial::begin(unsigned long baud, byte config)
       break;
   }
 
-  uart_init(&_serial, (uint32_t)baud, databits, parity, stopbits, _rx_invert, _tx_invert, _data_invert);
-  enableHalfDuplexRx();
-  uart_attach_rx_callback(&_serial, _rx_complete_irq);
+  _ready = uart_init(&_serial, (uint32_t)baud, databits, parity, stopbits, _rx_invert, _tx_invert, _data_invert);
+  if (_ready) {
+    enableHalfDuplexRx();
+    uart_attach_rx_callback(&_serial, _rx_complete_irq);
+  }
 }
 
 void HardwareSerial::end()
 {
+  _ready = false;
+
   // wait for transmission of outgoing data
   flush(TX_TIMEOUT);
 

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -146,7 +146,7 @@ class HardwareSerial : public Stream {
     using Print::write; // pull in write(str) from Print
     operator bool()
     {
-      return true;
+      return _ready;
     }
 
     void setRx(uint32_t _rx);
@@ -189,6 +189,7 @@ class HardwareSerial : public Stream {
 #endif // HAL_UART_MODULE_ENABLED && !HAL_UART_MODULE_ONLY
 
   private:
+    bool _ready;
     bool _rx_enabled;
     uint8_t _config;
     unsigned long _baud;

--- a/libraries/SrcWrapper/inc/uart.h
+++ b/libraries/SrcWrapper/inc/uart.h
@@ -255,7 +255,7 @@ struct serial_s {
 
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */
-void uart_init(serial_t *obj, uint32_t baudrate, uint32_t databits, uint32_t parity, uint32_t stopbits, bool rx_invert, bool tx_invert, bool data_invert);
+bool uart_init(serial_t *obj, uint32_t baudrate, uint32_t databits, uint32_t parity, uint32_t stopbits, bool rx_invert, bool tx_invert, bool data_invert);
 void uart_deinit(serial_t *obj);
 #if defined(HAL_PWR_MODULE_ENABLED) && (defined(UART_IT_WUF) || defined(LPUART1_BASE))
 void uart_config_lowpower(serial_t *obj);


### PR DESCRIPTION
This PR implements the _HardwareSerial_ bool() operator.

Currently, the core blocks if there is a write to a closed _HardwareSerial_ instance. The tx buffer will rapidly be full and the core waits forever for free space.

The bool() operator is a good way to check if the _HardwareSerial_ object is opened and ready to transmit data but in the current implementation, it allways returns true.

The PR implements a complete  bool() operator:
- Returns true when the _HardwareSerial_ object is ready.
- Returns false when the _HardwareSerial_ object is not ready.

Sample code:

```cpp
Serial.begin();
if (Serial) {
  Serial.println("Serial is opened");
  Serial.flush();
}
Serial.end();
if (Serial) {
  Serial.println("Serial is closed. Never be printed");
}
```