### PR TITLE
Fix LINKFLAGS containing a tuple in platformio build script

### DIFF
--- a/tools/platformio/platformio-build.py
+++ b/tools/platformio/platformio-build.py
@@ -376,13 +376,11 @@ if not board_config.get("build.ldscript", ""):
         print("Warning! Cannot find linker script for the current target!\n")
     env.Append(
         LINKFLAGS=[
-            (
-                "-Wl,--default-script",
-                join(
-                    inc_variant_dir,
-                    board_config.get("build.arduino.ldscript", "ldscript.ld"),
-                ),
-            )
+            "-Wl,--default-script",
+            join(
+                inc_variant_dir,
+                board_config.get("build.arduino.ldscript", "ldscript.ld"),
+            ),
         ]
     )
 


### PR DESCRIPTION
This PR fixes an issue in the platformio build script where a tuple containing the arguments is placed into LINKFLAGS. This broke a custom script in a different project (Bosch BSEC2 sensor library) that looks at LINKFLAGS.
I'm not sure how it worked before..

I've tested this locally and it's a minor change.