### PR TITLE
fix(Wire): only recover bus when device is master

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -90,7 +90,9 @@ void TwoWire::begin(uint8_t address, bool generalCall, bool NoStretchMode)
 
   _i2c.NoStretchMode = (NoStretchMode == true) ? 1 : 0;
 
-  recoverBus(); // in case I2C bus (device) is stuck after a reset for example
+  if (_i2c.isMaster == 1) {
+    recoverBus(); // in case I2C bus (device) is stuck after a reset for example
+  }
 
   i2c_init(&_i2c, 100000, ownAddress);
 


### PR DESCRIPTION
**Summary**

Fixed an issue in Wire.begin() where the I2C bus recovery routine was always triggered, even when initializing as a slave device. This could lead to unintended manipulation of the SCL line while SDA is low - potentially during an active transmission from the master. Only the master should perform a bus recovery.

This PR fix ensures that the SCL line is not manipulated when Wire.begin() is called in slave mode.
