### PR TITLE
fix: SoftwareSerial flush

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -409,6 +409,8 @@ void SoftwareSerial::flush()
   noInterrupts();
   _receive_buffer_head = _receive_buffer_tail = 0;
   interrupts();
+  // wait for previous transmit to complete
+  while (active_out);
 }
 
 int SoftwareSerial::peek()


### PR DESCRIPTION
This PR fixes the following **bug:** 

* [x] `SoftwareSerial.flush()` returns too early, see [issue #2904](https://github.com/stm32duino/Arduino_Core_STM32/issues/2904)

**Motivation**

I maintain a [LIN master library](https://github.com/gicking/LIN_master_portable_Arduino) for various architectures and serial interfaces. When porting to STM32 I noticed an faulty behavior of  `SoftwareSerial.flush()` (see issue report). This pull request fixes this. 

**Validation**

original:
<img width="1215" height="278" alt="Screenshot_SoftwareSerial_original" src="https://github.com/user-attachments/assets/2f31778a-10d6-448a-8b88-3c1d5c6b70ad" />

after bugfix:
<img width="1299" height="273" alt="Screenshot_SoftwareSerial_bugfix" src="https://github.com/user-attachments/assets/5234e18f-786d-4da5-92f9-8869cbd1da7e" />

See also this sketch [SoftwareSerial_flush.zip](https://github.com/user-attachments/files/24858968/SoftwareSerial_flush.zip)
