### PR TITLE
Add ADC 14bit support in U5

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -29,10 +29,12 @@ extern "C" {
 uint32_t g_anOutputPinConfigured[MAX_NB_PORT] = {0};
 #endif
 
-#if !defined(ADC_RESOLUTION_16B)
-#define MAX_ADC_RESOLUTION 12
-#else
+#if defined(ADC_RESOLUTION_16B)
 #define MAX_ADC_RESOLUTION 16
+#elif defined(ADC_RESOLUTION_14B)
+#define MAX_ADC_RESOLUTION 14
+#else
+#define MAX_ADC_RESOLUTION 12
 #endif
 #define MAX_PWM_RESOLUTION 16
 


### PR DESCRIPTION
**Summary**

STM32U5 Series cannot set analog read resolution to 14-bit. Because `MAX_ADC_RESOLUTION` has a value of 12 instead of 14.

This PR fixes the following **bugs**
* [X] Bug U5 cannot read ADC with 14-bit resolution

**Motivation**
When set analog read resolution to 14-bit, analog only read with 12-bit

**Validation**
* Build and test with custom U585VI board