### PR TITLE
change SerialUSB.baud() etc. to return the actual CDC line coding

### DIFF
--- a/libraries/USBDevice/inc/usbd_cdc_if.h
+++ b/libraries/USBDevice/inc/usbd_cdc_if.h
@@ -53,6 +53,12 @@ void CDC_deInit(void);
 bool CDC_connected(void);
 void CDC_enableDTR(bool enable);
 
+// getters for CDC line codings. Do not expose struct directly
+uint32_t CDC_getBaudrate(void);
+uint8_t  CDC_getStopBits(void);
+uint8_t  CDC_getParity(void);
+uint8_t  CDC_getDataBits(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/USBDevice/src/USBSerial.cpp
+++ b/libraries/USBDevice/src/USBSerial.cpp
@@ -158,22 +158,26 @@ void USBSerial::flush(void)
 
 uint32_t USBSerial::baud()
 {
-  return 115200;
+  // return (virtual) CDC line setting coding
+  return CDC_getBaudrate();
 }
 
 uint8_t USBSerial::stopbits()
 {
-  return ONE_STOP_BIT;
+  // return (virtual) CDC line setting coding
+  return CDC_getStopBits();
 }
 
 uint8_t USBSerial::paritytype()
 {
-  return NO_PARITY;
+  // return (virtual) CDC line setting coding
+  return CDC_getParity();
 }
 
 uint8_t USBSerial::numbits()
 {
-  return 8;
+  // return (virtual) CDC line setting coding
+  return CDC_getDataBits();
 }
 
 void USBSerial::dtr(bool enable)

--- a/libraries/USBDevice/src/cdc/usbd_cdc_if.c
+++ b/libraries/USBDevice/src/cdc/usbd_cdc_if.c
@@ -379,6 +379,30 @@ void CDC_enableDTR(bool enable)
   CDC_DTR_enabled = enable;
 }
 
+// getter for CDC baudrate
+uint32_t CDC_getBaudrate()
+{
+  return linecoding.bitrate;
+}
+
+// getter for CDC stop bits. Note: CDC definition identical to USBSerial.h
+uint8_t  CDC_getStopBits(void)
+{
+  return linecoding.format;
+}
+
+// getter for CDC parity. Note: CDC definition identical to USBSerial.h
+uint8_t  CDC_getParity(void)
+{
+  return linecoding.paritytype;
+}
+
+// getter for CDC data bits. Note: CDC definition identical to USBSerial.h
+uint8_t  CDC_getDataBits(void)
+{
+  return linecoding.datatype;
+}
+
 #endif /* USBD_USE_CDC */
 #endif /* USBCON */
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->
Methods `USBSerial.baud()`, `USBSerial.stopbits()`, `USBSerial.paritytype()` and `USBSerial.numbits()` already exist, but currently return dummy values. Reason is that these have no relevance on the actual USB communication. This PR returns the actual (virtual) VCP baudrate from CDC linecoding.

**Added Features**

* [x] `USBSerial::baud()` returns VCP parameter from CDC linecoding
* [x] `USBSerial.stopbits()` returns VCP parameter from CDC linecoding
* [x] `USBSerial.paritytype()` returns VCP parameter from CDC linecoding
* [x] `USBSerial::numbits()` returns VCP parameter from CDC linecoding

Notes:
- definitions for stop bits and parity are identical in CDC and `USBSerial.h`, i.e. no translation required
- PR uses getter functions to keep the change level low and avoid exposing (private) `linecoding`
- no new methods were implemented for `USBSerial`, only stubs changed

 **Motivation**

In a project I have to use a legacy Windows software, which has different operating modes using different COM port baudrates. In order to detect that operating mode, I need to detect the actual VCP baudrate on Windows side - even though it has no relevance for actual SerialUSB speed. 

Before selecting STM32 I checked, and the core does indeed provide USBSerial::baud() method. However, when I later tested it, I found it always returns 115200. On closer inspection I saw that USBSerial.c only contains stubs returning dummy values.

**Validation**

Running this code on a Nucleo-STM32L432KC prints the (virtual) SerialUSB baudrate configured on PC side via Serial2 / STLink. Also, SerialUSB output is not impaired.

[main.cpp](https://github.com/user-attachments/files/24549226/main.cpp)

**Code formatting**

all changes passed AStyle check
