### PR TITLE
Add readBytes(uint8_t *buffer, size_t length) to USBSerial.h

### DIFF
--- a/libraries/USBDevice/inc/USBSerial.h
+++ b/libraries/USBDevice/inc/USBSerial.h
@@ -37,7 +37,15 @@ class USBSerial : public Stream {
     virtual int peek(void);
     virtual int read(void);
     virtual size_t readBytes(char *buffer, size_t length);  // read chars from stream into buffer
+    size_t readBytes(uint8_t *buffer, size_t length)
+    {
+      return readBytes((char *)buffer, length);
+    }
     virtual size_t readBytesUntil(char terminator, char *buffer, size_t length);  // as readBytes with terminator character
+    size_t readBytesUntil(char terminator, uint8_t *buffer, size_t length)
+    {
+      return readBytesUntil(terminator, (char *)buffer, length);
+    }
     virtual void flush(void);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *buffer, size_t size);


### PR DESCRIPTION
This PR adds the uint8_t* variant of the readBytes method to USBSerial.h, to make it more similar to the HardwareSerial interface.

Motivation: this PR makes it easier to interchange USBSerial and HardwareSerial in user code.