### PR TITLE
Annotate Error_Handler with noreturn to help analysis

### DIFF
--- a/libraries/SrcWrapper/src/stm32/stm32_def.c
+++ b/libraries/SrcWrapper/src/stm32/stm32_def.c
@@ -11,7 +11,7 @@ extern "C" {
   * @retval None
   */
 #if !defined(NDEBUG)
-WEAK void _Error_Handler(const char *msg, int val)
+__attribute__((noreturn)) WEAK void _Error_Handler(const char *msg, int val)
 {
   /* User can add his own implementation to report the HAL error return state */
   core_debug("Error: %s (%i)\n", msg, val);


### PR DESCRIPTION
**Summary**

This PR annotates `_Error_Handler` with `__attribute__((noreturn))` that informs the compiler that the given function does not return.

**Motivation**

This simplifies analysis for both the compiler and external tools.

For example it fixes a warning I got, that the result of `getAssociatedChannel` in `HardwareTimer.cpp` *might*\* underflow when `1` is subtracted from the default return value of zero and this would then result in an out of bounds array access. "Might" in this context probably means to the compiler that there's either no `Error_Handler` defined or there's one that returns. In any case, the fact that these errors can pop up (like they did for me), means the code flow is not always clear enough for the compiler.

**Additional notes**

`HardwareTimer` and other similar files could maybe be updated in a way to fail/return safe values in all cases? Though this might cause undesirable seemingly working "default" behaviour while a crash would be very visible.

An another question is if there should there be a default halt loop `Error_Handler` even if `NDEBUG` is enabled (and a replacement is not defined). I lack sufficient experience with the core to know if this would be safer everything considered.