### PR TITLE
fix(uart): HardwareSerial begin() causes Infinite Loop

### DIFF
--- a/libraries/SrcWrapper/inc/uart.h
+++ b/libraries/SrcWrapper/inc/uart.h
@@ -272,6 +272,12 @@ void uart_enable_rx(serial_t *obj);
 
 size_t uart_debug_write(uint8_t *data, uint32_t size);
 
+#if defined(UART_PRESCALER_DIV1)
+uint32_t calculatePresc(uint32_t pclk, uint32_t baudrate, uint32_t oversampling);
+#endif
+
+uint32_t uart_getPCLK(UART_HandleTypeDef *huart);
+
 #endif /* HAL_UART_MODULE_ENABLED  && !HAL_UART_MODULE_ONLY */
 #ifdef __cplusplus
 }

--- a/libraries/SrcWrapper/src/stm32/uart.c
+++ b/libraries/SrcWrapper/src/stm32/uart.c
@@ -1475,9 +1475,9 @@ uint32_t uart_getPCLK(UART_HandleTypeDef *huart)
 #elif defined(STM32H7)
     uint32_t sysclk = HAL_RCC_GetSysClockFreq();
 #if defined(STM32H7A3xx) || defined (STM32H7A3xxQ) || defined(STM32H7B3xx) || defined(STM32H7B3xxQ) || defined(STM32H7B0xx) || defined(STM32H7B0xxQ)
-    uint32_t prescaler = (RCC->CDCFGR2 & (0x7UL << 9U)) >> 9U;
+    uint32_t prescaler = (RCC->SRDCFGR & RCC_SRDCFGR_SRDPPRE) >> RCC_SRDCFGR_SRDPPRE_Pos;
 #else
-    uint32_t prescaler = (RCC->D2CFGR & (0x7UL << 9U)) >> 9U;
+    uint32_t prescaler = (RCC->D3CFGR & RCC_D3CFGR_D3PPRE) >> RCC_D3CFGR_D3PPRE_Pos;
 #endif
 
     uint32_t apb4 = 1;
@@ -1521,7 +1521,7 @@ uint32_t uart_getPCLK(UART_HandleTypeDef *huart)
 
 #if defined(STM32WB0)
   uint32_t sysclk = HAL_RCC_GetSysClockFreq();
-  uint32_t ppre2 = (RCC->CFGR & (0x7UL << 11U)) >> 11U;
+  uint32_t ppre2 = (RCC->CFGR & RCC_CFGR_CLKSYSDIV) >> RCC_CFGR_CLKSYSDIV_Pos;
   uint32_t apb2_div = 1;
 
   switch (ppre2) {


### PR DESCRIPTION
I found an issue while using HardwareSerial. Sometimes, when calling begin() function, the ClockPrescaler field inside huart->Init contains a garbage value. This wrong value is then passed to HAL_UART_Init(), and later used in UART_SetConfig() → UART_DIV_SAMPLING16() macro. When this happens, the MCU triggers an interrupt and get stuck in an infinite loop.

I didn't see this problem with every HardwareSerial instance. Although I couldn't exactly find what it depends on probably it is happening when the HardwareSerial object is a member of another class, and begin() is called from that class’s constructor.

I am using PlatformIO, but I replaced framework by Arduino Core STM32 version with the latest one from GitHub. I encountered this issue while using STM32H750VBT chip.

To solve this issue I added some functions and code blocks in uart.c and uart.h files.

- Added clockPrescaler setter in uart_init() function for devices which support clockPrescaler for UART. However, while setting I needed value of connected Peripharel clock and clockPrescaler finder function.

- Therefore, Added a function to calculate the correct ClockPrescaler based on the UART’s PCLK frequency.

- Added a helper function to get the PCLK frequency. I inspected all the datasheets while making this function but I am newbie so that this function still needs more review and testing for different STM32 series.

Tried to make the solution generic. Changes passed from CI tool but review gonna be good.

Testing

- I tested on STM32H750VBT6, and it worked.