### PR TITLE
chore(pio): clean up cmsis package handling

### DIFF
--- a/.github/actions/pio-build/README.md
+++ b/.github/actions/pio-build/README.md
@@ -2,12 +2,6 @@
 
 This action build thanks PIO.
 
-## Inputs
-
-### `cmsis-version`
-
-The CMSIS version to use. Default `"5.9.0"`.
-
 ## Example usage
 
 ```yaml

--- a/.github/actions/pio-build/action.yml
+++ b/.github/actions/pio-build/action.yml
@@ -1,12 +1,6 @@
 # action.yml
 name: 'PlatformIO Build'
 description: 'Compile using PlatformIO'
-inputs:
-  cmsis-version:
-    description: 'CMSIS package version to use'
-    default: '5.9.0'
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.cmsis-version }}


### PR DESCRIPTION
First goal of this PR would be to use CMSIS 6 for pio build.
After some study, the build does not use the CMSIS package provided within the core but its own one which is version 5.9.0.
So I've remove the download of the CMSIS package provided within the core as it is useless.
CMSIS 6 support could be added if pio update to cmsis 6. 

/cc @valeros 