### PR TITLE
Add TinyUSB option to USB support

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -15519,6 +15519,8 @@ GenF3.menu.xusb.HSFS=High Speed in Full Speed mode
 GenF3.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 
 GenF4.menu.usb.none=None
+GenF4.menu.usb.TinyUSB=Adafruit TinyUSB
+GenF4.menu.usb.TinyUSB.build.usb_flags={build.usb_flags} -DARDUINO_ARCH_TINYUSB
 GenF4.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenF4.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 GenF4.menu.usb.CDC=CDC (no generic 'Serial')

--- a/boards.txt
+++ b/boards.txt
@@ -15480,6 +15480,8 @@ GenF0.menu.usb.HID=HID (keyboard and mouse)
 GenF0.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
 
 GenF1.menu.usb.none=None
+GenF1.menu.usb.TinyUSB=Adafruit TinyUSB
+GenF1.menu.usb.TinyUSB.build.usb_flags={build.extra_flags} -DARDUINO_ARCH_TINYUSB
 GenF1.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenF1.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 GenF1.menu.usb.CDC=CDC (no generic 'Serial')
@@ -15520,7 +15522,7 @@ GenF3.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 
 GenF4.menu.usb.none=None
 GenF4.menu.usb.TinyUSB=Adafruit TinyUSB
-GenF4.menu.usb.TinyUSB.build.usb_flags={build.usb_flags} -DARDUINO_ARCH_TINYUSB
+GenF4.menu.usb.TinyUSB.build.usb_flags={build.extra_flags} -DARDUINO_ARCH_TINYUSB
 GenF4.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenF4.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 GenF4.menu.usb.CDC=CDC (no generic 'Serial')
@@ -15555,6 +15557,8 @@ GenG0.menu.usb.HID=HID (keyboard and mouse)
 GenG0.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
 
 GenG4.menu.usb.none=None
+GenG4.menu.usb.TinyUSB=Adafruit TinyUSB
+GenG4.menu.usb.TinyUSB.build.usb_flags={build.extra_flags} -DARDUINO_ARCH_TINYUSB
 GenG4.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenG4.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 GenG4.menu.usb.CDC=CDC (no generic 'Serial')

--- a/boards.txt
+++ b/boards.txt
@@ -274,6 +274,7 @@ Nucleo_144.menu.pnum.NUCLEO_H745ZI_Q.build.variant_h=variant_NUCLEO_H745ZI_Q.h
 Nucleo_144.menu.pnum.NUCLEO_H745ZI_Q.openocd.target=stm32h7x
 Nucleo_144.menu.pnum.NUCLEO_H745ZI_Q.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H745_CM7.svd
 
+
 # NUCLEO_H753ZI board
 Nucleo_144.menu.pnum.NUCLEO_H753ZI=Nucleo H753ZI
 Nucleo_144.menu.pnum.NUCLEO_H753ZI.node=NODE_H753ZI
@@ -1385,22 +1386,6 @@ Disco.menu.pnum.B_L4S5I_IOT01A.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 Disco.menu.pnum.B_L4S5I_IOT01A.openocd.target=stm32l4x
 Disco.menu.pnum.B_L4S5I_IOT01A.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L4S5.svd
 
-# B_U585I_IOT02A board
-Disco.menu.pnum.B_U585I_IOT02A=B-U585I-IOT02A
-Disco.menu.pnum.B_U585I_IOT02A.node="NOD_U585AI,DIS_U585AI"
-Disco.menu.pnum.B_U585I_IOT02A.upload.maximum_size=2097152
-Disco.menu.pnum.B_U585I_IOT02A.upload.maximum_data_size=262144
-Disco.menu.pnum.B_U585I_IOT02A.build.mcu=cortex-m33
-Disco.menu.pnum.B_U585I_IOT02A.build.fpu=-mfpu=fpv5-sp-d16
-Disco.menu.pnum.B_U585I_IOT02A.build.float-abi=-mfloat-abi=hard
-Disco.menu.pnum.B_U585I_IOT02A.build.board=B_U585I_IOT02A
-Disco.menu.pnum.B_U585I_IOT02A.build.series=STM32U5xx
-Disco.menu.pnum.B_U585I_IOT02A.build.product_line=STM32U585xx
-Disco.menu.pnum.B_U585I_IOT02A.build.variant=STM32U5xx/U575A(G-I)IxQ_U585AIIxQ
-Disco.menu.pnum.B_U585I_IOT02A.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-Disco.menu.pnum.B_U585I_IOT02A.openocd.target=stm32u5x
-Disco.menu.pnum.B_U585I_IOT02A.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32U5xx/STM32U585.svd
-
 # STDES_MB2095 board
 Disco.menu.pnum.STDES_MB2095=STDES-MB2095
 Disco.menu.pnum.STDES_MB2095.node="No_mass_storage_for_this_board_Use_STLink_upload_method"
@@ -1416,6 +1401,22 @@ Disco.menu.pnum.STDES_MB2095.build.variant=STM32U3xx/U375V(E-G)IxQ_U385VGIxQ
 Disco.menu.pnum.STDES_MB2095.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 Disco.menu.pnum.STDES_MB2095.openocd.target=stm32u3x
 Disco.menu.pnum.STDES_MB2095.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32U3xx/STM32U385.svd
+
+# B_U585I_IOT02A board
+Disco.menu.pnum.B_U585I_IOT02A=B-U585I-IOT02A
+Disco.menu.pnum.B_U585I_IOT02A.node="NOD_U585AI,DIS_U585AI"
+Disco.menu.pnum.B_U585I_IOT02A.upload.maximum_size=2097152
+Disco.menu.pnum.B_U585I_IOT02A.upload.maximum_data_size=262144
+Disco.menu.pnum.B_U585I_IOT02A.build.mcu=cortex-m33
+Disco.menu.pnum.B_U585I_IOT02A.build.fpu=-mfpu=fpv5-sp-d16
+Disco.menu.pnum.B_U585I_IOT02A.build.float-abi=-mfloat-abi=hard
+Disco.menu.pnum.B_U585I_IOT02A.build.board=B_U585I_IOT02A
+Disco.menu.pnum.B_U585I_IOT02A.build.series=STM32U5xx
+Disco.menu.pnum.B_U585I_IOT02A.build.product_line=STM32U585xx
+Disco.menu.pnum.B_U585I_IOT02A.build.variant=STM32U5xx/U575A(G-I)IxQ_U585AIIxQ
+Disco.menu.pnum.B_U585I_IOT02A.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+Disco.menu.pnum.B_U585I_IOT02A.openocd.target=stm32u5x
+Disco.menu.pnum.B_U585I_IOT02A.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32U5xx/STM32U585.svd
 
 # STM32C0116-DK board
 Disco.menu.pnum.STM32C0116_DK=STM32C0116-DK
@@ -1545,7 +1546,7 @@ Disco.menu.pnum.DISCO_F413ZH.openocd.target=stm32f4x
 Disco.menu.pnum.DISCO_F413ZH.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F413.svd
 
 # DISCO_F429ZI board
-Disco.menu.pnum.DISCO_F429ZI=STM32F429ZI-DISCO
+Disco.menu.pnum.DISCO_F429ZI= STM32F429ZI-DISCO
 Disco.menu.pnum.DISCO_F429ZI.node=DIS_F429ZI
 Disco.menu.pnum.DISCO_F429ZI.upload.maximum_size=2097152
 Disco.menu.pnum.DISCO_F429ZI.upload.maximum_data_size=196608
@@ -1857,15 +1858,6 @@ GenC0.menu.pnum.GENERIC_C011F4PX.build.product_line=STM32C011xx
 GenC0.menu.pnum.GENERIC_C011F4PX.build.variant=STM32C0xx/C011D6Y_C011F(4-6)(P-U)
 GenC0.menu.pnum.GENERIC_C011F4PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32C0xx/STM32C011.svd
 
-# Generic C011F4Ux
-GenC0.menu.pnum.GENERIC_C011F4UX=Generic C011F4Ux
-GenC0.menu.pnum.GENERIC_C011F4UX.upload.maximum_size=16384
-GenC0.menu.pnum.GENERIC_C011F4UX.upload.maximum_data_size=6144
-GenC0.menu.pnum.GENERIC_C011F4UX.build.board=GENERIC_C011F4UX
-GenC0.menu.pnum.GENERIC_C011F4UX.build.product_line=STM32C011xx
-GenC0.menu.pnum.GENERIC_C011F4UX.build.variant=STM32C0xx/C011D6Y_C011F(4-6)(P-U)
-GenC0.menu.pnum.GENERIC_C011F4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32C0xx/STM32C011.svd
-
 # Generic C011F6Px
 GenC0.menu.pnum.GENERIC_C011F6PX=Generic C011F6Px
 GenC0.menu.pnum.GENERIC_C011F6PX.upload.maximum_size=32768
@@ -1874,6 +1866,15 @@ GenC0.menu.pnum.GENERIC_C011F6PX.build.board=GENERIC_C011F6PX
 GenC0.menu.pnum.GENERIC_C011F6PX.build.product_line=STM32C011xx
 GenC0.menu.pnum.GENERIC_C011F6PX.build.variant=STM32C0xx/C011D6Y_C011F(4-6)(P-U)
 GenC0.menu.pnum.GENERIC_C011F6PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32C0xx/STM32C011.svd
+
+# Generic C011F4Ux
+GenC0.menu.pnum.GENERIC_C011F4UX=Generic C011F4Ux
+GenC0.menu.pnum.GENERIC_C011F4UX.upload.maximum_size=16384
+GenC0.menu.pnum.GENERIC_C011F4UX.upload.maximum_data_size=6144
+GenC0.menu.pnum.GENERIC_C011F4UX.build.board=GENERIC_C011F4UX
+GenC0.menu.pnum.GENERIC_C011F4UX.build.product_line=STM32C011xx
+GenC0.menu.pnum.GENERIC_C011F4UX.build.variant=STM32C0xx/C011D6Y_C011F(4-6)(P-U)
+GenC0.menu.pnum.GENERIC_C011F4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32C0xx/STM32C011.svd
 
 # Generic C011F6Ux
 GenC0.menu.pnum.GENERIC_C011F6UX=Generic C011F6Ux
@@ -1911,15 +1912,6 @@ GenC0.menu.pnum.GENERIC_C031C4TX.build.product_line=STM32C031xx
 GenC0.menu.pnum.GENERIC_C031C4TX.build.variant=STM32C0xx/C031C(4-6)(T-U)
 GenC0.menu.pnum.GENERIC_C031C4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32C0xx/STM32C031.svd
 
-# Generic C031C4Ux
-GenC0.menu.pnum.GENERIC_C031C4UX=Generic C031C4Ux
-GenC0.menu.pnum.GENERIC_C031C4UX.upload.maximum_size=16384
-GenC0.menu.pnum.GENERIC_C031C4UX.upload.maximum_data_size=12288
-GenC0.menu.pnum.GENERIC_C031C4UX.build.board=GENERIC_C031C4UX
-GenC0.menu.pnum.GENERIC_C031C4UX.build.product_line=STM32C031xx
-GenC0.menu.pnum.GENERIC_C031C4UX.build.variant=STM32C0xx/C031C(4-6)(T-U)
-GenC0.menu.pnum.GENERIC_C031C4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32C0xx/STM32C031.svd
-
 # Generic C031C6Tx
 GenC0.menu.pnum.GENERIC_C031C6TX=Generic C031C6Tx
 GenC0.menu.pnum.GENERIC_C031C6TX.upload.maximum_size=32768
@@ -1928,6 +1920,15 @@ GenC0.menu.pnum.GENERIC_C031C6TX.build.board=GENERIC_C031C6TX
 GenC0.menu.pnum.GENERIC_C031C6TX.build.product_line=STM32C031xx
 GenC0.menu.pnum.GENERIC_C031C6TX.build.variant=STM32C0xx/C031C(4-6)(T-U)
 GenC0.menu.pnum.GENERIC_C031C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32C0xx/STM32C031.svd
+
+# Generic C031C4Ux
+GenC0.menu.pnum.GENERIC_C031C4UX=Generic C031C4Ux
+GenC0.menu.pnum.GENERIC_C031C4UX.upload.maximum_size=16384
+GenC0.menu.pnum.GENERIC_C031C4UX.upload.maximum_data_size=12288
+GenC0.menu.pnum.GENERIC_C031C4UX.build.board=GENERIC_C031C4UX
+GenC0.menu.pnum.GENERIC_C031C4UX.build.product_line=STM32C031xx
+GenC0.menu.pnum.GENERIC_C031C4UX.build.variant=STM32C0xx/C031C(4-6)(T-U)
+GenC0.menu.pnum.GENERIC_C031C4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32C0xx/STM32C031.svd
 
 # Generic C031C6Ux
 GenC0.menu.pnum.GENERIC_C031C6UX=Generic C031C6Ux
@@ -2361,15 +2362,6 @@ GenF0.menu.pnum.GENERIC_F042C4TX.build.product_line=STM32F042x6
 GenF0.menu.pnum.GENERIC_F042C4TX.build.variant=STM32F0xx/F042C(4-6)(T-U)
 GenF0.menu.pnum.GENERIC_F042C4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
 
-# Generic F042C4Ux
-GenF0.menu.pnum.GENERIC_F042C4UX=Generic F042C4Ux
-GenF0.menu.pnum.GENERIC_F042C4UX.upload.maximum_size=16384
-GenF0.menu.pnum.GENERIC_F042C4UX.upload.maximum_data_size=6144
-GenF0.menu.pnum.GENERIC_F042C4UX.build.board=GENERIC_F042C4UX
-GenF0.menu.pnum.GENERIC_F042C4UX.build.product_line=STM32F042x6
-GenF0.menu.pnum.GENERIC_F042C4UX.build.variant=STM32F0xx/F042C(4-6)(T-U)
-GenF0.menu.pnum.GENERIC_F042C4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
-
 # Generic F042C6Tx
 GenF0.menu.pnum.GENERIC_F042C6TX=Generic F042C6Tx
 GenF0.menu.pnum.GENERIC_F042C6TX.upload.maximum_size=32768
@@ -2378,6 +2370,15 @@ GenF0.menu.pnum.GENERIC_F042C6TX.build.board=GENERIC_F042C6TX
 GenF0.menu.pnum.GENERIC_F042C6TX.build.product_line=STM32F042x6
 GenF0.menu.pnum.GENERIC_F042C6TX.build.variant=STM32F0xx/F042C(4-6)(T-U)
 GenF0.menu.pnum.GENERIC_F042C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
+
+# Generic F042C4Ux
+GenF0.menu.pnum.GENERIC_F042C4UX=Generic F042C4Ux
+GenF0.menu.pnum.GENERIC_F042C4UX.upload.maximum_size=16384
+GenF0.menu.pnum.GENERIC_F042C4UX.upload.maximum_data_size=6144
+GenF0.menu.pnum.GENERIC_F042C4UX.build.board=GENERIC_F042C4UX
+GenF0.menu.pnum.GENERIC_F042C4UX.build.product_line=STM32F042x6
+GenF0.menu.pnum.GENERIC_F042C4UX.build.variant=STM32F0xx/F042C(4-6)(T-U)
+GenF0.menu.pnum.GENERIC_F042C4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
 
 # Generic F042C6Ux
 GenF0.menu.pnum.GENERIC_F042C6UX=Generic F042C6Ux
@@ -2613,15 +2614,6 @@ GenF0.menu.pnum.GENERIC_F071C8TX.build.product_line=STM32F071xB
 GenF0.menu.pnum.GENERIC_F071C8TX.build.variant=STM32F0xx/F071C8(T-U)_F071CB(T-U-Y)
 GenF0.menu.pnum.GENERIC_F071C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
-# Generic F071C8Ux
-GenF0.menu.pnum.GENERIC_F071C8UX=Generic F071C8Ux
-GenF0.menu.pnum.GENERIC_F071C8UX.upload.maximum_size=65536
-GenF0.menu.pnum.GENERIC_F071C8UX.upload.maximum_data_size=16384
-GenF0.menu.pnum.GENERIC_F071C8UX.build.board=GENERIC_F071C8UX
-GenF0.menu.pnum.GENERIC_F071C8UX.build.product_line=STM32F071xB
-GenF0.menu.pnum.GENERIC_F071C8UX.build.variant=STM32F0xx/F071C8(T-U)_F071CB(T-U-Y)
-GenF0.menu.pnum.GENERIC_F071C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
-
 # Generic F071CBTx
 GenF0.menu.pnum.GENERIC_F071CBTX=Generic F071CBTx
 GenF0.menu.pnum.GENERIC_F071CBTX.upload.maximum_size=131072
@@ -2630,6 +2622,15 @@ GenF0.menu.pnum.GENERIC_F071CBTX.build.board=GENERIC_F071CBTX
 GenF0.menu.pnum.GENERIC_F071CBTX.build.product_line=STM32F071xB
 GenF0.menu.pnum.GENERIC_F071CBTX.build.variant=STM32F0xx/F071C8(T-U)_F071CB(T-U-Y)
 GenF0.menu.pnum.GENERIC_F071CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
+
+# Generic F071C8Ux
+GenF0.menu.pnum.GENERIC_F071C8UX=Generic F071C8Ux
+GenF0.menu.pnum.GENERIC_F071C8UX.upload.maximum_size=65536
+GenF0.menu.pnum.GENERIC_F071C8UX.upload.maximum_data_size=16384
+GenF0.menu.pnum.GENERIC_F071C8UX.build.board=GENERIC_F071C8UX
+GenF0.menu.pnum.GENERIC_F071C8UX.build.product_line=STM32F071xB
+GenF0.menu.pnum.GENERIC_F071C8UX.build.variant=STM32F0xx/F071C8(T-U)_F071CB(T-U-Y)
+GenF0.menu.pnum.GENERIC_F071C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
 # Generic F071CBUx
 GenF0.menu.pnum.GENERIC_F071CBUX=Generic F071CBUx
@@ -2667,15 +2668,6 @@ GenF0.menu.pnum.GENERIC_F071V8HX.build.product_line=STM32F071xB
 GenF0.menu.pnum.GENERIC_F071V8HX.build.variant=STM32F0xx/F071V(8-B)(H-T)
 GenF0.menu.pnum.GENERIC_F071V8HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
-# Generic F071V8Tx
-GenF0.menu.pnum.GENERIC_F071V8TX=Generic F071V8Tx
-GenF0.menu.pnum.GENERIC_F071V8TX.upload.maximum_size=65536
-GenF0.menu.pnum.GENERIC_F071V8TX.upload.maximum_data_size=16384
-GenF0.menu.pnum.GENERIC_F071V8TX.build.board=GENERIC_F071V8TX
-GenF0.menu.pnum.GENERIC_F071V8TX.build.product_line=STM32F071xB
-GenF0.menu.pnum.GENERIC_F071V8TX.build.variant=STM32F0xx/F071V(8-B)(H-T)
-GenF0.menu.pnum.GENERIC_F071V8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
-
 # Generic F071VBHx
 GenF0.menu.pnum.GENERIC_F071VBHX=Generic F071VBHx
 GenF0.menu.pnum.GENERIC_F071VBHX.upload.maximum_size=131072
@@ -2684,6 +2676,15 @@ GenF0.menu.pnum.GENERIC_F071VBHX.build.board=GENERIC_F071VBHX
 GenF0.menu.pnum.GENERIC_F071VBHX.build.product_line=STM32F071xB
 GenF0.menu.pnum.GENERIC_F071VBHX.build.variant=STM32F0xx/F071V(8-B)(H-T)
 GenF0.menu.pnum.GENERIC_F071VBHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
+
+# Generic F071V8Tx
+GenF0.menu.pnum.GENERIC_F071V8TX=Generic F071V8Tx
+GenF0.menu.pnum.GENERIC_F071V8TX.upload.maximum_size=65536
+GenF0.menu.pnum.GENERIC_F071V8TX.upload.maximum_data_size=16384
+GenF0.menu.pnum.GENERIC_F071V8TX.build.board=GENERIC_F071V8TX
+GenF0.menu.pnum.GENERIC_F071V8TX.build.product_line=STM32F071xB
+GenF0.menu.pnum.GENERIC_F071V8TX.build.variant=STM32F0xx/F071V(8-B)(H-T)
+GenF0.menu.pnum.GENERIC_F071V8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
 # Generic F071VBTx
 GenF0.menu.pnum.GENERIC_F071VBTX=Generic F071VBTx
@@ -2703,15 +2704,6 @@ GenF0.menu.pnum.GENERIC_F072C8TX.build.product_line=STM32F072xB
 GenF0.menu.pnum.GENERIC_F072C8TX.build.variant=STM32F0xx/F072C8(T-U)_F072CB(T-U-Y)
 GenF0.menu.pnum.GENERIC_F072C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
 
-# Generic F072C8Ux
-GenF0.menu.pnum.GENERIC_F072C8UX=Generic F072C8Ux
-GenF0.menu.pnum.GENERIC_F072C8UX.upload.maximum_size=65536
-GenF0.menu.pnum.GENERIC_F072C8UX.upload.maximum_data_size=16384
-GenF0.menu.pnum.GENERIC_F072C8UX.build.board=GENERIC_F072C8UX
-GenF0.menu.pnum.GENERIC_F072C8UX.build.product_line=STM32F072xB
-GenF0.menu.pnum.GENERIC_F072C8UX.build.variant=STM32F0xx/F072C8(T-U)_F072CB(T-U-Y)
-GenF0.menu.pnum.GENERIC_F072C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
-
 # Generic F072CBTx
 GenF0.menu.pnum.GENERIC_F072CBTX=Generic F072CBTx
 GenF0.menu.pnum.GENERIC_F072CBTX.upload.maximum_size=131072
@@ -2720,6 +2712,15 @@ GenF0.menu.pnum.GENERIC_F072CBTX.build.board=GENERIC_F072CBTX
 GenF0.menu.pnum.GENERIC_F072CBTX.build.product_line=STM32F072xB
 GenF0.menu.pnum.GENERIC_F072CBTX.build.variant=STM32F0xx/F072C8(T-U)_F072CB(T-U-Y)
 GenF0.menu.pnum.GENERIC_F072CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
+
+# Generic F072C8Ux
+GenF0.menu.pnum.GENERIC_F072C8UX=Generic F072C8Ux
+GenF0.menu.pnum.GENERIC_F072C8UX.upload.maximum_size=65536
+GenF0.menu.pnum.GENERIC_F072C8UX.upload.maximum_data_size=16384
+GenF0.menu.pnum.GENERIC_F072C8UX.build.board=GENERIC_F072C8UX
+GenF0.menu.pnum.GENERIC_F072C8UX.build.product_line=STM32F072xB
+GenF0.menu.pnum.GENERIC_F072C8UX.build.variant=STM32F0xx/F072C8(T-U)_F072CB(T-U-Y)
+GenF0.menu.pnum.GENERIC_F072C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
 
 # Generic F072CBUx
 GenF0.menu.pnum.GENERIC_F072CBUX=Generic F072CBUx
@@ -2748,6 +2749,15 @@ GenF0.menu.pnum.GENERIC_F072R8TX.build.product_line=STM32F072xB
 GenF0.menu.pnum.GENERIC_F072R8TX.build.variant=STM32F0xx/F072R8T_F072RB(H-I-T)
 GenF0.menu.pnum.GENERIC_F072R8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
 
+# Generic F072RBTx
+GenF0.menu.pnum.GENERIC_F072RBTX=Generic F072RBTx
+GenF0.menu.pnum.GENERIC_F072RBTX.upload.maximum_size=131072
+GenF0.menu.pnum.GENERIC_F072RBTX.upload.maximum_data_size=16384
+GenF0.menu.pnum.GENERIC_F072RBTX.build.board=GENERIC_F072RBTX
+GenF0.menu.pnum.GENERIC_F072RBTX.build.product_line=STM32F072xB
+GenF0.menu.pnum.GENERIC_F072RBTX.build.variant=STM32F0xx/F072R8T_F072RB(H-I-T)
+GenF0.menu.pnum.GENERIC_F072RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
+
 # Generic F072RBHx
 GenF0.menu.pnum.GENERIC_F072RBHX=Generic F072RBHx
 GenF0.menu.pnum.GENERIC_F072RBHX.upload.maximum_size=131072
@@ -2766,15 +2776,6 @@ GenF0.menu.pnum.GENERIC_F072RBIX.build.product_line=STM32F072xB
 GenF0.menu.pnum.GENERIC_F072RBIX.build.variant=STM32F0xx/F072R8T_F072RB(H-I-T)
 GenF0.menu.pnum.GENERIC_F072RBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
 
-# Generic F072RBTx
-GenF0.menu.pnum.GENERIC_F072RBTX=Generic F072RBTx
-GenF0.menu.pnum.GENERIC_F072RBTX.upload.maximum_size=131072
-GenF0.menu.pnum.GENERIC_F072RBTX.upload.maximum_data_size=16384
-GenF0.menu.pnum.GENERIC_F072RBTX.build.board=GENERIC_F072RBTX
-GenF0.menu.pnum.GENERIC_F072RBTX.build.product_line=STM32F072xB
-GenF0.menu.pnum.GENERIC_F072RBTX.build.variant=STM32F0xx/F072R8T_F072RB(H-I-T)
-GenF0.menu.pnum.GENERIC_F072RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
-
 # Generic F072V8Hx
 GenF0.menu.pnum.GENERIC_F072V8HX=Generic F072V8Hx
 GenF0.menu.pnum.GENERIC_F072V8HX.upload.maximum_size=65536
@@ -2784,15 +2785,6 @@ GenF0.menu.pnum.GENERIC_F072V8HX.build.product_line=STM32F072xB
 GenF0.menu.pnum.GENERIC_F072V8HX.build.variant=STM32F0xx/F072V(8-B)(H-T)
 GenF0.menu.pnum.GENERIC_F072V8HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
 
-# Generic F072V8Tx
-GenF0.menu.pnum.GENERIC_F072V8TX=Generic F072V8Tx
-GenF0.menu.pnum.GENERIC_F072V8TX.upload.maximum_size=65536
-GenF0.menu.pnum.GENERIC_F072V8TX.upload.maximum_data_size=16384
-GenF0.menu.pnum.GENERIC_F072V8TX.build.board=GENERIC_F072V8TX
-GenF0.menu.pnum.GENERIC_F072V8TX.build.product_line=STM32F072xB
-GenF0.menu.pnum.GENERIC_F072V8TX.build.variant=STM32F0xx/F072V(8-B)(H-T)
-GenF0.menu.pnum.GENERIC_F072V8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
-
 # Generic F072VBHx
 GenF0.menu.pnum.GENERIC_F072VBHX=Generic F072VBHx
 GenF0.menu.pnum.GENERIC_F072VBHX.upload.maximum_size=131072
@@ -2801,6 +2793,15 @@ GenF0.menu.pnum.GENERIC_F072VBHX.build.board=GENERIC_F072VBHX
 GenF0.menu.pnum.GENERIC_F072VBHX.build.product_line=STM32F072xB
 GenF0.menu.pnum.GENERIC_F072VBHX.build.variant=STM32F0xx/F072V(8-B)(H-T)
 GenF0.menu.pnum.GENERIC_F072VBHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
+
+# Generic F072V8Tx
+GenF0.menu.pnum.GENERIC_F072V8TX=Generic F072V8Tx
+GenF0.menu.pnum.GENERIC_F072V8TX.upload.maximum_size=65536
+GenF0.menu.pnum.GENERIC_F072V8TX.upload.maximum_data_size=16384
+GenF0.menu.pnum.GENERIC_F072V8TX.build.board=GENERIC_F072V8TX
+GenF0.menu.pnum.GENERIC_F072V8TX.build.product_line=STM32F072xB
+GenF0.menu.pnum.GENERIC_F072V8TX.build.variant=STM32F0xx/F072V(8-B)(H-T)
+GenF0.menu.pnum.GENERIC_F072V8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
 
 # Generic F072VBTx
 GenF0.menu.pnum.GENERIC_F072VBTX=Generic F072VBTx
@@ -2883,15 +2884,6 @@ GenF0.menu.pnum.GENERIC_F091CBTX.build.product_line=STM32F091xC
 GenF0.menu.pnum.GENERIC_F091CBTX.build.variant=STM32F0xx/F091C(B-C)(T-U)
 GenF0.menu.pnum.GENERIC_F091CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
-# Generic F091CBUx
-GenF0.menu.pnum.GENERIC_F091CBUX=Generic F091CBUx
-GenF0.menu.pnum.GENERIC_F091CBUX.upload.maximum_size=131072
-GenF0.menu.pnum.GENERIC_F091CBUX.upload.maximum_data_size=32768
-GenF0.menu.pnum.GENERIC_F091CBUX.build.board=GENERIC_F091CBUX
-GenF0.menu.pnum.GENERIC_F091CBUX.build.product_line=STM32F091xC
-GenF0.menu.pnum.GENERIC_F091CBUX.build.variant=STM32F0xx/F091C(B-C)(T-U)
-GenF0.menu.pnum.GENERIC_F091CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
-
 # Generic F091CCTx
 GenF0.menu.pnum.GENERIC_F091CCTX=Generic F091CCTx
 GenF0.menu.pnum.GENERIC_F091CCTX.upload.maximum_size=262144
@@ -2900,6 +2892,15 @@ GenF0.menu.pnum.GENERIC_F091CCTX.build.board=GENERIC_F091CCTX
 GenF0.menu.pnum.GENERIC_F091CCTX.build.product_line=STM32F091xC
 GenF0.menu.pnum.GENERIC_F091CCTX.build.variant=STM32F0xx/F091C(B-C)(T-U)
 GenF0.menu.pnum.GENERIC_F091CCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
+
+# Generic F091CBUx
+GenF0.menu.pnum.GENERIC_F091CBUX=Generic F091CBUx
+GenF0.menu.pnum.GENERIC_F091CBUX.upload.maximum_size=131072
+GenF0.menu.pnum.GENERIC_F091CBUX.upload.maximum_data_size=32768
+GenF0.menu.pnum.GENERIC_F091CBUX.build.board=GENERIC_F091CBUX
+GenF0.menu.pnum.GENERIC_F091CBUX.build.product_line=STM32F091xC
+GenF0.menu.pnum.GENERIC_F091CBUX.build.variant=STM32F0xx/F091C(B-C)(T-U)
+GenF0.menu.pnum.GENERIC_F091CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
 # Generic F091CCUx
 GenF0.menu.pnum.GENERIC_F091CCUX=Generic F091CCUx
@@ -2919,15 +2920,6 @@ GenF0.menu.pnum.GENERIC_F091RBTX.build.product_line=STM32F091xC
 GenF0.menu.pnum.GENERIC_F091RBTX.build.variant=STM32F0xx/F091RBT_F091RC(H-T-Y)
 GenF0.menu.pnum.GENERIC_F091RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
-# Generic F091RCHx
-GenF0.menu.pnum.GENERIC_F091RCHX=Generic F091RCHx
-GenF0.menu.pnum.GENERIC_F091RCHX.upload.maximum_size=262144
-GenF0.menu.pnum.GENERIC_F091RCHX.upload.maximum_data_size=32768
-GenF0.menu.pnum.GENERIC_F091RCHX.build.board=GENERIC_F091RCHX
-GenF0.menu.pnum.GENERIC_F091RCHX.build.product_line=STM32F091xC
-GenF0.menu.pnum.GENERIC_F091RCHX.build.variant=STM32F0xx/F091RBT_F091RC(H-T-Y)
-GenF0.menu.pnum.GENERIC_F091RCHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
-
 # Generic F091RCTx
 GenF0.menu.pnum.GENERIC_F091RCTX=Generic F091RCTx
 GenF0.menu.pnum.GENERIC_F091RCTX.upload.maximum_size=262144
@@ -2936,6 +2928,15 @@ GenF0.menu.pnum.GENERIC_F091RCTX.build.board=GENERIC_F091RCTX
 GenF0.menu.pnum.GENERIC_F091RCTX.build.product_line=STM32F091xC
 GenF0.menu.pnum.GENERIC_F091RCTX.build.variant=STM32F0xx/F091RBT_F091RC(H-T-Y)
 GenF0.menu.pnum.GENERIC_F091RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
+
+# Generic F091RCHx
+GenF0.menu.pnum.GENERIC_F091RCHX=Generic F091RCHx
+GenF0.menu.pnum.GENERIC_F091RCHX.upload.maximum_size=262144
+GenF0.menu.pnum.GENERIC_F091RCHX.upload.maximum_data_size=32768
+GenF0.menu.pnum.GENERIC_F091RCHX.build.board=GENERIC_F091RCHX
+GenF0.menu.pnum.GENERIC_F091RCHX.build.product_line=STM32F091xC
+GenF0.menu.pnum.GENERIC_F091RCHX.build.variant=STM32F0xx/F091RBT_F091RC(H-T-Y)
+GenF0.menu.pnum.GENERIC_F091RCHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
 # Generic F091RCYx
 GenF0.menu.pnum.GENERIC_F091RCYX=Generic F091RCYx
@@ -2955,15 +2956,6 @@ GenF0.menu.pnum.GENERIC_F091VBTX.build.product_line=STM32F091xC
 GenF0.menu.pnum.GENERIC_F091VBTX.build.variant=STM32F0xx/F091VBT_F091VC(H-T)
 GenF0.menu.pnum.GENERIC_F091VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
-# Generic F091VCHx
-GenF0.menu.pnum.GENERIC_F091VCHX=Generic F091VCHx
-GenF0.menu.pnum.GENERIC_F091VCHX.upload.maximum_size=262144
-GenF0.menu.pnum.GENERIC_F091VCHX.upload.maximum_data_size=32768
-GenF0.menu.pnum.GENERIC_F091VCHX.build.board=GENERIC_F091VCHX
-GenF0.menu.pnum.GENERIC_F091VCHX.build.product_line=STM32F091xC
-GenF0.menu.pnum.GENERIC_F091VCHX.build.variant=STM32F0xx/F091VBT_F091VC(H-T)
-GenF0.menu.pnum.GENERIC_F091VCHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
-
 # Generic F091VCTx
 GenF0.menu.pnum.GENERIC_F091VCTX=Generic F091VCTx
 GenF0.menu.pnum.GENERIC_F091VCTX.upload.maximum_size=262144
@@ -2972,6 +2964,15 @@ GenF0.menu.pnum.GENERIC_F091VCTX.build.board=GENERIC_F091VCTX
 GenF0.menu.pnum.GENERIC_F091VCTX.build.product_line=STM32F091xC
 GenF0.menu.pnum.GENERIC_F091VCTX.build.variant=STM32F0xx/F091VBT_F091VC(H-T)
 GenF0.menu.pnum.GENERIC_F091VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
+
+# Generic F091VCHx
+GenF0.menu.pnum.GENERIC_F091VCHX=Generic F091VCHx
+GenF0.menu.pnum.GENERIC_F091VCHX.upload.maximum_size=262144
+GenF0.menu.pnum.GENERIC_F091VCHX.upload.maximum_data_size=32768
+GenF0.menu.pnum.GENERIC_F091VCHX.build.board=GENERIC_F091VCHX
+GenF0.menu.pnum.GENERIC_F091VCHX.build.product_line=STM32F091xC
+GenF0.menu.pnum.GENERIC_F091VCHX.build.variant=STM32F0xx/F091VBT_F091VC(H-T)
+GenF0.menu.pnum.GENERIC_F091VCHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
 
 # Generic F098CCTx
 GenF0.menu.pnum.GENERIC_F098CCTX=Generic F098CCTx
@@ -3090,6 +3091,35 @@ GenF1.pid.0=0x5740
 GenF1.upload.vid.0=0x1eaf
 GenF1.upload.pid.0=0x0003
 
+# BLUEPILL_F103C6 board
+GenF1.menu.pnum.BLUEPILL_F103C6=BluePill F103C6 (32K)
+GenF1.menu.pnum.BLUEPILL_F103C6.upload.maximum_size=32768
+GenF1.menu.pnum.BLUEPILL_F103C6.upload.maximum_data_size=10240
+GenF1.menu.pnum.BLUEPILL_F103C6.build.board=BLUEPILL_F103C6
+GenF1.menu.pnum.BLUEPILL_F103C6.build.product_line=STM32F103x6
+GenF1.menu.pnum.BLUEPILL_F103C6.build.variant=STM32F1xx/F103C4T_F103C6(T-U)
+GenF1.menu.pnum.BLUEPILL_F103C6.build.variant_h=variant_{build.board}.h
+GenF1.menu.pnum.BLUEPILL_F103C6.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# BLUEPILL_F103C8 board
+GenF1.menu.pnum.BLUEPILL_F103C8=BluePill F103C8
+GenF1.menu.pnum.BLUEPILL_F103C8.upload.maximum_size=65536
+GenF1.menu.pnum.BLUEPILL_F103C8.upload.maximum_data_size=20480
+GenF1.menu.pnum.BLUEPILL_F103C8.build.board=BLUEPILL_F103C8
+GenF1.menu.pnum.BLUEPILL_F103C8.build.product_line=STM32F103xB
+GenF1.menu.pnum.BLUEPILL_F103C8.build.variant=STM32F1xx/F103C8T_F103CB(T-U)
+GenF1.menu.pnum.BLUEPILL_F103C8.build.variant_h=variant_PILL_F103Cx.h
+GenF1.menu.pnum.BLUEPILL_F103C8.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+GenF1.menu.pnum.BLUEPILL_F103CB=BluePill F103CB (or C8 with 128k)
+GenF1.menu.pnum.BLUEPILL_F103CB.upload.maximum_size=131072
+GenF1.menu.pnum.BLUEPILL_F103CB.upload.maximum_data_size=20480
+GenF1.menu.pnum.BLUEPILL_F103CB.build.board=BLUEPILL_F103CB
+GenF1.menu.pnum.BLUEPILL_F103CB.build.product_line=STM32F103xB
+GenF1.menu.pnum.BLUEPILL_F103CB.build.variant_h=variant_PILL_F103Cx.h
+GenF1.menu.pnum.BLUEPILL_F103CB.build.variant=STM32F1xx/F103C8T_F103CB(T-U)
+GenF1.menu.pnum.BLUEPILL_F103CB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
 # BLACKPILL_F103C8 board
 GenF1.menu.pnum.BLACKPILL_F103C8=BlackPill F103C8
 GenF1.menu.pnum.BLACKPILL_F103C8.upload.maximum_size=65536
@@ -3108,6 +3138,56 @@ GenF1.menu.pnum.BLACKPILL_F103CB.build.product_line=STM32F103xB
 GenF1.menu.pnum.BLACKPILL_F103CB.build.variant_h=variant_PILL_F103Cx.h
 GenF1.menu.pnum.BLACKPILL_F103CB.build.variant=STM32F1xx/F103C8T_F103CB(T-U)
 GenF1.menu.pnum.BLACKPILL_F103CB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Databoard board
+GenF1.menu.pnum.DATABOARD=Databoard
+GenF1.menu.pnum.DATABOARD.upload.maximum_size=65536
+GenF1.menu.pnum.DATABOARD.upload.maximum_data_size=20480
+GenF1.menu.pnum.DATABOARD.build.board=DATABOARD
+GenF1.menu.pnum.DATABOARD.build.product_line=STM32F103xB
+GenF1.menu.pnum.DATABOARD.build.variant_h=variant_{build.board}.h
+GenF1.menu.pnum.DATABOARD.build.variant=STM32F1xx/F103C8T_F103CB(T-U)
+GenF1.menu.pnum.DATABOARD.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# VCCGND_F103ZET6_MINI board
+GenF1.menu.pnum.VCCGND_F103ZET6_MINI=VCCGND F103ZET6 Mini
+GenF1.menu.pnum.VCCGND_F103ZET6_MINI.upload.maximum_size=524288
+GenF1.menu.pnum.VCCGND_F103ZET6_MINI.upload.maximum_data_size=65536
+GenF1.menu.pnum.VCCGND_F103ZET6_MINI.build.board=VCCGND_F103ZET6_MINI
+GenF1.menu.pnum.VCCGND_F103ZET6_MINI.build.product_line=STM32F103xE
+GenF1.menu.pnum.VCCGND_F103ZET6_MINI.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
+GenF1.menu.pnum.VCCGND_F103ZET6_MINI.build.variant_h=variant_{build.board}.h
+GenF1.menu.pnum.VCCGND_F103ZET6_MINI.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# VCCGND_F103ZET6 board
+GenF1.menu.pnum.VCCGND_F103ZET6=VCCGND F103ZET6
+GenF1.menu.pnum.VCCGND_F103ZET6.upload.maximum_size=524288
+GenF1.menu.pnum.VCCGND_F103ZET6.upload.maximum_data_size=65536
+GenF1.menu.pnum.VCCGND_F103ZET6.build.board=VCCGND_F103ZET6
+GenF1.menu.pnum.VCCGND_F103ZET6.build.product_line=STM32F103xE
+GenF1.menu.pnum.VCCGND_F103ZET6.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
+GenF1.menu.pnum.VCCGND_F103ZET6.build.variant_h=variant_{build.board}.h
+GenF1.menu.pnum.VCCGND_F103ZET6.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# HY-TinySTM103TB board
+GenF1.menu.pnum.HY_TINYSTM103TB=HY-TinySTM103TB
+GenF1.menu.pnum.HY_TINYSTM103TB.upload.maximum_size=131072
+GenF1.menu.pnum.HY_TINYSTM103TB.upload.maximum_data_size=20480
+GenF1.menu.pnum.HY_TINYSTM103TB.build.board=HY_TINYSTM103TB
+GenF1.menu.pnum.HY_TINYSTM103TB.build.product_line=STM32F103xB
+GenF1.menu.pnum.HY_TINYSTM103TB.build.variant_h=variant_{build.board}.h
+GenF1.menu.pnum.HY_TINYSTM103TB.build.variant=STM32F1xx/F103T(8-B)U
+GenF1.menu.pnum.HY_TINYSTM103TB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# MAPLEMINI_F103CB board
+GenF1.menu.pnum.MAPLEMINI_F103CB=Maple Mini F103CB
+GenF1.menu.pnum.MAPLEMINI_F103CB.upload.maximum_size=131072
+GenF1.menu.pnum.MAPLEMINI_F103CB.upload.maximum_data_size=20480
+GenF1.menu.pnum.MAPLEMINI_F103CB.build.board=MAPLEMINI_F103CB
+GenF1.menu.pnum.MAPLEMINI_F103CB.build.product_line=STM32F103xB
+GenF1.menu.pnum.MAPLEMINI_F103CB.build.variant_h=variant_{build.board}.h
+GenF1.menu.pnum.MAPLEMINI_F103CB.build.variant=STM32F1xx/F103C8T_F103CB(T-U)
+GenF1.menu.pnum.MAPLEMINI_F103CB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Blue Button F103R8T board
 GenF1.menu.pnum.BLUEBUTTON_F103R8T=Blue Button F103R8T
@@ -3148,85 +3228,6 @@ GenF1.menu.pnum.BLUEBUTTON_F103RET.build.product_line=STM32F103xE
 GenF1.menu.pnum.BLUEBUTTON_F103RET.build.variant=STM32F1xx/F103R(C-D-E)T
 GenF1.menu.pnum.BLUEBUTTON_F103RET.build.variant_h=variant_{build.board}.h
 GenF1.menu.pnum.BLUEBUTTON_F103RET.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
-# BLUEPILL_F103C6 board
-GenF1.menu.pnum.BLUEPILL_F103C6=BluePill F103C6 (32K)
-GenF1.menu.pnum.BLUEPILL_F103C6.upload.maximum_size=32768
-GenF1.menu.pnum.BLUEPILL_F103C6.upload.maximum_data_size=10240
-GenF1.menu.pnum.BLUEPILL_F103C6.build.board=BLUEPILL_F103C6
-GenF1.menu.pnum.BLUEPILL_F103C6.build.product_line=STM32F103x6
-GenF1.menu.pnum.BLUEPILL_F103C6.build.variant=STM32F1xx/F103C4T_F103C6(T-U)
-GenF1.menu.pnum.BLUEPILL_F103C6.build.variant_h=variant_{build.board}.h
-GenF1.menu.pnum.BLUEPILL_F103C6.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
-# BLUEPILL_F103C8 board
-GenF1.menu.pnum.BLUEPILL_F103C8=BluePill F103C8
-GenF1.menu.pnum.BLUEPILL_F103C8.upload.maximum_size=65536
-GenF1.menu.pnum.BLUEPILL_F103C8.upload.maximum_data_size=20480
-GenF1.menu.pnum.BLUEPILL_F103C8.build.board=BLUEPILL_F103C8
-GenF1.menu.pnum.BLUEPILL_F103C8.build.product_line=STM32F103xB
-GenF1.menu.pnum.BLUEPILL_F103C8.build.variant=STM32F1xx/F103C8T_F103CB(T-U)
-GenF1.menu.pnum.BLUEPILL_F103C8.build.variant_h=variant_PILL_F103Cx.h
-GenF1.menu.pnum.BLUEPILL_F103C8.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
-GenF1.menu.pnum.BLUEPILL_F103CB=BluePill F103CB (or C8 with 128k)
-GenF1.menu.pnum.BLUEPILL_F103CB.upload.maximum_size=131072
-GenF1.menu.pnum.BLUEPILL_F103CB.upload.maximum_data_size=20480
-GenF1.menu.pnum.BLUEPILL_F103CB.build.board=BLUEPILL_F103CB
-GenF1.menu.pnum.BLUEPILL_F103CB.build.product_line=STM32F103xB
-GenF1.menu.pnum.BLUEPILL_F103CB.build.variant_h=variant_PILL_F103Cx.h
-GenF1.menu.pnum.BLUEPILL_F103CB.build.variant=STM32F1xx/F103C8T_F103CB(T-U)
-GenF1.menu.pnum.BLUEPILL_F103CB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
-# Databoard board
-GenF1.menu.pnum.DATABOARD=Databoard
-GenF1.menu.pnum.DATABOARD.upload.maximum_size=65536
-GenF1.menu.pnum.DATABOARD.upload.maximum_data_size=20480
-GenF1.menu.pnum.DATABOARD.build.board=DATABOARD
-GenF1.menu.pnum.DATABOARD.build.product_line=STM32F103xB
-GenF1.menu.pnum.DATABOARD.build.variant_h=variant_{build.board}.h
-GenF1.menu.pnum.DATABOARD.build.variant=STM32F1xx/F103C8T_F103CB(T-U)
-GenF1.menu.pnum.DATABOARD.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
-# HY-TinySTM103TB board
-GenF1.menu.pnum.HY_TINYSTM103TB=HY-TinySTM103TB
-GenF1.menu.pnum.HY_TINYSTM103TB.upload.maximum_size=131072
-GenF1.menu.pnum.HY_TINYSTM103TB.upload.maximum_data_size=20480
-GenF1.menu.pnum.HY_TINYSTM103TB.build.board=HY_TINYSTM103TB
-GenF1.menu.pnum.HY_TINYSTM103TB.build.product_line=STM32F103xB
-GenF1.menu.pnum.HY_TINYSTM103TB.build.variant_h=variant_{build.board}.h
-GenF1.menu.pnum.HY_TINYSTM103TB.build.variant=STM32F1xx/F103T(8-B)U
-GenF1.menu.pnum.HY_TINYSTM103TB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
-# MAPLEMINI_F103CB board
-GenF1.menu.pnum.MAPLEMINI_F103CB=Maple Mini F103CB
-GenF1.menu.pnum.MAPLEMINI_F103CB.upload.maximum_size=131072
-GenF1.menu.pnum.MAPLEMINI_F103CB.upload.maximum_data_size=20480
-GenF1.menu.pnum.MAPLEMINI_F103CB.build.board=MAPLEMINI_F103CB
-GenF1.menu.pnum.MAPLEMINI_F103CB.build.product_line=STM32F103xB
-GenF1.menu.pnum.MAPLEMINI_F103CB.build.variant_h=variant_{build.board}.h
-GenF1.menu.pnum.MAPLEMINI_F103CB.build.variant=STM32F1xx/F103C8T_F103CB(T-U)
-GenF1.menu.pnum.MAPLEMINI_F103CB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
-# VCCGND_F103ZET6_MINI board
-GenF1.menu.pnum.VCCGND_F103ZET6_MINI=VCCGND F103ZET6 Mini
-GenF1.menu.pnum.VCCGND_F103ZET6_MINI.upload.maximum_size=524288
-GenF1.menu.pnum.VCCGND_F103ZET6_MINI.upload.maximum_data_size=65536
-GenF1.menu.pnum.VCCGND_F103ZET6_MINI.build.board=VCCGND_F103ZET6_MINI
-GenF1.menu.pnum.VCCGND_F103ZET6_MINI.build.product_line=STM32F103xE
-GenF1.menu.pnum.VCCGND_F103ZET6_MINI.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
-GenF1.menu.pnum.VCCGND_F103ZET6_MINI.build.variant_h=variant_{build.board}.h
-GenF1.menu.pnum.VCCGND_F103ZET6_MINI.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
-# VCCGND_F103ZET6 board
-GenF1.menu.pnum.VCCGND_F103ZET6=VCCGND F103ZET6
-GenF1.menu.pnum.VCCGND_F103ZET6.upload.maximum_size=524288
-GenF1.menu.pnum.VCCGND_F103ZET6.upload.maximum_data_size=65536
-GenF1.menu.pnum.VCCGND_F103ZET6.build.board=VCCGND_F103ZET6
-GenF1.menu.pnum.VCCGND_F103ZET6.build.product_line=STM32F103xE
-GenF1.menu.pnum.VCCGND_F103ZET6.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
-GenF1.menu.pnum.VCCGND_F103ZET6.build.variant_h=variant_{build.board}.h
-GenF1.menu.pnum.VCCGND_F103ZET6.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Generic F100C4Tx
 GenF1.menu.pnum.GENERIC_F100C4TX=Generic F100C4Tx
@@ -3507,15 +3508,6 @@ GenF1.menu.pnum.GENERIC_F103R4HX.build.product_line=STM32F103x6
 GenF1.menu.pnum.GENERIC_F103R4HX.build.variant=STM32F1xx/F103R(4-6)H
 GenF1.menu.pnum.GENERIC_F103R4HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103R4Tx
-GenF1.menu.pnum.GENERIC_F103R4TX=Generic F103R4Tx
-GenF1.menu.pnum.GENERIC_F103R4TX.upload.maximum_size=16384
-GenF1.menu.pnum.GENERIC_F103R4TX.upload.maximum_data_size=6144
-GenF1.menu.pnum.GENERIC_F103R4TX.build.board=GENERIC_F103R4TX
-GenF1.menu.pnum.GENERIC_F103R4TX.build.product_line=STM32F103x6
-GenF1.menu.pnum.GENERIC_F103R4TX.build.variant=STM32F1xx/F103R(4-6)T
-GenF1.menu.pnum.GENERIC_F103R4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # Generic F103R6Hx
 GenF1.menu.pnum.GENERIC_F103R6HX=Generic F103R6Hx
 GenF1.menu.pnum.GENERIC_F103R6HX.upload.maximum_size=32768
@@ -3524,6 +3516,15 @@ GenF1.menu.pnum.GENERIC_F103R6HX.build.board=GENERIC_F103R6HX
 GenF1.menu.pnum.GENERIC_F103R6HX.build.product_line=STM32F103x6
 GenF1.menu.pnum.GENERIC_F103R6HX.build.variant=STM32F1xx/F103R(4-6)H
 GenF1.menu.pnum.GENERIC_F103R6HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Generic F103R4Tx
+GenF1.menu.pnum.GENERIC_F103R4TX=Generic F103R4Tx
+GenF1.menu.pnum.GENERIC_F103R4TX.upload.maximum_size=16384
+GenF1.menu.pnum.GENERIC_F103R4TX.upload.maximum_data_size=6144
+GenF1.menu.pnum.GENERIC_F103R4TX.build.board=GENERIC_F103R4TX
+GenF1.menu.pnum.GENERIC_F103R4TX.build.product_line=STM32F103x6
+GenF1.menu.pnum.GENERIC_F103R4TX.build.variant=STM32F1xx/F103R(4-6)T
+GenF1.menu.pnum.GENERIC_F103R4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Generic F103R6Tx
 GenF1.menu.pnum.GENERIC_F103R6TX=Generic F103R6Tx
@@ -3543,15 +3544,6 @@ GenF1.menu.pnum.GENERIC_F103R8HX.build.product_line=STM32F103xB
 GenF1.menu.pnum.GENERIC_F103R8HX.build.variant=STM32F1xx/F103R(8-B)H
 GenF1.menu.pnum.GENERIC_F103R8HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103R8Tx
-GenF1.menu.pnum.GENERIC_F103R8TX=Generic F103R8Tx
-GenF1.menu.pnum.GENERIC_F103R8TX.upload.maximum_size=65536
-GenF1.menu.pnum.GENERIC_F103R8TX.upload.maximum_data_size=20480
-GenF1.menu.pnum.GENERIC_F103R8TX.build.board=GENERIC_F103R8TX
-GenF1.menu.pnum.GENERIC_F103R8TX.build.product_line=STM32F103xB
-GenF1.menu.pnum.GENERIC_F103R8TX.build.variant=STM32F1xx/F103R(8-B)T
-GenF1.menu.pnum.GENERIC_F103R8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # Generic F103RBHx
 GenF1.menu.pnum.GENERIC_F103RBHX=Generic F103RBHx
 GenF1.menu.pnum.GENERIC_F103RBHX.upload.maximum_size=131072
@@ -3560,6 +3552,15 @@ GenF1.menu.pnum.GENERIC_F103RBHX.build.board=GENERIC_F103RBHX
 GenF1.menu.pnum.GENERIC_F103RBHX.build.product_line=STM32F103xB
 GenF1.menu.pnum.GENERIC_F103RBHX.build.variant=STM32F1xx/F103R(8-B)H
 GenF1.menu.pnum.GENERIC_F103RBHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Generic F103R8Tx
+GenF1.menu.pnum.GENERIC_F103R8TX=Generic F103R8Tx
+GenF1.menu.pnum.GENERIC_F103R8TX.upload.maximum_size=65536
+GenF1.menu.pnum.GENERIC_F103R8TX.upload.maximum_data_size=20480
+GenF1.menu.pnum.GENERIC_F103R8TX.build.board=GENERIC_F103R8TX
+GenF1.menu.pnum.GENERIC_F103R8TX.build.product_line=STM32F103xB
+GenF1.menu.pnum.GENERIC_F103R8TX.build.variant=STM32F1xx/F103R(8-B)T
+GenF1.menu.pnum.GENERIC_F103R8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Generic F103RBTx
 GenF1.menu.pnum.GENERIC_F103RBTX=Generic F103RBTx
@@ -3579,15 +3580,6 @@ GenF1.menu.pnum.GENERIC_F103RCTX.build.product_line=STM32F103xE
 GenF1.menu.pnum.GENERIC_F103RCTX.build.variant=STM32F1xx/F103R(C-D-E)T
 GenF1.menu.pnum.GENERIC_F103RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103RCYx
-GenF1.menu.pnum.GENERIC_F103RCYX=Generic F103RCYx
-GenF1.menu.pnum.GENERIC_F103RCYX.upload.maximum_size=262144
-GenF1.menu.pnum.GENERIC_F103RCYX.upload.maximum_data_size=49152
-GenF1.menu.pnum.GENERIC_F103RCYX.build.board=GENERIC_F103RCYX
-GenF1.menu.pnum.GENERIC_F103RCYX.build.product_line=STM32F103xE
-GenF1.menu.pnum.GENERIC_F103RCYX.build.variant=STM32F1xx/F103R(C-D-E)Y
-GenF1.menu.pnum.GENERIC_F103RCYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # Generic F103RDTx
 GenF1.menu.pnum.GENERIC_F103RDTX=Generic F103RDTx
 GenF1.menu.pnum.GENERIC_F103RDTX.upload.maximum_size=393216
@@ -3597,15 +3589,6 @@ GenF1.menu.pnum.GENERIC_F103RDTX.build.product_line=STM32F103xE
 GenF1.menu.pnum.GENERIC_F103RDTX.build.variant=STM32F1xx/F103R(C-D-E)T
 GenF1.menu.pnum.GENERIC_F103RDTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103RDYx
-GenF1.menu.pnum.GENERIC_F103RDYX=Generic F103RDYx
-GenF1.menu.pnum.GENERIC_F103RDYX.upload.maximum_size=393216
-GenF1.menu.pnum.GENERIC_F103RDYX.upload.maximum_data_size=65536
-GenF1.menu.pnum.GENERIC_F103RDYX.build.board=GENERIC_F103RDYX
-GenF1.menu.pnum.GENERIC_F103RDYX.build.product_line=STM32F103xE
-GenF1.menu.pnum.GENERIC_F103RDYX.build.variant=STM32F1xx/F103R(C-D-E)Y
-GenF1.menu.pnum.GENERIC_F103RDYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # Generic F103RETx
 GenF1.menu.pnum.GENERIC_F103RETX=Generic F103RETx
 GenF1.menu.pnum.GENERIC_F103RETX.upload.maximum_size=524288
@@ -3614,6 +3597,24 @@ GenF1.menu.pnum.GENERIC_F103RETX.build.board=GENERIC_F103RETX
 GenF1.menu.pnum.GENERIC_F103RETX.build.product_line=STM32F103xE
 GenF1.menu.pnum.GENERIC_F103RETX.build.variant=STM32F1xx/F103R(C-D-E)T
 GenF1.menu.pnum.GENERIC_F103RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Generic F103RCYx
+GenF1.menu.pnum.GENERIC_F103RCYX=Generic F103RCYx
+GenF1.menu.pnum.GENERIC_F103RCYX.upload.maximum_size=262144
+GenF1.menu.pnum.GENERIC_F103RCYX.upload.maximum_data_size=49152
+GenF1.menu.pnum.GENERIC_F103RCYX.build.board=GENERIC_F103RCYX
+GenF1.menu.pnum.GENERIC_F103RCYX.build.product_line=STM32F103xE
+GenF1.menu.pnum.GENERIC_F103RCYX.build.variant=STM32F1xx/F103R(C-D-E)Y
+GenF1.menu.pnum.GENERIC_F103RCYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Generic F103RDYx
+GenF1.menu.pnum.GENERIC_F103RDYX=Generic F103RDYx
+GenF1.menu.pnum.GENERIC_F103RDYX.upload.maximum_size=393216
+GenF1.menu.pnum.GENERIC_F103RDYX.upload.maximum_data_size=65536
+GenF1.menu.pnum.GENERIC_F103RDYX.build.board=GENERIC_F103RDYX
+GenF1.menu.pnum.GENERIC_F103RDYX.build.product_line=STM32F103xE
+GenF1.menu.pnum.GENERIC_F103RDYX.build.variant=STM32F1xx/F103R(C-D-E)Y
+GenF1.menu.pnum.GENERIC_F103RDYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Generic F103REYx
 GenF1.menu.pnum.GENERIC_F103REYX=Generic F103REYx
@@ -3687,15 +3688,6 @@ GenF1.menu.pnum.GENERIC_F103V8HX.build.product_line=STM32F103xB
 GenF1.menu.pnum.GENERIC_F103V8HX.build.variant=STM32F1xx/F103V8(H-T)_F103VB(H-I-T)
 GenF1.menu.pnum.GENERIC_F103V8HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103V8Tx
-GenF1.menu.pnum.GENERIC_F103V8TX=Generic F103V8Tx
-GenF1.menu.pnum.GENERIC_F103V8TX.upload.maximum_size=65536
-GenF1.menu.pnum.GENERIC_F103V8TX.upload.maximum_data_size=20480
-GenF1.menu.pnum.GENERIC_F103V8TX.build.board=GENERIC_F103V8TX
-GenF1.menu.pnum.GENERIC_F103V8TX.build.product_line=STM32F103xB
-GenF1.menu.pnum.GENERIC_F103V8TX.build.variant=STM32F1xx/F103V8(H-T)_F103VB(H-I-T)
-GenF1.menu.pnum.GENERIC_F103V8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # Generic F103VBHx
 GenF1.menu.pnum.GENERIC_F103VBHX=Generic F103VBHx
 GenF1.menu.pnum.GENERIC_F103VBHX.upload.maximum_size=131072
@@ -3705,14 +3697,14 @@ GenF1.menu.pnum.GENERIC_F103VBHX.build.product_line=STM32F103xB
 GenF1.menu.pnum.GENERIC_F103VBHX.build.variant=STM32F1xx/F103V8(H-T)_F103VB(H-I-T)
 GenF1.menu.pnum.GENERIC_F103VBHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103VBIx
-GenF1.menu.pnum.GENERIC_F103VBIX=Generic F103VBIx
-GenF1.menu.pnum.GENERIC_F103VBIX.upload.maximum_size=131072
-GenF1.menu.pnum.GENERIC_F103VBIX.upload.maximum_data_size=20480
-GenF1.menu.pnum.GENERIC_F103VBIX.build.board=GENERIC_F103VBIX
-GenF1.menu.pnum.GENERIC_F103VBIX.build.product_line=STM32F103xB
-GenF1.menu.pnum.GENERIC_F103VBIX.build.variant=STM32F1xx/F103V8(H-T)_F103VB(H-I-T)
-GenF1.menu.pnum.GENERIC_F103VBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+# Generic F103V8Tx
+GenF1.menu.pnum.GENERIC_F103V8TX=Generic F103V8Tx
+GenF1.menu.pnum.GENERIC_F103V8TX.upload.maximum_size=65536
+GenF1.menu.pnum.GENERIC_F103V8TX.upload.maximum_data_size=20480
+GenF1.menu.pnum.GENERIC_F103V8TX.build.board=GENERIC_F103V8TX
+GenF1.menu.pnum.GENERIC_F103V8TX.build.product_line=STM32F103xB
+GenF1.menu.pnum.GENERIC_F103V8TX.build.variant=STM32F1xx/F103V8(H-T)_F103VB(H-I-T)
+GenF1.menu.pnum.GENERIC_F103V8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Generic F103VBTx
 GenF1.menu.pnum.GENERIC_F103VBTX=Generic F103VBTx
@@ -3723,6 +3715,15 @@ GenF1.menu.pnum.GENERIC_F103VBTX.build.product_line=STM32F103xB
 GenF1.menu.pnum.GENERIC_F103VBTX.build.variant=STM32F1xx/F103V8(H-T)_F103VB(H-I-T)
 GenF1.menu.pnum.GENERIC_F103VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
+# Generic F103VBIx
+GenF1.menu.pnum.GENERIC_F103VBIX=Generic F103VBIx
+GenF1.menu.pnum.GENERIC_F103VBIX.upload.maximum_size=131072
+GenF1.menu.pnum.GENERIC_F103VBIX.upload.maximum_data_size=20480
+GenF1.menu.pnum.GENERIC_F103VBIX.build.board=GENERIC_F103VBIX
+GenF1.menu.pnum.GENERIC_F103VBIX.build.product_line=STM32F103xB
+GenF1.menu.pnum.GENERIC_F103VBIX.build.variant=STM32F1xx/F103V8(H-T)_F103VB(H-I-T)
+GenF1.menu.pnum.GENERIC_F103VBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
 # Generic F103VCHx
 GenF1.menu.pnum.GENERIC_F103VCHX=Generic F103VCHx
 GenF1.menu.pnum.GENERIC_F103VCHX.upload.maximum_size=262144
@@ -3731,15 +3732,6 @@ GenF1.menu.pnum.GENERIC_F103VCHX.build.board=GENERIC_F103VCHX
 GenF1.menu.pnum.GENERIC_F103VCHX.build.product_line=STM32F103xE
 GenF1.menu.pnum.GENERIC_F103VCHX.build.variant=STM32F1xx/F103V(C-D-E)(H-T)
 GenF1.menu.pnum.GENERIC_F103VCHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
-# Generic F103VCTx
-GenF1.menu.pnum.GENERIC_F103VCTX=Generic F103VCTx
-GenF1.menu.pnum.GENERIC_F103VCTX.upload.maximum_size=262144
-GenF1.menu.pnum.GENERIC_F103VCTX.upload.maximum_data_size=49152
-GenF1.menu.pnum.GENERIC_F103VCTX.build.board=GENERIC_F103VCTX
-GenF1.menu.pnum.GENERIC_F103VCTX.build.product_line=STM32F103xE
-GenF1.menu.pnum.GENERIC_F103VCTX.build.variant=STM32F1xx/F103V(C-D-E)(H-T)
-GenF1.menu.pnum.GENERIC_F103VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Generic F103VDHx
 GenF1.menu.pnum.GENERIC_F103VDHX=Generic F103VDHx
@@ -3750,15 +3742,6 @@ GenF1.menu.pnum.GENERIC_F103VDHX.build.product_line=STM32F103xE
 GenF1.menu.pnum.GENERIC_F103VDHX.build.variant=STM32F1xx/F103V(C-D-E)(H-T)
 GenF1.menu.pnum.GENERIC_F103VDHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103VDTx
-GenF1.menu.pnum.GENERIC_F103VDTX=Generic F103VDTx
-GenF1.menu.pnum.GENERIC_F103VDTX.upload.maximum_size=393216
-GenF1.menu.pnum.GENERIC_F103VDTX.upload.maximum_data_size=65536
-GenF1.menu.pnum.GENERIC_F103VDTX.build.board=GENERIC_F103VDTX
-GenF1.menu.pnum.GENERIC_F103VDTX.build.product_line=STM32F103xE
-GenF1.menu.pnum.GENERIC_F103VDTX.build.variant=STM32F1xx/F103V(C-D-E)(H-T)
-GenF1.menu.pnum.GENERIC_F103VDTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # Generic F103VEHx
 GenF1.menu.pnum.GENERIC_F103VEHX=Generic F103VEHx
 GenF1.menu.pnum.GENERIC_F103VEHX.upload.maximum_size=524288
@@ -3767,6 +3750,24 @@ GenF1.menu.pnum.GENERIC_F103VEHX.build.board=GENERIC_F103VEHX
 GenF1.menu.pnum.GENERIC_F103VEHX.build.product_line=STM32F103xE
 GenF1.menu.pnum.GENERIC_F103VEHX.build.variant=STM32F1xx/F103V(C-D-E)(H-T)
 GenF1.menu.pnum.GENERIC_F103VEHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Generic F103VCTx
+GenF1.menu.pnum.GENERIC_F103VCTX=Generic F103VCTx
+GenF1.menu.pnum.GENERIC_F103VCTX.upload.maximum_size=262144
+GenF1.menu.pnum.GENERIC_F103VCTX.upload.maximum_data_size=49152
+GenF1.menu.pnum.GENERIC_F103VCTX.build.board=GENERIC_F103VCTX
+GenF1.menu.pnum.GENERIC_F103VCTX.build.product_line=STM32F103xE
+GenF1.menu.pnum.GENERIC_F103VCTX.build.variant=STM32F1xx/F103V(C-D-E)(H-T)
+GenF1.menu.pnum.GENERIC_F103VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Generic F103VDTx
+GenF1.menu.pnum.GENERIC_F103VDTX=Generic F103VDTx
+GenF1.menu.pnum.GENERIC_F103VDTX.upload.maximum_size=393216
+GenF1.menu.pnum.GENERIC_F103VDTX.upload.maximum_data_size=65536
+GenF1.menu.pnum.GENERIC_F103VDTX.build.board=GENERIC_F103VDTX
+GenF1.menu.pnum.GENERIC_F103VDTX.build.product_line=STM32F103xE
+GenF1.menu.pnum.GENERIC_F103VDTX.build.variant=STM32F1xx/F103V(C-D-E)(H-T)
+GenF1.menu.pnum.GENERIC_F103VDTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Generic F103VETx
 GenF1.menu.pnum.GENERIC_F103VETX=Generic F103VETx
@@ -3804,15 +3805,6 @@ GenF1.menu.pnum.GENERIC_F103ZCHX.build.product_line=STM32F103xE
 GenF1.menu.pnum.GENERIC_F103ZCHX.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
 GenF1.menu.pnum.GENERIC_F103ZCHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103ZCTx
-GenF1.menu.pnum.GENERIC_F103ZCTX=Generic F103ZCTx
-GenF1.menu.pnum.GENERIC_F103ZCTX.upload.maximum_size=262144
-GenF1.menu.pnum.GENERIC_F103ZCTX.upload.maximum_data_size=49152
-GenF1.menu.pnum.GENERIC_F103ZCTX.build.board=GENERIC_F103ZCTX
-GenF1.menu.pnum.GENERIC_F103ZCTX.build.product_line=STM32F103xE
-GenF1.menu.pnum.GENERIC_F103ZCTX.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
-GenF1.menu.pnum.GENERIC_F103ZCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # Generic F103ZDHx
 GenF1.menu.pnum.GENERIC_F103ZDHX=Generic F103ZDHx
 GenF1.menu.pnum.GENERIC_F103ZDHX.upload.maximum_size=393216
@@ -3822,15 +3814,6 @@ GenF1.menu.pnum.GENERIC_F103ZDHX.build.product_line=STM32F103xE
 GenF1.menu.pnum.GENERIC_F103ZDHX.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
 GenF1.menu.pnum.GENERIC_F103ZDHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103ZDTx
-GenF1.menu.pnum.GENERIC_F103ZDTX=Generic F103ZDTx
-GenF1.menu.pnum.GENERIC_F103ZDTX.upload.maximum_size=393216
-GenF1.menu.pnum.GENERIC_F103ZDTX.upload.maximum_data_size=65536
-GenF1.menu.pnum.GENERIC_F103ZDTX.build.board=GENERIC_F103ZDTX
-GenF1.menu.pnum.GENERIC_F103ZDTX.build.product_line=STM32F103xE
-GenF1.menu.pnum.GENERIC_F103ZDTX.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
-GenF1.menu.pnum.GENERIC_F103ZDTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # Generic F103ZEHx
 GenF1.menu.pnum.GENERIC_F103ZEHX=Generic F103ZEHx
 GenF1.menu.pnum.GENERIC_F103ZEHX.upload.maximum_size=524288
@@ -3839,6 +3822,24 @@ GenF1.menu.pnum.GENERIC_F103ZEHX.build.board=GENERIC_F103ZEHX
 GenF1.menu.pnum.GENERIC_F103ZEHX.build.product_line=STM32F103xE
 GenF1.menu.pnum.GENERIC_F103ZEHX.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
 GenF1.menu.pnum.GENERIC_F103ZEHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Generic F103ZCTx
+GenF1.menu.pnum.GENERIC_F103ZCTX=Generic F103ZCTx
+GenF1.menu.pnum.GENERIC_F103ZCTX.upload.maximum_size=262144
+GenF1.menu.pnum.GENERIC_F103ZCTX.upload.maximum_data_size=49152
+GenF1.menu.pnum.GENERIC_F103ZCTX.build.board=GENERIC_F103ZCTX
+GenF1.menu.pnum.GENERIC_F103ZCTX.build.product_line=STM32F103xE
+GenF1.menu.pnum.GENERIC_F103ZCTX.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
+GenF1.menu.pnum.GENERIC_F103ZCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Generic F103ZDTx
+GenF1.menu.pnum.GENERIC_F103ZDTX=Generic F103ZDTx
+GenF1.menu.pnum.GENERIC_F103ZDTX.upload.maximum_size=393216
+GenF1.menu.pnum.GENERIC_F103ZDTX.upload.maximum_data_size=65536
+GenF1.menu.pnum.GENERIC_F103ZDTX.build.board=GENERIC_F103ZDTX
+GenF1.menu.pnum.GENERIC_F103ZDTX.build.product_line=STM32F103xE
+GenF1.menu.pnum.GENERIC_F103ZDTX.build.variant=STM32F1xx/F103Z(C-D-E)(H-T)
+GenF1.menu.pnum.GENERIC_F103ZDTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Generic F103ZETx
 GenF1.menu.pnum.GENERIC_F103ZETX=Generic F103ZETx
@@ -3858,15 +3859,6 @@ GenF1.menu.pnum.GENERIC_F103ZFHX.build.product_line=STM32F103xG
 GenF1.menu.pnum.GENERIC_F103ZFHX.build.variant=STM32F1xx/F103Z(F-G)(H-T)
 GenF1.menu.pnum.GENERIC_F103ZFHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
-# Generic F103ZFTx
-GenF1.menu.pnum.GENERIC_F103ZFTX=Generic F103ZFTx
-GenF1.menu.pnum.GENERIC_F103ZFTX.upload.maximum_size=786432
-GenF1.menu.pnum.GENERIC_F103ZFTX.upload.maximum_data_size=98304
-GenF1.menu.pnum.GENERIC_F103ZFTX.build.board=GENERIC_F103ZFTX
-GenF1.menu.pnum.GENERIC_F103ZFTX.build.product_line=STM32F103xG
-GenF1.menu.pnum.GENERIC_F103ZFTX.build.variant=STM32F1xx/F103Z(F-G)(H-T)
-GenF1.menu.pnum.GENERIC_F103ZFTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # Generic F103ZGHx
 GenF1.menu.pnum.GENERIC_F103ZGHX=Generic F103ZGHx
 GenF1.menu.pnum.GENERIC_F103ZGHX.upload.maximum_size=1048576
@@ -3875,6 +3867,15 @@ GenF1.menu.pnum.GENERIC_F103ZGHX.build.board=GENERIC_F103ZGHX
 GenF1.menu.pnum.GENERIC_F103ZGHX.build.product_line=STM32F103xG
 GenF1.menu.pnum.GENERIC_F103ZGHX.build.variant=STM32F1xx/F103Z(F-G)(H-T)
 GenF1.menu.pnum.GENERIC_F103ZGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
+
+# Generic F103ZFTx
+GenF1.menu.pnum.GENERIC_F103ZFTX=Generic F103ZFTx
+GenF1.menu.pnum.GENERIC_F103ZFTX.upload.maximum_size=786432
+GenF1.menu.pnum.GENERIC_F103ZFTX.upload.maximum_data_size=98304
+GenF1.menu.pnum.GENERIC_F103ZFTX.build.board=GENERIC_F103ZFTX
+GenF1.menu.pnum.GENERIC_F103ZFTX.build.product_line=STM32F103xG
+GenF1.menu.pnum.GENERIC_F103ZFTX.build.variant=STM32F1xx/F103Z(F-G)(H-T)
+GenF1.menu.pnum.GENERIC_F103ZFTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Generic F103ZGTx
 GenF1.menu.pnum.GENERIC_F103ZGTX=Generic F103ZGTx
@@ -3983,15 +3984,6 @@ GenF2.menu.pnum.GENERIC_F205RETX.build.product_line=STM32F205xx
 GenF2.menu.pnum.GENERIC_F205RETX.build.variant=STM32F2xx/F205RE(T-Y)_F205R(B-C-F)T_F205RG(E-T-Y)_F215R(E-G)T
 GenF2.menu.pnum.GENERIC_F205RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F205.svd
 
-# Generic F205REYx
-GenF2.menu.pnum.GENERIC_F205REYX=Generic F205REYx
-GenF2.menu.pnum.GENERIC_F205REYX.upload.maximum_size=524288
-GenF2.menu.pnum.GENERIC_F205REYX.upload.maximum_data_size=131072
-GenF2.menu.pnum.GENERIC_F205REYX.build.board=GENERIC_F205REYX
-GenF2.menu.pnum.GENERIC_F205REYX.build.product_line=STM32F205xx
-GenF2.menu.pnum.GENERIC_F205REYX.build.variant=STM32F2xx/F205RE(T-Y)_F205R(B-C-F)T_F205RG(E-T-Y)_F215R(E-G)T
-GenF2.menu.pnum.GENERIC_F205REYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F205.svd
-
 # Generic F205RFTx
 GenF2.menu.pnum.GENERIC_F205RFTX=Generic F205RFTx
 GenF2.menu.pnum.GENERIC_F205RFTX.upload.maximum_size=786432
@@ -4000,15 +3992,6 @@ GenF2.menu.pnum.GENERIC_F205RFTX.build.board=GENERIC_F205RFTX
 GenF2.menu.pnum.GENERIC_F205RFTX.build.product_line=STM32F205xx
 GenF2.menu.pnum.GENERIC_F205RFTX.build.variant=STM32F2xx/F205RE(T-Y)_F205R(B-C-F)T_F205RG(E-T-Y)_F215R(E-G)T
 GenF2.menu.pnum.GENERIC_F205RFTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F205.svd
-
-# Generic F205RGEx
-GenF2.menu.pnum.GENERIC_F205RGEX=Generic F205RGEx
-GenF2.menu.pnum.GENERIC_F205RGEX.upload.maximum_size=1048576
-GenF2.menu.pnum.GENERIC_F205RGEX.upload.maximum_data_size=131072
-GenF2.menu.pnum.GENERIC_F205RGEX.build.board=GENERIC_F205RGEX
-GenF2.menu.pnum.GENERIC_F205RGEX.build.product_line=STM32F205xx
-GenF2.menu.pnum.GENERIC_F205RGEX.build.variant=STM32F2xx/F205RE(T-Y)_F205R(B-C-F)T_F205RG(E-T-Y)_F215R(E-G)T
-GenF2.menu.pnum.GENERIC_F205RGEX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F205.svd
 
 # Generic F205RGTx
 GenF2.menu.pnum.GENERIC_F205RGTX=Generic F205RGTx
@@ -4019,6 +4002,15 @@ GenF2.menu.pnum.GENERIC_F205RGTX.build.product_line=STM32F205xx
 GenF2.menu.pnum.GENERIC_F205RGTX.build.variant=STM32F2xx/F205RE(T-Y)_F205R(B-C-F)T_F205RG(E-T-Y)_F215R(E-G)T
 GenF2.menu.pnum.GENERIC_F205RGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F205.svd
 
+# Generic F205REYx
+GenF2.menu.pnum.GENERIC_F205REYX=Generic F205REYx
+GenF2.menu.pnum.GENERIC_F205REYX.upload.maximum_size=524288
+GenF2.menu.pnum.GENERIC_F205REYX.upload.maximum_data_size=131072
+GenF2.menu.pnum.GENERIC_F205REYX.build.board=GENERIC_F205REYX
+GenF2.menu.pnum.GENERIC_F205REYX.build.product_line=STM32F205xx
+GenF2.menu.pnum.GENERIC_F205REYX.build.variant=STM32F2xx/F205RE(T-Y)_F205R(B-C-F)T_F205RG(E-T-Y)_F215R(E-G)T
+GenF2.menu.pnum.GENERIC_F205REYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F205.svd
+
 # Generic F205RGYx
 GenF2.menu.pnum.GENERIC_F205RGYX=Generic F205RGYx
 GenF2.menu.pnum.GENERIC_F205RGYX.upload.maximum_size=1048576
@@ -4027,6 +4019,15 @@ GenF2.menu.pnum.GENERIC_F205RGYX.build.board=GENERIC_F205RGYX
 GenF2.menu.pnum.GENERIC_F205RGYX.build.product_line=STM32F205xx
 GenF2.menu.pnum.GENERIC_F205RGYX.build.variant=STM32F2xx/F205RE(T-Y)_F205R(B-C-F)T_F205RG(E-T-Y)_F215R(E-G)T
 GenF2.menu.pnum.GENERIC_F205RGYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F205.svd
+
+# Generic F205RGEx
+GenF2.menu.pnum.GENERIC_F205RGEX=Generic F205RGEx
+GenF2.menu.pnum.GENERIC_F205RGEX.upload.maximum_size=1048576
+GenF2.menu.pnum.GENERIC_F205RGEX.upload.maximum_data_size=131072
+GenF2.menu.pnum.GENERIC_F205RGEX.build.board=GENERIC_F205RGEX
+GenF2.menu.pnum.GENERIC_F205RGEX.build.product_line=STM32F205xx
+GenF2.menu.pnum.GENERIC_F205RGEX.build.variant=STM32F2xx/F205RE(T-Y)_F205R(B-C-F)T_F205RG(E-T-Y)_F215R(E-G)T
+GenF2.menu.pnum.GENERIC_F205RGEX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F205.svd
 
 # Generic F205VBTx
 GenF2.menu.pnum.GENERIC_F205VBTX=Generic F205VBTx
@@ -4118,15 +4119,6 @@ GenF2.menu.pnum.GENERIC_F207ICHX.build.product_line=STM32F207xx
 GenF2.menu.pnum.GENERIC_F207ICHX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
 GenF2.menu.pnum.GENERIC_F207ICHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
 
-# Generic F207ICTx
-GenF2.menu.pnum.GENERIC_F207ICTX=Generic F207ICTx
-GenF2.menu.pnum.GENERIC_F207ICTX.upload.maximum_size=262144
-GenF2.menu.pnum.GENERIC_F207ICTX.upload.maximum_data_size=131072
-GenF2.menu.pnum.GENERIC_F207ICTX.build.board=GENERIC_F207ICTX
-GenF2.menu.pnum.GENERIC_F207ICTX.build.product_line=STM32F207xx
-GenF2.menu.pnum.GENERIC_F207ICTX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
-GenF2.menu.pnum.GENERIC_F207ICTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
-
 # Generic F207IEHx
 GenF2.menu.pnum.GENERIC_F207IEHX=Generic F207IEHx
 GenF2.menu.pnum.GENERIC_F207IEHX.upload.maximum_size=524288
@@ -4135,15 +4127,6 @@ GenF2.menu.pnum.GENERIC_F207IEHX.build.board=GENERIC_F207IEHX
 GenF2.menu.pnum.GENERIC_F207IEHX.build.product_line=STM32F207xx
 GenF2.menu.pnum.GENERIC_F207IEHX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
 GenF2.menu.pnum.GENERIC_F207IEHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
-
-# Generic F207IETx
-GenF2.menu.pnum.GENERIC_F207IETX=Generic F207IETx
-GenF2.menu.pnum.GENERIC_F207IETX.upload.maximum_size=524288
-GenF2.menu.pnum.GENERIC_F207IETX.upload.maximum_data_size=131072
-GenF2.menu.pnum.GENERIC_F207IETX.build.board=GENERIC_F207IETX
-GenF2.menu.pnum.GENERIC_F207IETX.build.product_line=STM32F207xx
-GenF2.menu.pnum.GENERIC_F207IETX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
-GenF2.menu.pnum.GENERIC_F207IETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
 
 # Generic F207IFHx
 GenF2.menu.pnum.GENERIC_F207IFHX=Generic F207IFHx
@@ -4154,15 +4137,6 @@ GenF2.menu.pnum.GENERIC_F207IFHX.build.product_line=STM32F207xx
 GenF2.menu.pnum.GENERIC_F207IFHX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
 GenF2.menu.pnum.GENERIC_F207IFHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
 
-# Generic F207IFTx
-GenF2.menu.pnum.GENERIC_F207IFTX=Generic F207IFTx
-GenF2.menu.pnum.GENERIC_F207IFTX.upload.maximum_size=786432
-GenF2.menu.pnum.GENERIC_F207IFTX.upload.maximum_data_size=131072
-GenF2.menu.pnum.GENERIC_F207IFTX.build.board=GENERIC_F207IFTX
-GenF2.menu.pnum.GENERIC_F207IFTX.build.product_line=STM32F207xx
-GenF2.menu.pnum.GENERIC_F207IFTX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
-GenF2.menu.pnum.GENERIC_F207IFTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
-
 # Generic F207IGHx
 GenF2.menu.pnum.GENERIC_F207IGHX=Generic F207IGHx
 GenF2.menu.pnum.GENERIC_F207IGHX.upload.maximum_size=1048576
@@ -4171,6 +4145,33 @@ GenF2.menu.pnum.GENERIC_F207IGHX.build.board=GENERIC_F207IGHX
 GenF2.menu.pnum.GENERIC_F207IGHX.build.product_line=STM32F207xx
 GenF2.menu.pnum.GENERIC_F207IGHX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
 GenF2.menu.pnum.GENERIC_F207IGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
+
+# Generic F207ICTx
+GenF2.menu.pnum.GENERIC_F207ICTX=Generic F207ICTx
+GenF2.menu.pnum.GENERIC_F207ICTX.upload.maximum_size=262144
+GenF2.menu.pnum.GENERIC_F207ICTX.upload.maximum_data_size=131072
+GenF2.menu.pnum.GENERIC_F207ICTX.build.board=GENERIC_F207ICTX
+GenF2.menu.pnum.GENERIC_F207ICTX.build.product_line=STM32F207xx
+GenF2.menu.pnum.GENERIC_F207ICTX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
+GenF2.menu.pnum.GENERIC_F207ICTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
+
+# Generic F207IETx
+GenF2.menu.pnum.GENERIC_F207IETX=Generic F207IETx
+GenF2.menu.pnum.GENERIC_F207IETX.upload.maximum_size=524288
+GenF2.menu.pnum.GENERIC_F207IETX.upload.maximum_data_size=131072
+GenF2.menu.pnum.GENERIC_F207IETX.build.board=GENERIC_F207IETX
+GenF2.menu.pnum.GENERIC_F207IETX.build.product_line=STM32F207xx
+GenF2.menu.pnum.GENERIC_F207IETX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
+GenF2.menu.pnum.GENERIC_F207IETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
+
+# Generic F207IFTx
+GenF2.menu.pnum.GENERIC_F207IFTX=Generic F207IFTx
+GenF2.menu.pnum.GENERIC_F207IFTX.upload.maximum_size=786432
+GenF2.menu.pnum.GENERIC_F207IFTX.upload.maximum_data_size=131072
+GenF2.menu.pnum.GENERIC_F207IFTX.build.board=GENERIC_F207IFTX
+GenF2.menu.pnum.GENERIC_F207IFTX.build.product_line=STM32F207xx
+GenF2.menu.pnum.GENERIC_F207IFTX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
+GenF2.menu.pnum.GENERIC_F207IFTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F207.svd
 
 # Generic F207IGTx
 GenF2.menu.pnum.GENERIC_F207IGTX=Generic F207IGTx
@@ -4316,15 +4317,6 @@ GenF2.menu.pnum.GENERIC_F217IEHX.build.product_line=STM32F217xx
 GenF2.menu.pnum.GENERIC_F217IEHX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
 GenF2.menu.pnum.GENERIC_F217IEHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F217.svd
 
-# Generic F217IETx
-GenF2.menu.pnum.GENERIC_F217IETX=Generic F217IETx
-GenF2.menu.pnum.GENERIC_F217IETX.upload.maximum_size=524288
-GenF2.menu.pnum.GENERIC_F217IETX.upload.maximum_data_size=131072
-GenF2.menu.pnum.GENERIC_F217IETX.build.board=GENERIC_F217IETX
-GenF2.menu.pnum.GENERIC_F217IETX.build.product_line=STM32F217xx
-GenF2.menu.pnum.GENERIC_F217IETX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
-GenF2.menu.pnum.GENERIC_F217IETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F217.svd
-
 # Generic F217IGHx
 GenF2.menu.pnum.GENERIC_F217IGHX=Generic F217IGHx
 GenF2.menu.pnum.GENERIC_F217IGHX.upload.maximum_size=1048576
@@ -4333,6 +4325,15 @@ GenF2.menu.pnum.GENERIC_F217IGHX.build.board=GENERIC_F217IGHX
 GenF2.menu.pnum.GENERIC_F217IGHX.build.product_line=STM32F217xx
 GenF2.menu.pnum.GENERIC_F217IGHX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
 GenF2.menu.pnum.GENERIC_F217IGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F217.svd
+
+# Generic F217IETx
+GenF2.menu.pnum.GENERIC_F217IETX=Generic F217IETx
+GenF2.menu.pnum.GENERIC_F217IETX.upload.maximum_size=524288
+GenF2.menu.pnum.GENERIC_F217IETX.upload.maximum_data_size=131072
+GenF2.menu.pnum.GENERIC_F217IETX.build.board=GENERIC_F217IETX
+GenF2.menu.pnum.GENERIC_F217IETX.build.product_line=STM32F217xx
+GenF2.menu.pnum.GENERIC_F217IETX.build.variant=STM32F2xx/F207I(C-E-F-G)(H-T)_F217I(E-G)(H-T)
+GenF2.menu.pnum.GENERIC_F217IETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F2xx/STM32F217.svd
 
 # Generic F217IGTx
 GenF2.menu.pnum.GENERIC_F217IGTX=Generic F217IGTx
@@ -4433,16 +4434,6 @@ GenF3.openocd.target=stm32f3x
 GenF3.vid.0=0x0483
 GenF3.pid.0=0x5740
 
-# OLIMEXINO_STM32F3
-GenF3.menu.pnum.OLIMEXINO_STM32F3=OLIMEXINO-STM32F3
-GenF3.menu.pnum.OLIMEXINO_STM32F3.upload.maximum_size=262144
-GenF3.menu.pnum.OLIMEXINO_STM32F3.upload.maximum_data_size=40960
-GenF3.menu.pnum.OLIMEXINO_STM32F3.build.board=OLIMEXINO_STM32F3
-GenF3.menu.pnum.OLIMEXINO_STM32F3.build.product_line=STM32F303xC
-GenF3.menu.pnum.OLIMEXINO_STM32F3.build.variant_h=variant_{build.board}.h
-GenF3.menu.pnum.OLIMEXINO_STM32F3.build.variant=STM32F3xx/F303R(B-C)T
-GenF3.menu.pnum.OLIMEXINO_STM32F3.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F3xx/STM32F303.svd
-
 # BLACKPILL_F303CC
 GenF3.menu.pnum.BLACKPILL_F303CC=RobotDyn BlackPill F303CC
 GenF3.menu.pnum.BLACKPILL_F303CC.upload.maximum_size=262144
@@ -4452,6 +4443,16 @@ GenF3.menu.pnum.BLACKPILL_F303CC.build.product_line=STM32F303xC
 GenF3.menu.pnum.BLACKPILL_F303CC.build.variant_h=variant_{build.board}.h
 GenF3.menu.pnum.BLACKPILL_F303CC.build.variant=STM32F3xx/F303C(B-C)T
 GenF3.menu.pnum.BLACKPILL_F303CC.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F3xx/STM32F303.svd
+
+# OLIMEXINO_STM32F3
+GenF3.menu.pnum.OLIMEXINO_STM32F3=OLIMEXINO-STM32F3
+GenF3.menu.pnum.OLIMEXINO_STM32F3.upload.maximum_size=262144
+GenF3.menu.pnum.OLIMEXINO_STM32F3.upload.maximum_data_size=40960
+GenF3.menu.pnum.OLIMEXINO_STM32F3.build.board=OLIMEXINO_STM32F3
+GenF3.menu.pnum.OLIMEXINO_STM32F3.build.product_line=STM32F303xC
+GenF3.menu.pnum.OLIMEXINO_STM32F3.build.variant_h=variant_{build.board}.h
+GenF3.menu.pnum.OLIMEXINO_STM32F3.build.variant=STM32F3xx/F303R(B-C)T
+GenF3.menu.pnum.OLIMEXINO_STM32F3.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F3xx/STM32F303.svd
 
 # Generic F301C6Tx
 GenF3.menu.pnum.GENERIC_F301C6TX=Generic F301C6Tx
@@ -4903,18 +4904,8 @@ GenF4.openocd.target=stm32f4x
 GenF4.vid.0=0x0483
 GenF4.pid.0=0x5740
 
-# Adafruit Feather STM32F405 board
-GenF4.menu.pnum.FEATHER_F405=Adafruit Feather STM32F405
-GenF4.menu.pnum.FEATHER_F405.upload.maximum_size=1048576
-GenF4.menu.pnum.FEATHER_F405.upload.maximum_data_size=131072
-GenF4.menu.pnum.FEATHER_F405.build.board=FEATHER_F405
-GenF4.menu.pnum.FEATHER_F405.build.product_line=STM32F405xx
-GenF4.menu.pnum.FEATHER_F405.build.variant_h=variant_{build.board}.h
-GenF4.menu.pnum.FEATHER_F405.build.variant=STM32F4xx/F405RGT_F415RGT
-GenF4.menu.pnum.FEATHER_F405.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-GenF4.menu.pnum.FEATHER_F405.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F405.svd
-
 # Black F407VE
+# https://github.com/mcauser/BLACK_F407VEZ
 GenF4.menu.pnum.BLACK_F407VE=Black F407VE
 GenF4.menu.pnum.BLACK_F407VE.upload.maximum_size=524288
 GenF4.menu.pnum.BLACK_F407VE.upload.maximum_data_size=131072
@@ -4926,6 +4917,7 @@ GenF4.menu.pnum.BLACK_F407VE.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 GenF4.menu.pnum.BLACK_F407VE.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
 
 # Black F407VG
+# https://github.com/mcauser/BLACK_F407VEZ with bigger chip
 GenF4.menu.pnum.BLACK_F407VG=Black F407VG
 GenF4.menu.pnum.BLACK_F407VG.upload.maximum_size=1048576
 GenF4.menu.pnum.BLACK_F407VG.upload.maximum_data_size=131072
@@ -4937,6 +4929,7 @@ GenF4.menu.pnum.BLACK_F407VG.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 GenF4.menu.pnum.BLACK_F407VG.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
 
 # Black F407ZE
+# https://github.com/mcauser/BLACK_F407ZE
 GenF4.menu.pnum.BLACK_F407ZE=Black F407ZE
 GenF4.menu.pnum.BLACK_F407ZE.upload.maximum_size=524288
 GenF4.menu.pnum.BLACK_F407ZE.upload.maximum_data_size=131072
@@ -4948,6 +4941,7 @@ GenF4.menu.pnum.BLACK_F407ZE.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 GenF4.menu.pnum.BLACK_F407ZE.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
 
 # Black F407ZG
+# https://github.com/mcauser/BLACK_F407ZG
 GenF4.menu.pnum.BLACK_F407ZG=Black F407ZG
 GenF4.menu.pnum.BLACK_F407ZG.upload.maximum_size=1048576
 GenF4.menu.pnum.BLACK_F407ZG.upload.maximum_data_size=131072
@@ -4957,6 +4951,38 @@ GenF4.menu.pnum.BLACK_F407ZG.build.variant_h=variant_BLACK_F407ZX.h
 GenF4.menu.pnum.BLACK_F407ZG.build.variant=STM32F4xx/F407Z(E-G)T_F417Z(E-G)T
 GenF4.menu.pnum.BLACK_F407ZG.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 GenF4.menu.pnum.BLACK_F407ZG.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
+
+# Blue F407VE mini: http://wiki.stm32duino.com/index.php?title=Vcc-gnd.com_STM32F407VET6_Mini
+GenF4.menu.pnum.BLUE_F407VE_MINI=Blue F407VE mini
+GenF4.menu.pnum.BLUE_F407VE_MINI.upload.maximum_size=524288
+GenF4.menu.pnum.BLUE_F407VE_MINI.upload.maximum_data_size=131072
+GenF4.menu.pnum.BLUE_F407VE_MINI.build.board=BLUE_F407VE_MINI
+GenF4.menu.pnum.BLUE_F407VE_MINI.build.product_line=STM32F407xx
+GenF4.menu.pnum.BLUE_F407VE_MINI.build.variant_h=variant_{build.board}.h
+GenF4.menu.pnum.BLUE_F407VE_MINI.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
+GenF4.menu.pnum.BLUE_F407VE_MINI.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+GenF4.menu.pnum.BLUE_F407VE_MINI.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
+
+# DIYMORE STM32F407VGT board
+GenF4.menu.pnum.DIYMORE_F407VGT=DIYMORE STM32F407VGT
+GenF4.menu.pnum.DIYMORE_F407VGT.upload.maximum_size=1048576
+GenF4.menu.pnum.DIYMORE_F407VGT.upload.maximum_data_size=131072
+GenF4.menu.pnum.DIYMORE_F407VGT.build.board=DIYMORE_F407VGT
+GenF4.menu.pnum.DIYMORE_F407VGT.build.product_line=STM32F407xx
+GenF4.menu.pnum.DIYMORE_F407VGT.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
+GenF4.menu.pnum.DIYMORE_F407VGT.build.variant_h=variant_{build.board}.h
+GenF4.menu.pnum.DIYMORE_F407VGT.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
+
+# FK407M1
+GenF4.menu.pnum.FK407M1=FK407M1 STM32F407VET
+GenF4.menu.pnum.FK407M1.upload.maximum_size=524288
+GenF4.menu.pnum.FK407M1.upload.maximum_data_size=131072
+GenF4.menu.pnum.FK407M1.build.board=FK407M1
+GenF4.menu.pnum.FK407M1.build.product_line=STM32F407xx
+GenF4.menu.pnum.FK407M1.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
+GenF4.menu.pnum.FK407M1.build.variant_h=variant_{build.board}.h
+GenF4.menu.pnum.FK407M1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+GenF4.menu.pnum.FK407M1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
 
 # BlackPill F401CC
 GenF4.menu.pnum.BLACKPILL_F401CC=BlackPill F401CC
@@ -4981,6 +5007,7 @@ GenF4.menu.pnum.BLACKPILL_F401CE.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 GenF4.menu.pnum.BLACKPILL_F401CE.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
 
 # BlackPill F411CE
+# https://github.com/mcauser/WEACT_F411CEU6
 GenF4.menu.pnum.BLACKPILL_F411CE=BlackPill F411CE
 GenF4.menu.pnum.BLACKPILL_F411CE.upload.maximum_size=524288
 GenF4.menu.pnum.BLACKPILL_F411CE.upload.maximum_data_size=131072
@@ -4991,18 +5018,8 @@ GenF4.menu.pnum.BLACKPILL_F411CE.build.variant_h=variant_{build.board}.h
 GenF4.menu.pnum.BLACKPILL_F411CE.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 GenF4.menu.pnum.BLACKPILL_F411CE.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F411.svd
 
-# Blue F407VE mini
-GenF4.menu.pnum.BLUE_F407VE_MINI=Blue F407VE mini
-GenF4.menu.pnum.BLUE_F407VE_MINI.upload.maximum_size=524288
-GenF4.menu.pnum.BLUE_F407VE_MINI.upload.maximum_data_size=131072
-GenF4.menu.pnum.BLUE_F407VE_MINI.build.board=BLUE_F407VE_MINI
-GenF4.menu.pnum.BLUE_F407VE_MINI.build.product_line=STM32F407xx
-GenF4.menu.pnum.BLUE_F407VE_MINI.build.variant_h=variant_{build.board}.h
-GenF4.menu.pnum.BLUE_F407VE_MINI.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
-GenF4.menu.pnum.BLUE_F407VE_MINI.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-GenF4.menu.pnum.BLUE_F407VE_MINI.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
-
 # Core board F401RCT6
+# https://stm32-base.org/boards/STM32F401RCT6-STM32F-Core-Board
 GenF4.menu.pnum.CoreBoard_F401RC=Core board F401RCT6
 GenF4.menu.pnum.CoreBoard_F401RC.upload.maximum_size=262144
 GenF4.menu.pnum.CoreBoard_F401RC.upload.maximum_data_size=65536
@@ -5013,28 +5030,19 @@ GenF4.menu.pnum.CoreBoard_F401RC.build.variant_h=variant_{build.board}.h
 GenF4.menu.pnum.CoreBoard_F401RC.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 GenF4.menu.pnum.CoreBoard_F401RC.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
 
-# DIYMORE STM32F407VGT board
-GenF4.menu.pnum.DIYMORE_F407VGT=DIYMORE STM32F407VGT
-GenF4.menu.pnum.DIYMORE_F407VGT.upload.maximum_size=1048576
-GenF4.menu.pnum.DIYMORE_F407VGT.upload.maximum_data_size=131072
-GenF4.menu.pnum.DIYMORE_F407VGT.build.board=DIYMORE_F407VGT
-GenF4.menu.pnum.DIYMORE_F407VGT.build.product_line=STM32F407xx
-GenF4.menu.pnum.DIYMORE_F407VGT.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
-GenF4.menu.pnum.DIYMORE_F407VGT.build.variant_h=variant_{build.board}.h
-GenF4.menu.pnum.DIYMORE_F407VGT.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
-
-# FK407M1
-GenF4.menu.pnum.FK407M1=FK407M1 STM32F407VET
-GenF4.menu.pnum.FK407M1.upload.maximum_size=524288
-GenF4.menu.pnum.FK407M1.upload.maximum_data_size=131072
-GenF4.menu.pnum.FK407M1.build.board=FK407M1
-GenF4.menu.pnum.FK407M1.build.product_line=STM32F407xx
-GenF4.menu.pnum.FK407M1.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
-GenF4.menu.pnum.FK407M1.build.variant_h=variant_{build.board}.h
-GenF4.menu.pnum.FK407M1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-GenF4.menu.pnum.FK407M1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
+# Adafruit Feather STM32F405 board
+GenF4.menu.pnum.FEATHER_F405=Adafruit Feather STM32F405
+GenF4.menu.pnum.FEATHER_F405.upload.maximum_size=1048576
+GenF4.menu.pnum.FEATHER_F405.upload.maximum_data_size=131072
+GenF4.menu.pnum.FEATHER_F405.build.board=FEATHER_F405
+GenF4.menu.pnum.FEATHER_F405.build.product_line=STM32F405xx
+GenF4.menu.pnum.FEATHER_F405.build.variant_h=variant_{build.board}.h
+GenF4.menu.pnum.FEATHER_F405.build.variant=STM32F4xx/F405RGT_F415RGT
+GenF4.menu.pnum.FEATHER_F405.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+GenF4.menu.pnum.FEATHER_F405.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F405.svd
 
 # ThunderPack F411xxE
+# https://github.com/jgillick/ThunderPack/tree/STM32F4
 GenF4.menu.pnum.THUNDERPACK_F411=ThunderPack v1.1+
 GenF4.menu.pnum.THUNDERPACK_F411.upload.maximum_size=524288
 GenF4.menu.pnum.THUNDERPACK_F411.upload.maximum_data_size=131072
@@ -5065,24 +5073,6 @@ GenF4.menu.pnum.GENERIC_F401CBUX.build.product_line=STM32F401xC
 GenF4.menu.pnum.GENERIC_F401CBUX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
 GenF4.menu.pnum.GENERIC_F401CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
 
-# Generic F401CBYx
-GenF4.menu.pnum.GENERIC_F401CBYX=Generic F401CBYx
-GenF4.menu.pnum.GENERIC_F401CBYX.upload.maximum_size=131072
-GenF4.menu.pnum.GENERIC_F401CBYX.upload.maximum_data_size=65536
-GenF4.menu.pnum.GENERIC_F401CBYX.build.board=GENERIC_F401CBYX
-GenF4.menu.pnum.GENERIC_F401CBYX.build.product_line=STM32F401xC
-GenF4.menu.pnum.GENERIC_F401CBYX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
-GenF4.menu.pnum.GENERIC_F401CBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
-
-# Generic F401CCFx
-GenF4.menu.pnum.GENERIC_F401CCFX=Generic F401CCFx
-GenF4.menu.pnum.GENERIC_F401CCFX.upload.maximum_size=262144
-GenF4.menu.pnum.GENERIC_F401CCFX.upload.maximum_data_size=65536
-GenF4.menu.pnum.GENERIC_F401CCFX.build.board=GENERIC_F401CCFX
-GenF4.menu.pnum.GENERIC_F401CCFX.build.product_line=STM32F401xC
-GenF4.menu.pnum.GENERIC_F401CCFX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
-GenF4.menu.pnum.GENERIC_F401CCFX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
-
 # Generic F401CCUx
 GenF4.menu.pnum.GENERIC_F401CCUX=Generic F401CCUx
 GenF4.menu.pnum.GENERIC_F401CCUX.upload.maximum_size=262144
@@ -5091,6 +5081,15 @@ GenF4.menu.pnum.GENERIC_F401CCUX.build.board=GENERIC_F401CCUX
 GenF4.menu.pnum.GENERIC_F401CCUX.build.product_line=STM32F401xC
 GenF4.menu.pnum.GENERIC_F401CCUX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
 GenF4.menu.pnum.GENERIC_F401CCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
+
+# Generic F401CBYx
+GenF4.menu.pnum.GENERIC_F401CBYX=Generic F401CBYx
+GenF4.menu.pnum.GENERIC_F401CBYX.upload.maximum_size=131072
+GenF4.menu.pnum.GENERIC_F401CBYX.upload.maximum_data_size=65536
+GenF4.menu.pnum.GENERIC_F401CBYX.build.board=GENERIC_F401CBYX
+GenF4.menu.pnum.GENERIC_F401CBYX.build.product_line=STM32F401xC
+GenF4.menu.pnum.GENERIC_F401CBYX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
+GenF4.menu.pnum.GENERIC_F401CBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
 
 # Generic F401CCYx
 GenF4.menu.pnum.GENERIC_F401CCYX=Generic F401CCYx
@@ -5110,15 +5109,6 @@ GenF4.menu.pnum.GENERIC_F401CDUX.build.product_line=STM32F401xE
 GenF4.menu.pnum.GENERIC_F401CDUX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
 GenF4.menu.pnum.GENERIC_F401CDUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
 
-# Generic F401CDYx
-GenF4.menu.pnum.GENERIC_F401CDYX=Generic F401CDYx
-GenF4.menu.pnum.GENERIC_F401CDYX.upload.maximum_size=393216
-GenF4.menu.pnum.GENERIC_F401CDYX.upload.maximum_data_size=98304
-GenF4.menu.pnum.GENERIC_F401CDYX.build.board=GENERIC_F401CDYX
-GenF4.menu.pnum.GENERIC_F401CDYX.build.product_line=STM32F401xE
-GenF4.menu.pnum.GENERIC_F401CDYX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
-GenF4.menu.pnum.GENERIC_F401CDYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
-
 # Generic F401CEUx
 GenF4.menu.pnum.GENERIC_F401CEUX=Generic F401CEUx
 GenF4.menu.pnum.GENERIC_F401CEUX.upload.maximum_size=524288
@@ -5128,6 +5118,15 @@ GenF4.menu.pnum.GENERIC_F401CEUX.build.product_line=STM32F401xE
 GenF4.menu.pnum.GENERIC_F401CEUX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
 GenF4.menu.pnum.GENERIC_F401CEUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
 
+# Generic F401CDYx
+GenF4.menu.pnum.GENERIC_F401CDYX=Generic F401CDYx
+GenF4.menu.pnum.GENERIC_F401CDYX.upload.maximum_size=393216
+GenF4.menu.pnum.GENERIC_F401CDYX.upload.maximum_data_size=98304
+GenF4.menu.pnum.GENERIC_F401CDYX.build.board=GENERIC_F401CDYX
+GenF4.menu.pnum.GENERIC_F401CDYX.build.product_line=STM32F401xE
+GenF4.menu.pnum.GENERIC_F401CDYX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
+GenF4.menu.pnum.GENERIC_F401CDYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
+
 # Generic F401CEYx
 GenF4.menu.pnum.GENERIC_F401CEYX=Generic F401CEYx
 GenF4.menu.pnum.GENERIC_F401CEYX.upload.maximum_size=524288
@@ -5136,6 +5135,15 @@ GenF4.menu.pnum.GENERIC_F401CEYX.build.board=GENERIC_F401CEYX
 GenF4.menu.pnum.GENERIC_F401CEYX.build.product_line=STM32F401xE
 GenF4.menu.pnum.GENERIC_F401CEYX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
 GenF4.menu.pnum.GENERIC_F401CEYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
+
+# Generic F401CCFx
+GenF4.menu.pnum.GENERIC_F401CCFX=Generic F401CCFx
+GenF4.menu.pnum.GENERIC_F401CCFX.upload.maximum_size=262144
+GenF4.menu.pnum.GENERIC_F401CCFX.upload.maximum_data_size=65536
+GenF4.menu.pnum.GENERIC_F401CCFX.build.board=GENERIC_F401CCFX
+GenF4.menu.pnum.GENERIC_F401CCFX.build.product_line=STM32F401xC
+GenF4.menu.pnum.GENERIC_F401CCFX.build.variant=STM32F4xx/F401CC(F-U-Y)_F401C(B-D-E)(U-Y)
+GenF4.menu.pnum.GENERIC_F401CCFX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
 
 # Generic F401RBTx
 GenF4.menu.pnum.GENERIC_F401RBTX=Generic F401RBTx
@@ -5335,15 +5343,6 @@ GenF4.menu.pnum.GENERIC_F410R8IX.build.product_line=STM32F410Rx
 GenF4.menu.pnum.GENERIC_F410R8IX.build.variant=STM32F4xx/F410R(8-B)(I-T)
 GenF4.menu.pnum.GENERIC_F410R8IX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F410.svd
 
-# Generic F410R8Tx
-GenF4.menu.pnum.GENERIC_F410R8TX=Generic F410R8Tx
-GenF4.menu.pnum.GENERIC_F410R8TX.upload.maximum_size=65536
-GenF4.menu.pnum.GENERIC_F410R8TX.upload.maximum_data_size=32768
-GenF4.menu.pnum.GENERIC_F410R8TX.build.board=GENERIC_F410R8TX
-GenF4.menu.pnum.GENERIC_F410R8TX.build.product_line=STM32F410Rx
-GenF4.menu.pnum.GENERIC_F410R8TX.build.variant=STM32F4xx/F410R(8-B)(I-T)
-GenF4.menu.pnum.GENERIC_F410R8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F410.svd
-
 # Generic F410RBIx
 GenF4.menu.pnum.GENERIC_F410RBIX=Generic F410RBIx
 GenF4.menu.pnum.GENERIC_F410RBIX.upload.maximum_size=131072
@@ -5352,6 +5351,15 @@ GenF4.menu.pnum.GENERIC_F410RBIX.build.board=GENERIC_F410RBIX
 GenF4.menu.pnum.GENERIC_F410RBIX.build.product_line=STM32F410Rx
 GenF4.menu.pnum.GENERIC_F410RBIX.build.variant=STM32F4xx/F410R(8-B)(I-T)
 GenF4.menu.pnum.GENERIC_F410RBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F410.svd
+
+# Generic F410R8Tx
+GenF4.menu.pnum.GENERIC_F410R8TX=Generic F410R8Tx
+GenF4.menu.pnum.GENERIC_F410R8TX.upload.maximum_size=65536
+GenF4.menu.pnum.GENERIC_F410R8TX.upload.maximum_data_size=32768
+GenF4.menu.pnum.GENERIC_F410R8TX.build.board=GENERIC_F410R8TX
+GenF4.menu.pnum.GENERIC_F410R8TX.build.product_line=STM32F410Rx
+GenF4.menu.pnum.GENERIC_F410R8TX.build.variant=STM32F4xx/F410R(8-B)(I-T)
+GenF4.menu.pnum.GENERIC_F410R8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F410.svd
 
 # Generic F410RBTx
 GenF4.menu.pnum.GENERIC_F410RBTX=Generic F410RBTx
@@ -5389,15 +5397,6 @@ GenF4.menu.pnum.GENERIC_F411CCUX.build.product_line=STM32F411xE
 GenF4.menu.pnum.GENERIC_F411CCUX.build.variant=STM32F4xx/F411C(C-E)(U-Y)
 GenF4.menu.pnum.GENERIC_F411CCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F411.svd
 
-# Generic F411CCYx
-GenF4.menu.pnum.GENERIC_F411CCYX=Generic F411CCYx
-GenF4.menu.pnum.GENERIC_F411CCYX.upload.maximum_size=262144
-GenF4.menu.pnum.GENERIC_F411CCYX.upload.maximum_data_size=131072
-GenF4.menu.pnum.GENERIC_F411CCYX.build.board=GENERIC_F411CCYX
-GenF4.menu.pnum.GENERIC_F411CCYX.build.product_line=STM32F411xE
-GenF4.menu.pnum.GENERIC_F411CCYX.build.variant=STM32F4xx/F411C(C-E)(U-Y)
-GenF4.menu.pnum.GENERIC_F411CCYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F411.svd
-
 # Generic F411CEUx
 GenF4.menu.pnum.GENERIC_F411CEUX=Generic F411CEUx
 GenF4.menu.pnum.GENERIC_F411CEUX.upload.maximum_size=524288
@@ -5406,6 +5405,15 @@ GenF4.menu.pnum.GENERIC_F411CEUX.build.board=GENERIC_F411CEUX
 GenF4.menu.pnum.GENERIC_F411CEUX.build.product_line=STM32F411xE
 GenF4.menu.pnum.GENERIC_F411CEUX.build.variant=STM32F4xx/F411C(C-E)(U-Y)
 GenF4.menu.pnum.GENERIC_F411CEUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F411.svd
+
+# Generic F411CCYx
+GenF4.menu.pnum.GENERIC_F411CCYX=Generic F411CCYx
+GenF4.menu.pnum.GENERIC_F411CCYX.upload.maximum_size=262144
+GenF4.menu.pnum.GENERIC_F411CCYX.upload.maximum_data_size=131072
+GenF4.menu.pnum.GENERIC_F411CCYX.build.board=GENERIC_F411CCYX
+GenF4.menu.pnum.GENERIC_F411CCYX.build.product_line=STM32F411xE
+GenF4.menu.pnum.GENERIC_F411CCYX.build.variant=STM32F4xx/F411C(C-E)(U-Y)
+GenF4.menu.pnum.GENERIC_F411CCYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F411.svd
 
 # Generic F411CEYx
 GenF4.menu.pnum.GENERIC_F411CEYX=Generic F411CEYx
@@ -5479,24 +5487,6 @@ GenF4.menu.pnum.GENERIC_F412RETX.build.product_line=STM32F412Rx
 GenF4.menu.pnum.GENERIC_F412RETX.build.variant=STM32F4xx/F412R(E-G)(T-Y)x(P)
 GenF4.menu.pnum.GENERIC_F412RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
 
-# Generic F412REYx
-GenF4.menu.pnum.GENERIC_F412REYX=Generic F412REYx
-GenF4.menu.pnum.GENERIC_F412REYX.upload.maximum_size=524288
-GenF4.menu.pnum.GENERIC_F412REYX.upload.maximum_data_size=262144
-GenF4.menu.pnum.GENERIC_F412REYX.build.board=GENERIC_F412REYX
-GenF4.menu.pnum.GENERIC_F412REYX.build.product_line=STM32F412Rx
-GenF4.menu.pnum.GENERIC_F412REYX.build.variant=STM32F4xx/F412R(E-G)(T-Y)x(P)
-GenF4.menu.pnum.GENERIC_F412REYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
-
-# Generic F412REYxP
-GenF4.menu.pnum.GENERIC_F412REYXP=Generic F412REYxP
-GenF4.menu.pnum.GENERIC_F412REYXP.upload.maximum_size=524288
-GenF4.menu.pnum.GENERIC_F412REYXP.upload.maximum_data_size=262144
-GenF4.menu.pnum.GENERIC_F412REYXP.build.board=GENERIC_F412REYXP
-GenF4.menu.pnum.GENERIC_F412REYXP.build.product_line=STM32F412Rx
-GenF4.menu.pnum.GENERIC_F412REYXP.build.variant=STM32F4xx/F412R(E-G)(T-Y)x(P)
-GenF4.menu.pnum.GENERIC_F412REYXP.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
-
 # Generic F412RGTx
 GenF4.menu.pnum.GENERIC_F412RGTX=Generic F412RGTx
 GenF4.menu.pnum.GENERIC_F412RGTX.upload.maximum_size=1048576
@@ -5506,6 +5496,15 @@ GenF4.menu.pnum.GENERIC_F412RGTX.build.product_line=STM32F412Rx
 GenF4.menu.pnum.GENERIC_F412RGTX.build.variant=STM32F4xx/F412R(E-G)(T-Y)x(P)
 GenF4.menu.pnum.GENERIC_F412RGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
 
+# Generic F412REYx
+GenF4.menu.pnum.GENERIC_F412REYX=Generic F412REYx
+GenF4.menu.pnum.GENERIC_F412REYX.upload.maximum_size=524288
+GenF4.menu.pnum.GENERIC_F412REYX.upload.maximum_data_size=262144
+GenF4.menu.pnum.GENERIC_F412REYX.build.board=GENERIC_F412REYX
+GenF4.menu.pnum.GENERIC_F412REYX.build.product_line=STM32F412Rx
+GenF4.menu.pnum.GENERIC_F412REYX.build.variant=STM32F4xx/F412R(E-G)(T-Y)x(P)
+GenF4.menu.pnum.GENERIC_F412REYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
+
 # Generic F412RGYx
 GenF4.menu.pnum.GENERIC_F412RGYX=Generic F412RGYx
 GenF4.menu.pnum.GENERIC_F412RGYX.upload.maximum_size=1048576
@@ -5514,6 +5513,15 @@ GenF4.menu.pnum.GENERIC_F412RGYX.build.board=GENERIC_F412RGYX
 GenF4.menu.pnum.GENERIC_F412RGYX.build.product_line=STM32F412Rx
 GenF4.menu.pnum.GENERIC_F412RGYX.build.variant=STM32F4xx/F412R(E-G)(T-Y)x(P)
 GenF4.menu.pnum.GENERIC_F412RGYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
+
+# Generic F412REYxP
+GenF4.menu.pnum.GENERIC_F412REYXP=Generic F412REYxP
+GenF4.menu.pnum.GENERIC_F412REYXP.upload.maximum_size=524288
+GenF4.menu.pnum.GENERIC_F412REYXP.upload.maximum_data_size=262144
+GenF4.menu.pnum.GENERIC_F412REYXP.build.board=GENERIC_F412REYXP
+GenF4.menu.pnum.GENERIC_F412REYXP.build.product_line=STM32F412Rx
+GenF4.menu.pnum.GENERIC_F412REYXP.build.variant=STM32F4xx/F412R(E-G)(T-Y)x(P)
+GenF4.menu.pnum.GENERIC_F412REYXP.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
 
 # Generic F412RGYxP
 GenF4.menu.pnum.GENERIC_F412RGYXP=Generic F412RGYxP
@@ -5533,15 +5541,6 @@ GenF4.menu.pnum.GENERIC_F412ZEJX.build.product_line=STM32F412Zx
 GenF4.menu.pnum.GENERIC_F412ZEJX.build.variant=STM32F4xx/F412Z(E-G)(J-T)
 GenF4.menu.pnum.GENERIC_F412ZEJX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
 
-# Generic F412ZETx
-GenF4.menu.pnum.GENERIC_F412ZETX=Generic F412ZETx
-GenF4.menu.pnum.GENERIC_F412ZETX.upload.maximum_size=524288
-GenF4.menu.pnum.GENERIC_F412ZETX.upload.maximum_data_size=262144
-GenF4.menu.pnum.GENERIC_F412ZETX.build.board=GENERIC_F412ZETX
-GenF4.menu.pnum.GENERIC_F412ZETX.build.product_line=STM32F412Zx
-GenF4.menu.pnum.GENERIC_F412ZETX.build.variant=STM32F4xx/F412Z(E-G)(J-T)
-GenF4.menu.pnum.GENERIC_F412ZETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
-
 # Generic F412ZGJx
 GenF4.menu.pnum.GENERIC_F412ZGJX=Generic F412ZGJx
 GenF4.menu.pnum.GENERIC_F412ZGJX.upload.maximum_size=1048576
@@ -5550,6 +5549,15 @@ GenF4.menu.pnum.GENERIC_F412ZGJX.build.board=GENERIC_F412ZGJX
 GenF4.menu.pnum.GENERIC_F412ZGJX.build.product_line=STM32F412Zx
 GenF4.menu.pnum.GENERIC_F412ZGJX.build.variant=STM32F4xx/F412Z(E-G)(J-T)
 GenF4.menu.pnum.GENERIC_F412ZGJX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
+
+# Generic F412ZETx
+GenF4.menu.pnum.GENERIC_F412ZETX=Generic F412ZETx
+GenF4.menu.pnum.GENERIC_F412ZETX.upload.maximum_size=524288
+GenF4.menu.pnum.GENERIC_F412ZETX.upload.maximum_data_size=262144
+GenF4.menu.pnum.GENERIC_F412ZETX.build.board=GENERIC_F412ZETX
+GenF4.menu.pnum.GENERIC_F412ZETX.build.product_line=STM32F412Zx
+GenF4.menu.pnum.GENERIC_F412ZETX.build.variant=STM32F4xx/F412Z(E-G)(J-T)
+GenF4.menu.pnum.GENERIC_F412ZETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
 
 # Generic F412ZGTx
 GenF4.menu.pnum.GENERIC_F412ZGTX=Generic F412ZGTx
@@ -5605,15 +5613,6 @@ GenF4.menu.pnum.GENERIC_F413ZGJX.build.product_line=STM32F413xx
 GenF4.menu.pnum.GENERIC_F413ZGJX.build.variant=STM32F4xx/F413Z(G-H)(J-T)_F423ZH(J-T)
 GenF4.menu.pnum.GENERIC_F413ZGJX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F413.svd
 
-# Generic F413ZGTx
-GenF4.menu.pnum.GENERIC_F413ZGTX=Generic F413ZGTx
-GenF4.menu.pnum.GENERIC_F413ZGTX.upload.maximum_size=1048576
-GenF4.menu.pnum.GENERIC_F413ZGTX.upload.maximum_data_size=327680
-GenF4.menu.pnum.GENERIC_F413ZGTX.build.board=GENERIC_F413ZGTX
-GenF4.menu.pnum.GENERIC_F413ZGTX.build.product_line=STM32F413xx
-GenF4.menu.pnum.GENERIC_F413ZGTX.build.variant=STM32F4xx/F413Z(G-H)(J-T)_F423ZH(J-T)
-GenF4.menu.pnum.GENERIC_F413ZGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F413.svd
-
 # Generic F413ZHJx
 GenF4.menu.pnum.GENERIC_F413ZHJX=Generic F413ZHJx
 GenF4.menu.pnum.GENERIC_F413ZHJX.upload.maximum_size=1572864
@@ -5622,6 +5621,15 @@ GenF4.menu.pnum.GENERIC_F413ZHJX.build.board=GENERIC_F413ZHJX
 GenF4.menu.pnum.GENERIC_F413ZHJX.build.product_line=STM32F413xx
 GenF4.menu.pnum.GENERIC_F413ZHJX.build.variant=STM32F4xx/F413Z(G-H)(J-T)_F423ZH(J-T)
 GenF4.menu.pnum.GENERIC_F413ZHJX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F413.svd
+
+# Generic F413ZGTx
+GenF4.menu.pnum.GENERIC_F413ZGTX=Generic F413ZGTx
+GenF4.menu.pnum.GENERIC_F413ZGTX.upload.maximum_size=1048576
+GenF4.menu.pnum.GENERIC_F413ZGTX.upload.maximum_data_size=327680
+GenF4.menu.pnum.GENERIC_F413ZGTX.build.board=GENERIC_F413ZGTX
+GenF4.menu.pnum.GENERIC_F413ZGTX.build.product_line=STM32F413xx
+GenF4.menu.pnum.GENERIC_F413ZGTX.build.variant=STM32F4xx/F413Z(G-H)(J-T)_F423ZH(J-T)
+GenF4.menu.pnum.GENERIC_F413ZGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F413.svd
 
 # Generic F413ZHTx
 GenF4.menu.pnum.GENERIC_F413ZHTX=Generic F413ZHTx
@@ -5839,15 +5847,6 @@ GenF4.menu.pnum.GENERIC_F439ZGTX.build.product_line=STM32F439xx
 GenF4.menu.pnum.GENERIC_F439ZGTX.build.variant=STM32F4xx/F427Z(G-I)T_F429ZET_F429Z(G-I)(T-Y)_F437Z(G-I)T_F439Z(G-I)(T-Y)
 GenF4.menu.pnum.GENERIC_F439ZGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F439.svd
 
-# Generic F439ZGYx
-GenF4.menu.pnum.GENERIC_F439ZGYX=Generic F439ZGYx
-GenF4.menu.pnum.GENERIC_F439ZGYX.upload.maximum_size=1048576
-GenF4.menu.pnum.GENERIC_F439ZGYX.upload.maximum_data_size=196608
-GenF4.menu.pnum.GENERIC_F439ZGYX.build.board=GENERIC_F439ZGYX
-GenF4.menu.pnum.GENERIC_F439ZGYX.build.product_line=STM32F439xx
-GenF4.menu.pnum.GENERIC_F439ZGYX.build.variant=STM32F4xx/F427Z(G-I)T_F429ZET_F429Z(G-I)(T-Y)_F437Z(G-I)T_F439Z(G-I)(T-Y)
-GenF4.menu.pnum.GENERIC_F439ZGYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F439.svd
-
 # Generic F439ZITx
 GenF4.menu.pnum.GENERIC_F439ZITX=Generic F439ZITx
 GenF4.menu.pnum.GENERIC_F439ZITX.upload.maximum_size=2097152
@@ -5856,6 +5855,15 @@ GenF4.menu.pnum.GENERIC_F439ZITX.build.board=GENERIC_F439ZITX
 GenF4.menu.pnum.GENERIC_F439ZITX.build.product_line=STM32F439xx
 GenF4.menu.pnum.GENERIC_F439ZITX.build.variant=STM32F4xx/F427Z(G-I)T_F429ZET_F429Z(G-I)(T-Y)_F437Z(G-I)T_F439Z(G-I)(T-Y)
 GenF4.menu.pnum.GENERIC_F439ZITX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F439.svd
+
+# Generic F439ZGYx
+GenF4.menu.pnum.GENERIC_F439ZGYX=Generic F439ZGYx
+GenF4.menu.pnum.GENERIC_F439ZGYX.upload.maximum_size=1048576
+GenF4.menu.pnum.GENERIC_F439ZGYX.upload.maximum_data_size=196608
+GenF4.menu.pnum.GENERIC_F439ZGYX.build.board=GENERIC_F439ZGYX
+GenF4.menu.pnum.GENERIC_F439ZGYX.build.product_line=STM32F439xx
+GenF4.menu.pnum.GENERIC_F439ZGYX.build.variant=STM32F4xx/F427Z(G-I)T_F429ZET_F429Z(G-I)(T-Y)_F437Z(G-I)T_F439Z(G-I)(T-Y)
+GenF4.menu.pnum.GENERIC_F439ZGYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F439.svd
 
 # Generic F439ZIYx
 GenF4.menu.pnum.GENERIC_F439ZIYX=Generic F439ZIYx
@@ -6295,15 +6303,6 @@ GenF7.menu.pnum.GENERIC_F765IGKX.build.product_line=STM32F765xx
 GenF7.menu.pnum.GENERIC_F765IGKX.build.variant=STM32F7xx/F765I(G-I)(K-T)_F767I(G-I)(K-T)_F777II(K-T)
 GenF7.menu.pnum.GENERIC_F765IGKX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F765.svd
 
-# Generic F765IGTx
-GenF7.menu.pnum.GENERIC_F765IGTX=Generic F765IGTx
-GenF7.menu.pnum.GENERIC_F765IGTX.upload.maximum_size=1048576
-GenF7.menu.pnum.GENERIC_F765IGTX.upload.maximum_data_size=393216
-GenF7.menu.pnum.GENERIC_F765IGTX.build.board=GENERIC_F765IGTX
-GenF7.menu.pnum.GENERIC_F765IGTX.build.product_line=STM32F765xx
-GenF7.menu.pnum.GENERIC_F765IGTX.build.variant=STM32F7xx/F765I(G-I)(K-T)_F767I(G-I)(K-T)_F777II(K-T)
-GenF7.menu.pnum.GENERIC_F765IGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F765.svd
-
 # Generic F765IIKx
 GenF7.menu.pnum.GENERIC_F765IIKX=Generic F765IIKx
 GenF7.menu.pnum.GENERIC_F765IIKX.upload.maximum_size=2097152
@@ -6312,6 +6311,15 @@ GenF7.menu.pnum.GENERIC_F765IIKX.build.board=GENERIC_F765IIKX
 GenF7.menu.pnum.GENERIC_F765IIKX.build.product_line=STM32F765xx
 GenF7.menu.pnum.GENERIC_F765IIKX.build.variant=STM32F7xx/F765I(G-I)(K-T)_F767I(G-I)(K-T)_F777II(K-T)
 GenF7.menu.pnum.GENERIC_F765IIKX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F765.svd
+
+# Generic F765IGTx
+GenF7.menu.pnum.GENERIC_F765IGTX=Generic F765IGTx
+GenF7.menu.pnum.GENERIC_F765IGTX.upload.maximum_size=1048576
+GenF7.menu.pnum.GENERIC_F765IGTX.upload.maximum_data_size=393216
+GenF7.menu.pnum.GENERIC_F765IGTX.build.board=GENERIC_F765IGTX
+GenF7.menu.pnum.GENERIC_F765IGTX.build.product_line=STM32F765xx
+GenF7.menu.pnum.GENERIC_F765IGTX.build.variant=STM32F7xx/F765I(G-I)(K-T)_F767I(G-I)(K-T)_F777II(K-T)
+GenF7.menu.pnum.GENERIC_F765IGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F765.svd
 
 # Generic F765IITx
 GenF7.menu.pnum.GENERIC_F765IITX=Generic F765IITx
@@ -6385,15 +6393,6 @@ GenF7.menu.pnum.GENERIC_F767IGKX.build.product_line=STM32F767xx
 GenF7.menu.pnum.GENERIC_F767IGKX.build.variant=STM32F7xx/F765I(G-I)(K-T)_F767I(G-I)(K-T)_F777II(K-T)
 GenF7.menu.pnum.GENERIC_F767IGKX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F767.svd
 
-# Generic F767IGTx
-GenF7.menu.pnum.GENERIC_F767IGTX=Generic F767IGTx
-GenF7.menu.pnum.GENERIC_F767IGTX.upload.maximum_size=1048576
-GenF7.menu.pnum.GENERIC_F767IGTX.upload.maximum_data_size=393216
-GenF7.menu.pnum.GENERIC_F767IGTX.build.board=GENERIC_F767IGTX
-GenF7.menu.pnum.GENERIC_F767IGTX.build.product_line=STM32F767xx
-GenF7.menu.pnum.GENERIC_F767IGTX.build.variant=STM32F7xx/F765I(G-I)(K-T)_F767I(G-I)(K-T)_F777II(K-T)
-GenF7.menu.pnum.GENERIC_F767IGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F767.svd
-
 # Generic F767IIKx
 GenF7.menu.pnum.GENERIC_F767IIKX=Generic F767IIKx
 GenF7.menu.pnum.GENERIC_F767IIKX.upload.maximum_size=2097152
@@ -6402,6 +6401,15 @@ GenF7.menu.pnum.GENERIC_F767IIKX.build.board=GENERIC_F767IIKX
 GenF7.menu.pnum.GENERIC_F767IIKX.build.product_line=STM32F767xx
 GenF7.menu.pnum.GENERIC_F767IIKX.build.variant=STM32F7xx/F765I(G-I)(K-T)_F767I(G-I)(K-T)_F777II(K-T)
 GenF7.menu.pnum.GENERIC_F767IIKX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F767.svd
+
+# Generic F767IGTx
+GenF7.menu.pnum.GENERIC_F767IGTX=Generic F767IGTx
+GenF7.menu.pnum.GENERIC_F767IGTX.upload.maximum_size=1048576
+GenF7.menu.pnum.GENERIC_F767IGTX.upload.maximum_data_size=393216
+GenF7.menu.pnum.GENERIC_F767IGTX.build.board=GENERIC_F767IGTX
+GenF7.menu.pnum.GENERIC_F767IGTX.build.product_line=STM32F767xx
+GenF7.menu.pnum.GENERIC_F767IGTX.build.variant=STM32F7xx/F765I(G-I)(K-T)_F767I(G-I)(K-T)_F777II(K-T)
+GenF7.menu.pnum.GENERIC_F767IGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F767.svd
 
 # Generic F767IITx
 GenF7.menu.pnum.GENERIC_F767IITX=Generic F767IITx
@@ -6645,15 +6653,6 @@ GenG0.menu.pnum.GENERIC_G031C4TX.build.product_line=STM32G031xx
 GenG0.menu.pnum.GENERIC_G031C4TX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G031C4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
-# Generic G031C4Ux
-GenG0.menu.pnum.GENERIC_G031C4UX=Generic G031C4Ux
-GenG0.menu.pnum.GENERIC_G031C4UX.upload.maximum_size=16384
-GenG0.menu.pnum.GENERIC_G031C4UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031C4UX.build.board=GENERIC_G031C4UX
-GenG0.menu.pnum.GENERIC_G031C4UX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031C4UX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G031C4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
-
 # Generic G031C6Tx
 GenG0.menu.pnum.GENERIC_G031C6TX=Generic G031C6Tx
 GenG0.menu.pnum.GENERIC_G031C6TX.upload.maximum_size=32768
@@ -6662,15 +6661,6 @@ GenG0.menu.pnum.GENERIC_G031C6TX.build.board=GENERIC_G031C6TX
 GenG0.menu.pnum.GENERIC_G031C6TX.build.product_line=STM32G031xx
 GenG0.menu.pnum.GENERIC_G031C6TX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G031C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
-
-# Generic G031C6Ux
-GenG0.menu.pnum.GENERIC_G031C6UX=Generic G031C6Ux
-GenG0.menu.pnum.GENERIC_G031C6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G031C6UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031C6UX.build.board=GENERIC_G031C6UX
-GenG0.menu.pnum.GENERIC_G031C6UX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031C6UX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G031C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
 # Generic G031C8Tx
 GenG0.menu.pnum.GENERIC_G031C8TX=Generic G031C8Tx
@@ -6681,6 +6671,24 @@ GenG0.menu.pnum.GENERIC_G031C8TX.build.product_line=STM32G031xx
 GenG0.menu.pnum.GENERIC_G031C8TX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G031C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
+# Generic G031C4Ux
+GenG0.menu.pnum.GENERIC_G031C4UX=Generic G031C4Ux
+GenG0.menu.pnum.GENERIC_G031C4UX.upload.maximum_size=16384
+GenG0.menu.pnum.GENERIC_G031C4UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031C4UX.build.board=GENERIC_G031C4UX
+GenG0.menu.pnum.GENERIC_G031C4UX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031C4UX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G031C4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
+
+# Generic G031C6Ux
+GenG0.menu.pnum.GENERIC_G031C6UX=Generic G031C6Ux
+GenG0.menu.pnum.GENERIC_G031C6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G031C6UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031C6UX.build.board=GENERIC_G031C6UX
+GenG0.menu.pnum.GENERIC_G031C6UX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031C6UX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G031C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
+
 # Generic G031C8Ux
 GenG0.menu.pnum.GENERIC_G031C8UX=Generic G031C8Ux
 GenG0.menu.pnum.GENERIC_G031C8UX.upload.maximum_size=65536
@@ -6689,33 +6697,6 @@ GenG0.menu.pnum.GENERIC_G031C8UX.build.board=GENERIC_G031C8UX
 GenG0.menu.pnum.GENERIC_G031C8UX.build.product_line=STM32G031xx
 GenG0.menu.pnum.GENERIC_G031C8UX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G031C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
-
-# Generic G031F4Px
-GenG0.menu.pnum.GENERIC_G031F4PX=Generic G031F4Px
-GenG0.menu.pnum.GENERIC_G031F4PX.upload.maximum_size=16384
-GenG0.menu.pnum.GENERIC_G031F4PX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031F4PX.build.board=GENERIC_G031F4PX
-GenG0.menu.pnum.GENERIC_G031F4PX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031F4PX.build.variant=STM32G0xx/G031F(4-6-8)P_G031Y8Y_G041F(6-8)P_G041Y8Y
-GenG0.menu.pnum.GENERIC_G031F4PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
-
-# Generic G031F6Px
-GenG0.menu.pnum.GENERIC_G031F6PX=Generic G031F6Px
-GenG0.menu.pnum.GENERIC_G031F6PX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G031F6PX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031F6PX.build.board=GENERIC_G031F6PX
-GenG0.menu.pnum.GENERIC_G031F6PX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031F6PX.build.variant=STM32G0xx/G031F(4-6-8)P_G031Y8Y_G041F(6-8)P_G041Y8Y
-GenG0.menu.pnum.GENERIC_G031F6PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
-
-# Generic G031F8Px
-GenG0.menu.pnum.GENERIC_G031F8PX=Generic G031F8Px
-GenG0.menu.pnum.GENERIC_G031F8PX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G031F8PX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031F8PX.build.board=GENERIC_G031F8PX
-GenG0.menu.pnum.GENERIC_G031F8PX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031F8PX.build.variant=STM32G0xx/G031F(4-6-8)P_G031Y8Y_G041F(6-8)P_G041Y8Y
-GenG0.menu.pnum.GENERIC_G031F8PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
 # Generic G031G4Ux
 GenG0.menu.pnum.GENERIC_G031G4UX=Generic G031G4Ux
@@ -6744,6 +6725,60 @@ GenG0.menu.pnum.GENERIC_G031G8UX.build.product_line=STM32G031xx
 GenG0.menu.pnum.GENERIC_G031G8UX.build.variant=STM32G0xx/G031G(4-6-8)U_G041G(6-8)U
 GenG0.menu.pnum.GENERIC_G031G8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
+# Generic G041G6Ux
+GenG0.menu.pnum.GENERIC_G041G6UX=Generic G041G6Ux
+GenG0.menu.pnum.GENERIC_G041G6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G041G6UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G041G6UX.build.board=GENERIC_G041G6UX
+GenG0.menu.pnum.GENERIC_G041G6UX.build.product_line=STM32G041xx
+GenG0.menu.pnum.GENERIC_G041G6UX.build.variant=STM32G0xx/G031G(4-6-8)U_G041G(6-8)U
+GenG0.menu.pnum.GENERIC_G041G6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+
+# Generic G041G8Ux
+GenG0.menu.pnum.GENERIC_G041G8UX=Generic G041G8Ux
+GenG0.menu.pnum.GENERIC_G041G8UX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G041G8UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G041G8UX.build.board=GENERIC_G041G8UX
+GenG0.menu.pnum.GENERIC_G041G8UX.build.product_line=STM32G041xx
+GenG0.menu.pnum.GENERIC_G041G8UX.build.variant=STM32G0xx/G031G(4-6-8)U_G041G(6-8)U
+GenG0.menu.pnum.GENERIC_G041G8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+
+# Generic G041C6Tx
+GenG0.menu.pnum.GENERIC_G041C6TX=Generic G041C6Tx
+GenG0.menu.pnum.GENERIC_G041C6TX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G041C6TX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G041C6TX.build.board=GENERIC_G041C6TX
+GenG0.menu.pnum.GENERIC_G041C6TX.build.product_line=STM32G041xx
+GenG0.menu.pnum.GENERIC_G041C6TX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G041C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+
+# Generic G041C8Tx
+GenG0.menu.pnum.GENERIC_G041C8TX=Generic G041C8Tx
+GenG0.menu.pnum.GENERIC_G041C8TX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G041C8TX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G041C8TX.build.board=GENERIC_G041C8TX
+GenG0.menu.pnum.GENERIC_G041C8TX.build.product_line=STM32G041xx
+GenG0.menu.pnum.GENERIC_G041C8TX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G041C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+
+# Generic G041C6Ux
+GenG0.menu.pnum.GENERIC_G041C6UX=Generic G041C6Ux
+GenG0.menu.pnum.GENERIC_G041C6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G041C6UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G041C6UX.build.board=GENERIC_G041C6UX
+GenG0.menu.pnum.GENERIC_G041C6UX.build.product_line=STM32G041xx
+GenG0.menu.pnum.GENERIC_G041C6UX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G041C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+
+# Generic G041C8Ux
+GenG0.menu.pnum.GENERIC_G041C8UX=Generic G041C8Ux
+GenG0.menu.pnum.GENERIC_G041C8UX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G041C8UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G041C8UX.build.board=GENERIC_G041C8UX
+GenG0.menu.pnum.GENERIC_G041C8UX.build.product_line=STM32G041xx
+GenG0.menu.pnum.GENERIC_G041C8UX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G041C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+
 # Generic G031J4Mx
 GenG0.menu.pnum.GENERIC_G031J4MX=Generic G031J4Mx
 GenG0.menu.pnum.GENERIC_G031J4MX.upload.maximum_size=16384
@@ -6762,59 +6797,32 @@ GenG0.menu.pnum.GENERIC_G031J6MX.build.product_line=STM32G031xx
 GenG0.menu.pnum.GENERIC_G031J6MX.build.variant=STM32G0xx/G031J(4-6)M_G041J6M
 GenG0.menu.pnum.GENERIC_G031J6MX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
-# Generic G031K4Tx
-GenG0.menu.pnum.GENERIC_G031K4TX=Generic G031K4Tx
-GenG0.menu.pnum.GENERIC_G031K4TX.upload.maximum_size=16384
-GenG0.menu.pnum.GENERIC_G031K4TX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031K4TX.build.board=GENERIC_G031K4TX
-GenG0.menu.pnum.GENERIC_G031K4TX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031K4TX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G031K4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
+# Generic G031F4Px
+GenG0.menu.pnum.GENERIC_G031F4PX=Generic G031F4Px
+GenG0.menu.pnum.GENERIC_G031F4PX.upload.maximum_size=16384
+GenG0.menu.pnum.GENERIC_G031F4PX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031F4PX.build.board=GENERIC_G031F4PX
+GenG0.menu.pnum.GENERIC_G031F4PX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031F4PX.build.variant=STM32G0xx/G031F(4-6-8)P_G031Y8Y_G041F(6-8)P_G041Y8Y
+GenG0.menu.pnum.GENERIC_G031F4PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
-# Generic G031K4Ux
-GenG0.menu.pnum.GENERIC_G031K4UX=Generic G031K4Ux
-GenG0.menu.pnum.GENERIC_G031K4UX.upload.maximum_size=16384
-GenG0.menu.pnum.GENERIC_G031K4UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031K4UX.build.board=GENERIC_G031K4UX
-GenG0.menu.pnum.GENERIC_G031K4UX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031K4UX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G031K4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
+# Generic G031F6Px
+GenG0.menu.pnum.GENERIC_G031F6PX=Generic G031F6Px
+GenG0.menu.pnum.GENERIC_G031F6PX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G031F6PX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031F6PX.build.board=GENERIC_G031F6PX
+GenG0.menu.pnum.GENERIC_G031F6PX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031F6PX.build.variant=STM32G0xx/G031F(4-6-8)P_G031Y8Y_G041F(6-8)P_G041Y8Y
+GenG0.menu.pnum.GENERIC_G031F6PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
-# Generic G031K6Tx
-GenG0.menu.pnum.GENERIC_G031K6TX=Generic G031K6Tx
-GenG0.menu.pnum.GENERIC_G031K6TX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G031K6TX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031K6TX.build.board=GENERIC_G031K6TX
-GenG0.menu.pnum.GENERIC_G031K6TX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031K6TX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G031K6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
-
-# Generic G031K6Ux
-GenG0.menu.pnum.GENERIC_G031K6UX=Generic G031K6Ux
-GenG0.menu.pnum.GENERIC_G031K6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G031K6UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031K6UX.build.board=GENERIC_G031K6UX
-GenG0.menu.pnum.GENERIC_G031K6UX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031K6UX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G031K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
-
-# Generic G031K8Tx
-GenG0.menu.pnum.GENERIC_G031K8TX=Generic G031K8Tx
-GenG0.menu.pnum.GENERIC_G031K8TX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G031K8TX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031K8TX.build.board=GENERIC_G031K8TX
-GenG0.menu.pnum.GENERIC_G031K8TX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031K8TX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G031K8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
-
-# Generic G031K8Ux
-GenG0.menu.pnum.GENERIC_G031K8UX=Generic G031K8Ux
-GenG0.menu.pnum.GENERIC_G031K8UX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G031K8UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G031K8UX.build.board=GENERIC_G031K8UX
-GenG0.menu.pnum.GENERIC_G031K8UX.build.product_line=STM32G031xx
-GenG0.menu.pnum.GENERIC_G031K8UX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G031K8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
+# Generic G031F8Px
+GenG0.menu.pnum.GENERIC_G031F8PX=Generic G031F8Px
+GenG0.menu.pnum.GENERIC_G031F8PX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G031F8PX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031F8PX.build.board=GENERIC_G031F8PX
+GenG0.menu.pnum.GENERIC_G031F8PX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031F8PX.build.variant=STM32G0xx/G031F(4-6-8)P_G031Y8Y_G041F(6-8)P_G041Y8Y
+GenG0.menu.pnum.GENERIC_G031F8PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
 # Generic G031Y8Yx
 GenG0.menu.pnum.GENERIC_G031Y8YX=Generic G031Y8Yx
@@ -6825,41 +6833,59 @@ GenG0.menu.pnum.GENERIC_G031Y8YX.build.product_line=STM32G031xx
 GenG0.menu.pnum.GENERIC_G031Y8YX.build.variant=STM32G0xx/G031F(4-6-8)P_G031Y8Y_G041F(6-8)P_G041Y8Y
 GenG0.menu.pnum.GENERIC_G031Y8YX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
-# Generic G041C6Tx
-GenG0.menu.pnum.GENERIC_G041C6TX=Generic G041C6Tx
-GenG0.menu.pnum.GENERIC_G041C6TX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G041C6TX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G041C6TX.build.board=GENERIC_G041C6TX
-GenG0.menu.pnum.GENERIC_G041C6TX.build.product_line=STM32G041xx
-GenG0.menu.pnum.GENERIC_G041C6TX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G041C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+# Generic G031K4Tx
+GenG0.menu.pnum.GENERIC_G031K4TX=Generic G031K4Tx
+GenG0.menu.pnum.GENERIC_G031K4TX.upload.maximum_size=16384
+GenG0.menu.pnum.GENERIC_G031K4TX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031K4TX.build.board=GENERIC_G031K4TX
+GenG0.menu.pnum.GENERIC_G031K4TX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031K4TX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G031K4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
-# Generic G041C6Ux
-GenG0.menu.pnum.GENERIC_G041C6UX=Generic G041C6Ux
-GenG0.menu.pnum.GENERIC_G041C6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G041C6UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G041C6UX.build.board=GENERIC_G041C6UX
-GenG0.menu.pnum.GENERIC_G041C6UX.build.product_line=STM32G041xx
-GenG0.menu.pnum.GENERIC_G041C6UX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G041C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+# Generic G031K6Tx
+GenG0.menu.pnum.GENERIC_G031K6TX=Generic G031K6Tx
+GenG0.menu.pnum.GENERIC_G031K6TX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G031K6TX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031K6TX.build.board=GENERIC_G031K6TX
+GenG0.menu.pnum.GENERIC_G031K6TX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031K6TX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G031K6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
-# Generic G041C8Tx
-GenG0.menu.pnum.GENERIC_G041C8TX=Generic G041C8Tx
-GenG0.menu.pnum.GENERIC_G041C8TX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G041C8TX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G041C8TX.build.board=GENERIC_G041C8TX
-GenG0.menu.pnum.GENERIC_G041C8TX.build.product_line=STM32G041xx
-GenG0.menu.pnum.GENERIC_G041C8TX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G041C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+# Generic G031K8Tx
+GenG0.menu.pnum.GENERIC_G031K8TX=Generic G031K8Tx
+GenG0.menu.pnum.GENERIC_G031K8TX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G031K8TX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031K8TX.build.board=GENERIC_G031K8TX
+GenG0.menu.pnum.GENERIC_G031K8TX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031K8TX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G031K8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
-# Generic G041C8Ux
-GenG0.menu.pnum.GENERIC_G041C8UX=Generic G041C8Ux
-GenG0.menu.pnum.GENERIC_G041C8UX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G041C8UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G041C8UX.build.board=GENERIC_G041C8UX
-GenG0.menu.pnum.GENERIC_G041C8UX.build.product_line=STM32G041xx
-GenG0.menu.pnum.GENERIC_G041C8UX.build.variant=STM32G0xx/G031C(4-6-8)(T-U)_G041C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G041C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+# Generic G031K4Ux
+GenG0.menu.pnum.GENERIC_G031K4UX=Generic G031K4Ux
+GenG0.menu.pnum.GENERIC_G031K4UX.upload.maximum_size=16384
+GenG0.menu.pnum.GENERIC_G031K4UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031K4UX.build.board=GENERIC_G031K4UX
+GenG0.menu.pnum.GENERIC_G031K4UX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031K4UX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G031K4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
+
+# Generic G031K6Ux
+GenG0.menu.pnum.GENERIC_G031K6UX=Generic G031K6Ux
+GenG0.menu.pnum.GENERIC_G031K6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G031K6UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031K6UX.build.board=GENERIC_G031K6UX
+GenG0.menu.pnum.GENERIC_G031K6UX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031K6UX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G031K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
+
+# Generic G031K8Ux
+GenG0.menu.pnum.GENERIC_G031K8UX=Generic G031K8Ux
+GenG0.menu.pnum.GENERIC_G031K8UX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G031K8UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G031K8UX.build.board=GENERIC_G031K8UX
+GenG0.menu.pnum.GENERIC_G031K8UX.build.product_line=STM32G031xx
+GenG0.menu.pnum.GENERIC_G031K8UX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G031K8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G031.svd
 
 # Generic G041F6Px
 GenG0.menu.pnum.GENERIC_G041F6PX=Generic G041F6Px
@@ -6879,24 +6905,6 @@ GenG0.menu.pnum.GENERIC_G041F8PX.build.product_line=STM32G041xx
 GenG0.menu.pnum.GENERIC_G041F8PX.build.variant=STM32G0xx/G031F(4-6-8)P_G031Y8Y_G041F(6-8)P_G041Y8Y
 GenG0.menu.pnum.GENERIC_G041F8PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
 
-# Generic G041G6Ux
-GenG0.menu.pnum.GENERIC_G041G6UX=Generic G041G6Ux
-GenG0.menu.pnum.GENERIC_G041G6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G041G6UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G041G6UX.build.board=GENERIC_G041G6UX
-GenG0.menu.pnum.GENERIC_G041G6UX.build.product_line=STM32G041xx
-GenG0.menu.pnum.GENERIC_G041G6UX.build.variant=STM32G0xx/G031G(4-6-8)U_G041G(6-8)U
-GenG0.menu.pnum.GENERIC_G041G6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
-
-# Generic G041G8Ux
-GenG0.menu.pnum.GENERIC_G041G8UX=Generic G041G8Ux
-GenG0.menu.pnum.GENERIC_G041G8UX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G041G8UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G041G8UX.build.board=GENERIC_G041G8UX
-GenG0.menu.pnum.GENERIC_G041G8UX.build.product_line=STM32G041xx
-GenG0.menu.pnum.GENERIC_G041G8UX.build.variant=STM32G0xx/G031G(4-6-8)U_G041G(6-8)U
-GenG0.menu.pnum.GENERIC_G041G8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
-
 # Generic G041J6Mx
 GenG0.menu.pnum.GENERIC_G041J6MX=Generic G041J6Mx
 GenG0.menu.pnum.GENERIC_G041J6MX.upload.maximum_size=32768
@@ -6915,15 +6923,6 @@ GenG0.menu.pnum.GENERIC_G041K6TX.build.product_line=STM32G041xx
 GenG0.menu.pnum.GENERIC_G041K6TX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G041K6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
 
-# Generic G041K6Ux
-GenG0.menu.pnum.GENERIC_G041K6UX=Generic G041K6Ux
-GenG0.menu.pnum.GENERIC_G041K6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G041K6UX.upload.maximum_data_size=8192
-GenG0.menu.pnum.GENERIC_G041K6UX.build.board=GENERIC_G041K6UX
-GenG0.menu.pnum.GENERIC_G041K6UX.build.product_line=STM32G041xx
-GenG0.menu.pnum.GENERIC_G041K6UX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G041K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
-
 # Generic G041K8Tx
 GenG0.menu.pnum.GENERIC_G041K8TX=Generic G041K8Tx
 GenG0.menu.pnum.GENERIC_G041K8TX.upload.maximum_size=65536
@@ -6932,6 +6931,15 @@ GenG0.menu.pnum.GENERIC_G041K8TX.build.board=GENERIC_G041K8TX
 GenG0.menu.pnum.GENERIC_G041K8TX.build.product_line=STM32G041xx
 GenG0.menu.pnum.GENERIC_G041K8TX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G041K8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
+
+# Generic G041K6Ux
+GenG0.menu.pnum.GENERIC_G041K6UX=Generic G041K6Ux
+GenG0.menu.pnum.GENERIC_G041K6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G041K6UX.upload.maximum_data_size=8192
+GenG0.menu.pnum.GENERIC_G041K6UX.build.board=GENERIC_G041K6UX
+GenG0.menu.pnum.GENERIC_G041K6UX.build.product_line=STM32G041xx
+GenG0.menu.pnum.GENERIC_G041K6UX.build.variant=STM32G0xx/G031K(4-6-8)(T-U)_G041K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G041K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G041.svd
 
 # Generic G041K8Ux
 GenG0.menu.pnum.GENERIC_G041K8UX=Generic G041K8Ux
@@ -7005,15 +7013,6 @@ GenG0.menu.pnum.GENERIC_G051C6TX.build.product_line=STM32G051xx
 GenG0.menu.pnum.GENERIC_G051C6TX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G051C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
 
-# Generic G051C6Ux
-GenG0.menu.pnum.GENERIC_G051C6UX=Generic G051C6Ux
-GenG0.menu.pnum.GENERIC_G051C6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G051C6UX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G051C6UX.build.board=GENERIC_G051C6UX
-GenG0.menu.pnum.GENERIC_G051C6UX.build.product_line=STM32G051xx
-GenG0.menu.pnum.GENERIC_G051C6UX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G051C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
-
 # Generic G051C8Tx
 GenG0.menu.pnum.GENERIC_G051C8TX=Generic G051C8Tx
 GenG0.menu.pnum.GENERIC_G051C8TX.upload.maximum_size=65536
@@ -7023,6 +7022,15 @@ GenG0.menu.pnum.GENERIC_G051C8TX.build.product_line=STM32G051xx
 GenG0.menu.pnum.GENERIC_G051C8TX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G051C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
 
+# Generic G051C6Ux
+GenG0.menu.pnum.GENERIC_G051C6UX=Generic G051C6Ux
+GenG0.menu.pnum.GENERIC_G051C6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G051C6UX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G051C6UX.build.board=GENERIC_G051C6UX
+GenG0.menu.pnum.GENERIC_G051C6UX.build.product_line=STM32G051xx
+GenG0.menu.pnum.GENERIC_G051C6UX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G051C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
+
 # Generic G051C8Ux
 GenG0.menu.pnum.GENERIC_G051C8UX=Generic G051C8Ux
 GenG0.menu.pnum.GENERIC_G051C8UX.upload.maximum_size=65536
@@ -7031,6 +7039,42 @@ GenG0.menu.pnum.GENERIC_G051C8UX.build.board=GENERIC_G051C8UX
 GenG0.menu.pnum.GENERIC_G051C8UX.build.product_line=STM32G051xx
 GenG0.menu.pnum.GENERIC_G051C8UX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G051C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
+
+# Generic G061C6Tx
+GenG0.menu.pnum.GENERIC_G061C6TX=Generic G061C6Tx
+GenG0.menu.pnum.GENERIC_G061C6TX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G061C6TX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G061C6TX.build.board=GENERIC_G061C6TX
+GenG0.menu.pnum.GENERIC_G061C6TX.build.product_line=STM32G061xx
+GenG0.menu.pnum.GENERIC_G061C6TX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G061C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
+
+# Generic G061C8Tx
+GenG0.menu.pnum.GENERIC_G061C8TX=Generic G061C8Tx
+GenG0.menu.pnum.GENERIC_G061C8TX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G061C8TX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G061C8TX.build.board=GENERIC_G061C8TX
+GenG0.menu.pnum.GENERIC_G061C8TX.build.product_line=STM32G061xx
+GenG0.menu.pnum.GENERIC_G061C8TX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G061C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
+
+# Generic G061C6Ux
+GenG0.menu.pnum.GENERIC_G061C6UX=Generic G061C6Ux
+GenG0.menu.pnum.GENERIC_G061C6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G061C6UX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G061C6UX.build.board=GENERIC_G061C6UX
+GenG0.menu.pnum.GENERIC_G061C6UX.build.product_line=STM32G061xx
+GenG0.menu.pnum.GENERIC_G061C6UX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G061C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
+
+# Generic G061C8Ux
+GenG0.menu.pnum.GENERIC_G061C8UX=Generic G061C8Ux
+GenG0.menu.pnum.GENERIC_G061C8UX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G061C8UX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G061C8UX.build.board=GENERIC_G061C8UX
+GenG0.menu.pnum.GENERIC_G061C8UX.build.product_line=STM32G061xx
+GenG0.menu.pnum.GENERIC_G061C8UX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G061C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
 
 # Generic G051F6Px
 GenG0.menu.pnum.GENERIC_G051F6PX=Generic G051F6Px
@@ -7059,96 +7103,6 @@ GenG0.menu.pnum.GENERIC_G051F8YX.build.product_line=STM32G051xx
 GenG0.menu.pnum.GENERIC_G051F8YX.build.variant=STM32G0xx/G051F6P_G051F8(P-Y)_G061F6P_G061F8(P-Y)
 GenG0.menu.pnum.GENERIC_G051F8YX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
 
-# Generic G051G6Ux
-GenG0.menu.pnum.GENERIC_G051G6UX=Generic G051G6Ux
-GenG0.menu.pnum.GENERIC_G051G6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G051G6UX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G051G6UX.build.board=GENERIC_G051G6UX
-GenG0.menu.pnum.GENERIC_G051G6UX.build.product_line=STM32G051xx
-GenG0.menu.pnum.GENERIC_G051G6UX.build.variant=STM32G0xx/G051G(6-8)U_G061G(6-8)U
-GenG0.menu.pnum.GENERIC_G051G6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
-
-# Generic G051G8Ux
-GenG0.menu.pnum.GENERIC_G051G8UX=Generic G051G8Ux
-GenG0.menu.pnum.GENERIC_G051G8UX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G051G8UX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G051G8UX.build.board=GENERIC_G051G8UX
-GenG0.menu.pnum.GENERIC_G051G8UX.build.product_line=STM32G051xx
-GenG0.menu.pnum.GENERIC_G051G8UX.build.variant=STM32G0xx/G051G(6-8)U_G061G(6-8)U
-GenG0.menu.pnum.GENERIC_G051G8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
-
-# Generic G051K6Tx
-GenG0.menu.pnum.GENERIC_G051K6TX=Generic G051K6Tx
-GenG0.menu.pnum.GENERIC_G051K6TX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G051K6TX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G051K6TX.build.board=GENERIC_G051K6TX
-GenG0.menu.pnum.GENERIC_G051K6TX.build.product_line=STM32G051xx
-GenG0.menu.pnum.GENERIC_G051K6TX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G051K6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
-
-# Generic G051K6Ux
-GenG0.menu.pnum.GENERIC_G051K6UX=Generic G051K6Ux
-GenG0.menu.pnum.GENERIC_G051K6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G051K6UX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G051K6UX.build.board=GENERIC_G051K6UX
-GenG0.menu.pnum.GENERIC_G051K6UX.build.product_line=STM32G051xx
-GenG0.menu.pnum.GENERIC_G051K6UX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G051K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
-
-# Generic G051K8Tx
-GenG0.menu.pnum.GENERIC_G051K8TX=Generic G051K8Tx
-GenG0.menu.pnum.GENERIC_G051K8TX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G051K8TX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G051K8TX.build.board=GENERIC_G051K8TX
-GenG0.menu.pnum.GENERIC_G051K8TX.build.product_line=STM32G051xx
-GenG0.menu.pnum.GENERIC_G051K8TX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G051K8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
-
-# Generic G051K8Ux
-GenG0.menu.pnum.GENERIC_G051K8UX=Generic G051K8Ux
-GenG0.menu.pnum.GENERIC_G051K8UX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G051K8UX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G051K8UX.build.board=GENERIC_G051K8UX
-GenG0.menu.pnum.GENERIC_G051K8UX.build.product_line=STM32G051xx
-GenG0.menu.pnum.GENERIC_G051K8UX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G051K8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
-
-# Generic G061C6Tx
-GenG0.menu.pnum.GENERIC_G061C6TX=Generic G061C6Tx
-GenG0.menu.pnum.GENERIC_G061C6TX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G061C6TX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G061C6TX.build.board=GENERIC_G061C6TX
-GenG0.menu.pnum.GENERIC_G061C6TX.build.product_line=STM32G061xx
-GenG0.menu.pnum.GENERIC_G061C6TX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G061C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
-
-# Generic G061C6Ux
-GenG0.menu.pnum.GENERIC_G061C6UX=Generic G061C6Ux
-GenG0.menu.pnum.GENERIC_G061C6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G061C6UX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G061C6UX.build.board=GENERIC_G061C6UX
-GenG0.menu.pnum.GENERIC_G061C6UX.build.product_line=STM32G061xx
-GenG0.menu.pnum.GENERIC_G061C6UX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G061C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
-
-# Generic G061C8Tx
-GenG0.menu.pnum.GENERIC_G061C8TX=Generic G061C8Tx
-GenG0.menu.pnum.GENERIC_G061C8TX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G061C8TX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G061C8TX.build.board=GENERIC_G061C8TX
-GenG0.menu.pnum.GENERIC_G061C8TX.build.product_line=STM32G061xx
-GenG0.menu.pnum.GENERIC_G061C8TX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G061C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
-
-# Generic G061C8Ux
-GenG0.menu.pnum.GENERIC_G061C8UX=Generic G061C8Ux
-GenG0.menu.pnum.GENERIC_G061C8UX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G061C8UX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G061C8UX.build.board=GENERIC_G061C8UX
-GenG0.menu.pnum.GENERIC_G061C8UX.build.product_line=STM32G061xx
-GenG0.menu.pnum.GENERIC_G061C8UX.build.variant=STM32G0xx/G051C(6-8)(T-U)_G061C(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G061C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
-
 # Generic G061F6Px
 GenG0.menu.pnum.GENERIC_G061F6PX=Generic G061F6Px
 GenG0.menu.pnum.GENERIC_G061F6PX.upload.maximum_size=32768
@@ -7176,6 +7130,24 @@ GenG0.menu.pnum.GENERIC_G061F8YX.build.product_line=STM32G061xx
 GenG0.menu.pnum.GENERIC_G061F8YX.build.variant=STM32G0xx/G051F6P_G051F8(P-Y)_G061F6P_G061F8(P-Y)
 GenG0.menu.pnum.GENERIC_G061F8YX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
 
+# Generic G051G6Ux
+GenG0.menu.pnum.GENERIC_G051G6UX=Generic G051G6Ux
+GenG0.menu.pnum.GENERIC_G051G6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G051G6UX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G051G6UX.build.board=GENERIC_G051G6UX
+GenG0.menu.pnum.GENERIC_G051G6UX.build.product_line=STM32G051xx
+GenG0.menu.pnum.GENERIC_G051G6UX.build.variant=STM32G0xx/G051G(6-8)U_G061G(6-8)U
+GenG0.menu.pnum.GENERIC_G051G6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
+
+# Generic G051G8Ux
+GenG0.menu.pnum.GENERIC_G051G8UX=Generic G051G8Ux
+GenG0.menu.pnum.GENERIC_G051G8UX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G051G8UX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G051G8UX.build.board=GENERIC_G051G8UX
+GenG0.menu.pnum.GENERIC_G051G8UX.build.product_line=STM32G051xx
+GenG0.menu.pnum.GENERIC_G051G8UX.build.variant=STM32G0xx/G051G(6-8)U_G061G(6-8)U
+GenG0.menu.pnum.GENERIC_G051G8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
+
 # Generic G061G6Ux
 GenG0.menu.pnum.GENERIC_G061G6UX=Generic G061G6Ux
 GenG0.menu.pnum.GENERIC_G061G6UX.upload.maximum_size=32768
@@ -7194,6 +7166,42 @@ GenG0.menu.pnum.GENERIC_G061G8UX.build.product_line=STM32G061xx
 GenG0.menu.pnum.GENERIC_G061G8UX.build.variant=STM32G0xx/G051G(6-8)U_G061G(6-8)U
 GenG0.menu.pnum.GENERIC_G061G8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
 
+# Generic G051K6Tx
+GenG0.menu.pnum.GENERIC_G051K6TX=Generic G051K6Tx
+GenG0.menu.pnum.GENERIC_G051K6TX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G051K6TX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G051K6TX.build.board=GENERIC_G051K6TX
+GenG0.menu.pnum.GENERIC_G051K6TX.build.product_line=STM32G051xx
+GenG0.menu.pnum.GENERIC_G051K6TX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G051K6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
+
+# Generic G051K8Tx
+GenG0.menu.pnum.GENERIC_G051K8TX=Generic G051K8Tx
+GenG0.menu.pnum.GENERIC_G051K8TX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G051K8TX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G051K8TX.build.board=GENERIC_G051K8TX
+GenG0.menu.pnum.GENERIC_G051K8TX.build.product_line=STM32G051xx
+GenG0.menu.pnum.GENERIC_G051K8TX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G051K8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
+
+# Generic G051K6Ux
+GenG0.menu.pnum.GENERIC_G051K6UX=Generic G051K6Ux
+GenG0.menu.pnum.GENERIC_G051K6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G051K6UX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G051K6UX.build.board=GENERIC_G051K6UX
+GenG0.menu.pnum.GENERIC_G051K6UX.build.product_line=STM32G051xx
+GenG0.menu.pnum.GENERIC_G051K6UX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G051K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
+
+# Generic G051K8Ux
+GenG0.menu.pnum.GENERIC_G051K8UX=Generic G051K8Ux
+GenG0.menu.pnum.GENERIC_G051K8UX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G051K8UX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G051K8UX.build.board=GENERIC_G051K8UX
+GenG0.menu.pnum.GENERIC_G051K8UX.build.product_line=STM32G051xx
+GenG0.menu.pnum.GENERIC_G051K8UX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G051K8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G051.svd
+
 # Generic G061K6Tx
 GenG0.menu.pnum.GENERIC_G061K6TX=Generic G061K6Tx
 GenG0.menu.pnum.GENERIC_G061K6TX.upload.maximum_size=32768
@@ -7203,15 +7211,6 @@ GenG0.menu.pnum.GENERIC_G061K6TX.build.product_line=STM32G061xx
 GenG0.menu.pnum.GENERIC_G061K6TX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G061K6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
 
-# Generic G061K6Ux
-GenG0.menu.pnum.GENERIC_G061K6UX=Generic G061K6Ux
-GenG0.menu.pnum.GENERIC_G061K6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G061K6UX.upload.maximum_data_size=18432
-GenG0.menu.pnum.GENERIC_G061K6UX.build.board=GENERIC_G061K6UX
-GenG0.menu.pnum.GENERIC_G061K6UX.build.product_line=STM32G061xx
-GenG0.menu.pnum.GENERIC_G061K6UX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
-GenG0.menu.pnum.GENERIC_G061K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
-
 # Generic G061K8Tx
 GenG0.menu.pnum.GENERIC_G061K8TX=Generic G061K8Tx
 GenG0.menu.pnum.GENERIC_G061K8TX.upload.maximum_size=65536
@@ -7220,6 +7219,15 @@ GenG0.menu.pnum.GENERIC_G061K8TX.build.board=GENERIC_G061K8TX
 GenG0.menu.pnum.GENERIC_G061K8TX.build.product_line=STM32G061xx
 GenG0.menu.pnum.GENERIC_G061K8TX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
 GenG0.menu.pnum.GENERIC_G061K8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
+
+# Generic G061K6Ux
+GenG0.menu.pnum.GENERIC_G061K6UX=Generic G061K6Ux
+GenG0.menu.pnum.GENERIC_G061K6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G061K6UX.upload.maximum_data_size=18432
+GenG0.menu.pnum.GENERIC_G061K6UX.build.board=GENERIC_G061K6UX
+GenG0.menu.pnum.GENERIC_G061K6UX.build.product_line=STM32G061xx
+GenG0.menu.pnum.GENERIC_G061K6UX.build.variant=STM32G0xx/G051K(6-8)(T-U)_G061K(6-8)(T-U)
+GenG0.menu.pnum.GENERIC_G061K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G061.svd
 
 # Generic G061K8Ux
 GenG0.menu.pnum.GENERIC_G061K8UX=Generic G061K8Ux
@@ -7238,6 +7246,60 @@ GenG0.menu.pnum.GENERIC_G070CBTX.build.board=GENERIC_G070CBTX
 GenG0.menu.pnum.GENERIC_G070CBTX.build.product_line=STM32G070xx
 GenG0.menu.pnum.GENERIC_G070CBTX.build.variant=STM32G0xx/G070CBT
 GenG0.menu.pnum.GENERIC_G070CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G070.svd
+
+# Generic G071EBYx
+GenG0.menu.pnum.GENERIC_G071EBYX=Generic G071EBYx
+GenG0.menu.pnum.GENERIC_G071EBYX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G071EBYX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G071EBYX.build.board=GENERIC_G071EBYX
+GenG0.menu.pnum.GENERIC_G071EBYX.build.product_line=STM32G071xx
+GenG0.menu.pnum.GENERIC_G071EBYX.build.variant=STM32G0xx/G071EBY_G081EBY
+GenG0.menu.pnum.GENERIC_G071EBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
+# Generic G081EBYx
+GenG0.menu.pnum.GENERIC_G081EBYX=Generic G081EBYx
+GenG0.menu.pnum.GENERIC_G081EBYX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G081EBYX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G081EBYX.build.board=GENERIC_G081EBYX
+GenG0.menu.pnum.GENERIC_G081EBYX.build.product_line=STM32G081xx
+GenG0.menu.pnum.GENERIC_G081EBYX.build.variant=STM32G0xx/G071EBY_G081EBY
+GenG0.menu.pnum.GENERIC_G081EBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
+
+# Generic G071G6Ux
+GenG0.menu.pnum.GENERIC_G071G6UX=Generic G071G6Ux
+GenG0.menu.pnum.GENERIC_G071G6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G071G6UX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G071G6UX.build.board=GENERIC_G071G6UX
+GenG0.menu.pnum.GENERIC_G071G6UX.build.product_line=STM32G071xx
+GenG0.menu.pnum.GENERIC_G071G6UX.build.variant=STM32G0xx/G071G(6-8-B)U_G081GBU
+GenG0.menu.pnum.GENERIC_G071G6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
+# Generic G071G8Ux
+GenG0.menu.pnum.GENERIC_G071G8UX=Generic G071G8Ux
+GenG0.menu.pnum.GENERIC_G071G8UX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G071G8UX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G071G8UX.build.board=GENERIC_G071G8UX
+GenG0.menu.pnum.GENERIC_G071G8UX.build.product_line=STM32G071xx
+GenG0.menu.pnum.GENERIC_G071G8UX.build.variant=STM32G0xx/G071G(6-8-B)U_G081GBU
+GenG0.menu.pnum.GENERIC_G071G8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
+# Generic G071GBUx
+GenG0.menu.pnum.GENERIC_G071GBUX=Generic G071GBUx
+GenG0.menu.pnum.GENERIC_G071GBUX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G071GBUX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G071GBUX.build.board=GENERIC_G071GBUX
+GenG0.menu.pnum.GENERIC_G071GBUX.build.product_line=STM32G071xx
+GenG0.menu.pnum.GENERIC_G071GBUX.build.variant=STM32G0xx/G071G(6-8-B)U_G081GBU
+GenG0.menu.pnum.GENERIC_G071GBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
+# Generic G081GBUx
+GenG0.menu.pnum.GENERIC_G081GBUX=Generic G081GBUx
+GenG0.menu.pnum.GENERIC_G081GBUX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G081GBUX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G081GBUX.build.board=GENERIC_G081GBUX
+GenG0.menu.pnum.GENERIC_G081GBUX.build.product_line=STM32G081xx
+GenG0.menu.pnum.GENERIC_G081GBUX.build.variant=STM32G0xx/G071G(6-8-B)U_G081GBU
+GenG0.menu.pnum.GENERIC_G081GBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
 
 # Generic G070KBTx
 GenG0.menu.pnum.GENERIC_G070KBTX=Generic G070KBTx
@@ -7266,15 +7328,6 @@ GenG0.menu.pnum.GENERIC_G071C6TX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071C6TX.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
 GenG0.menu.pnum.GENERIC_G071C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
-# Generic G071C6Ux
-GenG0.menu.pnum.GENERIC_G071C6UX=Generic G071C6Ux
-GenG0.menu.pnum.GENERIC_G071C6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G071C6UX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G071C6UX.build.board=GENERIC_G071C6UX
-GenG0.menu.pnum.GENERIC_G071C6UX.build.product_line=STM32G071xx
-GenG0.menu.pnum.GENERIC_G071C6UX.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
-GenG0.menu.pnum.GENERIC_G071C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
-
 # Generic G071C8Tx
 GenG0.menu.pnum.GENERIC_G071C8TX=Generic G071C8Tx
 GenG0.menu.pnum.GENERIC_G071C8TX.upload.maximum_size=65536
@@ -7283,15 +7336,6 @@ GenG0.menu.pnum.GENERIC_G071C8TX.build.board=GENERIC_G071C8TX
 GenG0.menu.pnum.GENERIC_G071C8TX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071C8TX.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
 GenG0.menu.pnum.GENERIC_G071C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
-
-# Generic G071C8Ux
-GenG0.menu.pnum.GENERIC_G071C8UX=Generic G071C8Ux
-GenG0.menu.pnum.GENERIC_G071C8UX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G071C8UX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G071C8UX.build.board=GENERIC_G071C8UX
-GenG0.menu.pnum.GENERIC_G071C8UX.build.product_line=STM32G071xx
-GenG0.menu.pnum.GENERIC_G071C8UX.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
-GenG0.menu.pnum.GENERIC_G071C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
 # Generic G071CBTx
 GenG0.menu.pnum.GENERIC_G071CBTX=Generic G071CBTx
@@ -7302,6 +7346,24 @@ GenG0.menu.pnum.GENERIC_G071CBTX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071CBTX.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
 GenG0.menu.pnum.GENERIC_G071CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
+# Generic G071C6Ux
+GenG0.menu.pnum.GENERIC_G071C6UX=Generic G071C6Ux
+GenG0.menu.pnum.GENERIC_G071C6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G071C6UX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G071C6UX.build.board=GENERIC_G071C6UX
+GenG0.menu.pnum.GENERIC_G071C6UX.build.product_line=STM32G071xx
+GenG0.menu.pnum.GENERIC_G071C6UX.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
+GenG0.menu.pnum.GENERIC_G071C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
+# Generic G071C8Ux
+GenG0.menu.pnum.GENERIC_G071C8UX=Generic G071C8Ux
+GenG0.menu.pnum.GENERIC_G071C8UX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G071C8UX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G071C8UX.build.board=GENERIC_G071C8UX
+GenG0.menu.pnum.GENERIC_G071C8UX.build.product_line=STM32G071xx
+GenG0.menu.pnum.GENERIC_G071C8UX.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
+GenG0.menu.pnum.GENERIC_G071C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
 # Generic G071CBUx
 GenG0.menu.pnum.GENERIC_G071CBUX=Generic G071CBUx
 GenG0.menu.pnum.GENERIC_G071CBUX.upload.maximum_size=131072
@@ -7311,33 +7373,6 @@ GenG0.menu.pnum.GENERIC_G071CBUX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071CBUX.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
 GenG0.menu.pnum.GENERIC_G071CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
-# Generic G071EBYx
-GenG0.menu.pnum.GENERIC_G071EBYX=Generic G071EBYx
-GenG0.menu.pnum.GENERIC_G071EBYX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G071EBYX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G071EBYX.build.board=GENERIC_G071EBYX
-GenG0.menu.pnum.GENERIC_G071EBYX.build.product_line=STM32G071xx
-GenG0.menu.pnum.GENERIC_G071EBYX.build.variant=STM32G0xx/G071EBY_G081EBY
-GenG0.menu.pnum.GENERIC_G071EBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
-
-# Generic G071G6Ux
-GenG0.menu.pnum.GENERIC_G071G6UX=Generic G071G6Ux
-GenG0.menu.pnum.GENERIC_G071G6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G071G6UX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G071G6UX.build.board=GENERIC_G071G6UX
-GenG0.menu.pnum.GENERIC_G071G6UX.build.product_line=STM32G071xx
-GenG0.menu.pnum.GENERIC_G071G6UX.build.variant=STM32G0xx/G071G(6-8-B)U_G081GBU
-GenG0.menu.pnum.GENERIC_G071G6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
-
-# Generic G071G8Ux
-GenG0.menu.pnum.GENERIC_G071G8UX=Generic G071G8Ux
-GenG0.menu.pnum.GENERIC_G071G8UX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G071G8UX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G071G8UX.build.board=GENERIC_G071G8UX
-GenG0.menu.pnum.GENERIC_G071G8UX.build.product_line=STM32G071xx
-GenG0.menu.pnum.GENERIC_G071G8UX.build.variant=STM32G0xx/G071G(6-8-B)U_G081GBU
-GenG0.menu.pnum.GENERIC_G071G8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
-
 # Generic G071G8UxN
 GenG0.menu.pnum.GENERIC_G071G8UXN=Generic G071G8UxN
 GenG0.menu.pnum.GENERIC_G071G8UXN.upload.maximum_size=65536
@@ -7346,15 +7381,6 @@ GenG0.menu.pnum.GENERIC_G071G8UXN.build.board=GENERIC_G071G8UXN
 GenG0.menu.pnum.GENERIC_G071G8UXN.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071G8UXN.build.variant=STM32G0xx/G071G(8-B)UxN_G081GBUxN
 GenG0.menu.pnum.GENERIC_G071G8UXN.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
-
-# Generic G071GBUx
-GenG0.menu.pnum.GENERIC_G071GBUX=Generic G071GBUx
-GenG0.menu.pnum.GENERIC_G071GBUX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G071GBUX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G071GBUX.build.board=GENERIC_G071GBUX
-GenG0.menu.pnum.GENERIC_G071GBUX.build.product_line=STM32G071xx
-GenG0.menu.pnum.GENERIC_G071GBUX.build.variant=STM32G0xx/G071G(6-8-B)U_G081GBU
-GenG0.menu.pnum.GENERIC_G071GBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
 # Generic G071GBUxN
 GenG0.menu.pnum.GENERIC_G071GBUXN=Generic G071GBUxN
@@ -7374,15 +7400,6 @@ GenG0.menu.pnum.GENERIC_G071K6TX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071K6TX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
 GenG0.menu.pnum.GENERIC_G071K6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
-# Generic G071K6Ux
-GenG0.menu.pnum.GENERIC_G071K6UX=Generic G071K6Ux
-GenG0.menu.pnum.GENERIC_G071K6UX.upload.maximum_size=32768
-GenG0.menu.pnum.GENERIC_G071K6UX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G071K6UX.build.board=GENERIC_G071K6UX
-GenG0.menu.pnum.GENERIC_G071K6UX.build.product_line=STM32G071xx
-GenG0.menu.pnum.GENERIC_G071K6UX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
-GenG0.menu.pnum.GENERIC_G071K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
-
 # Generic G071K8Tx
 GenG0.menu.pnum.GENERIC_G071K8TX=Generic G071K8Tx
 GenG0.menu.pnum.GENERIC_G071K8TX.upload.maximum_size=65536
@@ -7391,15 +7408,6 @@ GenG0.menu.pnum.GENERIC_G071K8TX.build.board=GENERIC_G071K8TX
 GenG0.menu.pnum.GENERIC_G071K8TX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071K8TX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
 GenG0.menu.pnum.GENERIC_G071K8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
-
-# Generic G071K8Ux
-GenG0.menu.pnum.GENERIC_G071K8UX=Generic G071K8Ux
-GenG0.menu.pnum.GENERIC_G071K8UX.upload.maximum_size=65536
-GenG0.menu.pnum.GENERIC_G071K8UX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G071K8UX.build.board=GENERIC_G071K8UX
-GenG0.menu.pnum.GENERIC_G071K8UX.build.product_line=STM32G071xx
-GenG0.menu.pnum.GENERIC_G071K8UX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
-GenG0.menu.pnum.GENERIC_G071K8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
 # Generic G071KBTx
 GenG0.menu.pnum.GENERIC_G071KBTX=Generic G071KBTx
@@ -7410,6 +7418,24 @@ GenG0.menu.pnum.GENERIC_G071KBTX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071KBTX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
 GenG0.menu.pnum.GENERIC_G071KBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
+# Generic G071K6Ux
+GenG0.menu.pnum.GENERIC_G071K6UX=Generic G071K6Ux
+GenG0.menu.pnum.GENERIC_G071K6UX.upload.maximum_size=32768
+GenG0.menu.pnum.GENERIC_G071K6UX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G071K6UX.build.board=GENERIC_G071K6UX
+GenG0.menu.pnum.GENERIC_G071K6UX.build.product_line=STM32G071xx
+GenG0.menu.pnum.GENERIC_G071K6UX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
+GenG0.menu.pnum.GENERIC_G071K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
+# Generic G071K8Ux
+GenG0.menu.pnum.GENERIC_G071K8UX=Generic G071K8Ux
+GenG0.menu.pnum.GENERIC_G071K8UX.upload.maximum_size=65536
+GenG0.menu.pnum.GENERIC_G071K8UX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G071K8UX.build.board=GENERIC_G071K8UX
+GenG0.menu.pnum.GENERIC_G071K8UX.build.product_line=STM32G071xx
+GenG0.menu.pnum.GENERIC_G071K8UX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
+GenG0.menu.pnum.GENERIC_G071K8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
 # Generic G071KBUx
 GenG0.menu.pnum.GENERIC_G071KBUX=Generic G071KBUx
 GenG0.menu.pnum.GENERIC_G071KBUX.upload.maximum_size=131072
@@ -7418,6 +7444,24 @@ GenG0.menu.pnum.GENERIC_G071KBUX.build.board=GENERIC_G071KBUX
 GenG0.menu.pnum.GENERIC_G071KBUX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071KBUX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
 GenG0.menu.pnum.GENERIC_G071KBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
+# Generic G081KBTx
+GenG0.menu.pnum.GENERIC_G081KBTX=Generic G081KBTx
+GenG0.menu.pnum.GENERIC_G081KBTX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G081KBTX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G081KBTX.build.board=GENERIC_G081KBTX
+GenG0.menu.pnum.GENERIC_G081KBTX.build.product_line=STM32G081xx
+GenG0.menu.pnum.GENERIC_G081KBTX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
+GenG0.menu.pnum.GENERIC_G081KBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
+
+# Generic G081KBUx
+GenG0.menu.pnum.GENERIC_G081KBUX=Generic G081KBUx
+GenG0.menu.pnum.GENERIC_G081KBUX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G081KBUX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G081KBUX.build.board=GENERIC_G081KBUX
+GenG0.menu.pnum.GENERIC_G081KBUX.build.product_line=STM32G081xx
+GenG0.menu.pnum.GENERIC_G081KBUX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
+GenG0.menu.pnum.GENERIC_G081KBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
 
 # Generic G071R6Tx
 GenG0.menu.pnum.GENERIC_G071R6TX=Generic G071R6Tx
@@ -7437,15 +7481,6 @@ GenG0.menu.pnum.GENERIC_G071R8TX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071R8TX.build.variant=STM32G0xx/G071R(6-8)T_G071RB(I-T)_G081RB(I-T)
 GenG0.menu.pnum.GENERIC_G071R8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
-# Generic G071RBIx
-GenG0.menu.pnum.GENERIC_G071RBIX=Generic G071RBIx
-GenG0.menu.pnum.GENERIC_G071RBIX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G071RBIX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G071RBIX.build.board=GENERIC_G071RBIX
-GenG0.menu.pnum.GENERIC_G071RBIX.build.product_line=STM32G071xx
-GenG0.menu.pnum.GENERIC_G071RBIX.build.variant=STM32G0xx/G071R(6-8)T_G071RB(I-T)_G081RB(I-T)
-GenG0.menu.pnum.GENERIC_G071RBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
-
 # Generic G071RBTx
 GenG0.menu.pnum.GENERIC_G071RBTX=Generic G071RBTx
 GenG0.menu.pnum.GENERIC_G071RBTX.upload.maximum_size=131072
@@ -7454,6 +7489,15 @@ GenG0.menu.pnum.GENERIC_G071RBTX.build.board=GENERIC_G071RBTX
 GenG0.menu.pnum.GENERIC_G071RBTX.build.product_line=STM32G071xx
 GenG0.menu.pnum.GENERIC_G071RBTX.build.variant=STM32G0xx/G071R(6-8)T_G071RB(I-T)_G081RB(I-T)
 GenG0.menu.pnum.GENERIC_G071RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
+
+# Generic G071RBIx
+GenG0.menu.pnum.GENERIC_G071RBIX=Generic G071RBIx
+GenG0.menu.pnum.GENERIC_G071RBIX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G071RBIX.upload.maximum_data_size=36864
+GenG0.menu.pnum.GENERIC_G071RBIX.build.board=GENERIC_G071RBIX
+GenG0.menu.pnum.GENERIC_G071RBIX.build.product_line=STM32G071xx
+GenG0.menu.pnum.GENERIC_G071RBIX.build.variant=STM32G0xx/G071R(6-8)T_G071RB(I-T)_G081RB(I-T)
+GenG0.menu.pnum.GENERIC_G071RBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G071.svd
 
 # Generic G081CBTx
 GenG0.menu.pnum.GENERIC_G081CBTX=Generic G081CBTx
@@ -7473,24 +7517,6 @@ GenG0.menu.pnum.GENERIC_G081CBUX.build.product_line=STM32G081xx
 GenG0.menu.pnum.GENERIC_G081CBUX.build.variant=STM32G0xx/G071C(6-8-B)(T-U)_G081CB(T-U)
 GenG0.menu.pnum.GENERIC_G081CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
 
-# Generic G081EBYx
-GenG0.menu.pnum.GENERIC_G081EBYX=Generic G081EBYx
-GenG0.menu.pnum.GENERIC_G081EBYX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G081EBYX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G081EBYX.build.board=GENERIC_G081EBYX
-GenG0.menu.pnum.GENERIC_G081EBYX.build.product_line=STM32G081xx
-GenG0.menu.pnum.GENERIC_G081EBYX.build.variant=STM32G0xx/G071EBY_G081EBY
-GenG0.menu.pnum.GENERIC_G081EBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
-
-# Generic G081GBUx
-GenG0.menu.pnum.GENERIC_G081GBUX=Generic G081GBUx
-GenG0.menu.pnum.GENERIC_G081GBUX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G081GBUX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G081GBUX.build.board=GENERIC_G081GBUX
-GenG0.menu.pnum.GENERIC_G081GBUX.build.product_line=STM32G081xx
-GenG0.menu.pnum.GENERIC_G081GBUX.build.variant=STM32G0xx/G071G(6-8-B)U_G081GBU
-GenG0.menu.pnum.GENERIC_G081GBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
-
 # Generic G081GBUxN
 GenG0.menu.pnum.GENERIC_G081GBUXN=Generic G081GBUxN
 GenG0.menu.pnum.GENERIC_G081GBUXN.upload.maximum_size=131072
@@ -7499,24 +7525,6 @@ GenG0.menu.pnum.GENERIC_G081GBUXN.build.board=GENERIC_G081GBUXN
 GenG0.menu.pnum.GENERIC_G081GBUXN.build.product_line=STM32G081xx
 GenG0.menu.pnum.GENERIC_G081GBUXN.build.variant=STM32G0xx/G071G(8-B)UxN_G081GBUxN
 GenG0.menu.pnum.GENERIC_G081GBUXN.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
-
-# Generic G081KBTx
-GenG0.menu.pnum.GENERIC_G081KBTX=Generic G081KBTx
-GenG0.menu.pnum.GENERIC_G081KBTX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G081KBTX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G081KBTX.build.board=GENERIC_G081KBTX
-GenG0.menu.pnum.GENERIC_G081KBTX.build.product_line=STM32G081xx
-GenG0.menu.pnum.GENERIC_G081KBTX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
-GenG0.menu.pnum.GENERIC_G081KBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
-
-# Generic G081KBUx
-GenG0.menu.pnum.GENERIC_G081KBUX=Generic G081KBUx
-GenG0.menu.pnum.GENERIC_G081KBUX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G081KBUX.upload.maximum_data_size=36864
-GenG0.menu.pnum.GENERIC_G081KBUX.build.board=GENERIC_G081KBUX
-GenG0.menu.pnum.GENERIC_G081KBUX.build.product_line=STM32G081xx
-GenG0.menu.pnum.GENERIC_G081KBUX.build.variant=STM32G0xx/G071K(6-8-B)(T-U)_G081KB(T-U)
-GenG0.menu.pnum.GENERIC_G081KBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G081.svd
 
 # Generic G081RBIx
 GenG0.menu.pnum.GENERIC_G081RBIX=Generic G081RBIx
@@ -7572,15 +7580,6 @@ GenG0.menu.pnum.GENERIC_G0B1CBTX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1CBTX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0B1CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
-# Generic G0B1CBUx
-GenG0.menu.pnum.GENERIC_G0B1CBUX=Generic G0B1CBUx
-GenG0.menu.pnum.GENERIC_G0B1CBUX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G0B1CBUX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0B1CBUX.build.board=GENERIC_G0B1CBUX
-GenG0.menu.pnum.GENERIC_G0B1CBUX.build.product_line=STM32G0B1xx
-GenG0.menu.pnum.GENERIC_G0B1CBUX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
-GenG0.menu.pnum.GENERIC_G0B1CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
-
 # Generic G0B1CCTx
 GenG0.menu.pnum.GENERIC_G0B1CCTX=Generic G0B1CCTx
 GenG0.menu.pnum.GENERIC_G0B1CCTX.upload.maximum_size=262144
@@ -7590,15 +7589,6 @@ GenG0.menu.pnum.GENERIC_G0B1CCTX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1CCTX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0B1CCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
-# Generic G0B1CCUx
-GenG0.menu.pnum.GENERIC_G0B1CCUX=Generic G0B1CCUx
-GenG0.menu.pnum.GENERIC_G0B1CCUX.upload.maximum_size=262144
-GenG0.menu.pnum.GENERIC_G0B1CCUX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0B1CCUX.build.board=GENERIC_G0B1CCUX
-GenG0.menu.pnum.GENERIC_G0B1CCUX.build.product_line=STM32G0B1xx
-GenG0.menu.pnum.GENERIC_G0B1CCUX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
-GenG0.menu.pnum.GENERIC_G0B1CCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
-
 # Generic G0B1CETx
 GenG0.menu.pnum.GENERIC_G0B1CETX=Generic G0B1CETx
 GenG0.menu.pnum.GENERIC_G0B1CETX.upload.maximum_size=524288
@@ -7607,6 +7597,24 @@ GenG0.menu.pnum.GENERIC_G0B1CETX.build.board=GENERIC_G0B1CETX
 GenG0.menu.pnum.GENERIC_G0B1CETX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1CETX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0B1CETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
+
+# Generic G0B1CBUx
+GenG0.menu.pnum.GENERIC_G0B1CBUX=Generic G0B1CBUx
+GenG0.menu.pnum.GENERIC_G0B1CBUX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G0B1CBUX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0B1CBUX.build.board=GENERIC_G0B1CBUX
+GenG0.menu.pnum.GENERIC_G0B1CBUX.build.product_line=STM32G0B1xx
+GenG0.menu.pnum.GENERIC_G0B1CBUX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
+GenG0.menu.pnum.GENERIC_G0B1CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
+
+# Generic G0B1CCUx
+GenG0.menu.pnum.GENERIC_G0B1CCUX=Generic G0B1CCUx
+GenG0.menu.pnum.GENERIC_G0B1CCUX.upload.maximum_size=262144
+GenG0.menu.pnum.GENERIC_G0B1CCUX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0B1CCUX.build.board=GENERIC_G0B1CCUX
+GenG0.menu.pnum.GENERIC_G0B1CCUX.build.product_line=STM32G0B1xx
+GenG0.menu.pnum.GENERIC_G0B1CCUX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
+GenG0.menu.pnum.GENERIC_G0B1CCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
 # Generic G0B1CEUx
 GenG0.menu.pnum.GENERIC_G0B1CEUX=Generic G0B1CEUx
@@ -7626,15 +7634,6 @@ GenG0.menu.pnum.GENERIC_G0B1KBTX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1KBTX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0B1KBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
-# Generic G0B1KBUx
-GenG0.menu.pnum.GENERIC_G0B1KBUX=Generic G0B1KBUx
-GenG0.menu.pnum.GENERIC_G0B1KBUX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G0B1KBUX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0B1KBUX.build.board=GENERIC_G0B1KBUX
-GenG0.menu.pnum.GENERIC_G0B1KBUX.build.product_line=STM32G0B1xx
-GenG0.menu.pnum.GENERIC_G0B1KBUX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
-GenG0.menu.pnum.GENERIC_G0B1KBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
-
 # Generic G0B1KCTx
 GenG0.menu.pnum.GENERIC_G0B1KCTX=Generic G0B1KCTx
 GenG0.menu.pnum.GENERIC_G0B1KCTX.upload.maximum_size=262144
@@ -7643,15 +7642,6 @@ GenG0.menu.pnum.GENERIC_G0B1KCTX.build.board=GENERIC_G0B1KCTX
 GenG0.menu.pnum.GENERIC_G0B1KCTX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1KCTX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0B1KCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
-
-# Generic G0B1KCUx
-GenG0.menu.pnum.GENERIC_G0B1KCUX=Generic G0B1KCUx
-GenG0.menu.pnum.GENERIC_G0B1KCUX.upload.maximum_size=262144
-GenG0.menu.pnum.GENERIC_G0B1KCUX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0B1KCUX.build.board=GENERIC_G0B1KCUX
-GenG0.menu.pnum.GENERIC_G0B1KCUX.build.product_line=STM32G0B1xx
-GenG0.menu.pnum.GENERIC_G0B1KCUX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
-GenG0.menu.pnum.GENERIC_G0B1KCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
 # Generic G0B1KETx
 GenG0.menu.pnum.GENERIC_G0B1KETX=Generic G0B1KETx
@@ -7662,6 +7652,24 @@ GenG0.menu.pnum.GENERIC_G0B1KETX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1KETX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0B1KETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
+# Generic G0B1KBUx
+GenG0.menu.pnum.GENERIC_G0B1KBUX=Generic G0B1KBUx
+GenG0.menu.pnum.GENERIC_G0B1KBUX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G0B1KBUX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0B1KBUX.build.board=GENERIC_G0B1KBUX
+GenG0.menu.pnum.GENERIC_G0B1KBUX.build.product_line=STM32G0B1xx
+GenG0.menu.pnum.GENERIC_G0B1KBUX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
+GenG0.menu.pnum.GENERIC_G0B1KBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
+
+# Generic G0B1KCUx
+GenG0.menu.pnum.GENERIC_G0B1KCUX=Generic G0B1KCUx
+GenG0.menu.pnum.GENERIC_G0B1KCUX.upload.maximum_size=262144
+GenG0.menu.pnum.GENERIC_G0B1KCUX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0B1KCUX.build.board=GENERIC_G0B1KCUX
+GenG0.menu.pnum.GENERIC_G0B1KCUX.build.product_line=STM32G0B1xx
+GenG0.menu.pnum.GENERIC_G0B1KCUX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
+GenG0.menu.pnum.GENERIC_G0B1KCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
+
 # Generic G0B1KEUx
 GenG0.menu.pnum.GENERIC_G0B1KEUX=Generic G0B1KEUx
 GenG0.menu.pnum.GENERIC_G0B1KEUX.upload.maximum_size=524288
@@ -7670,6 +7678,42 @@ GenG0.menu.pnum.GENERIC_G0B1KEUX.build.board=GENERIC_G0B1KEUX
 GenG0.menu.pnum.GENERIC_G0B1KEUX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1KEUX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0B1KEUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
+
+# Generic G0C1KCTx
+GenG0.menu.pnum.GENERIC_G0C1KCTX=Generic G0C1KCTx
+GenG0.menu.pnum.GENERIC_G0C1KCTX.upload.maximum_size=262144
+GenG0.menu.pnum.GENERIC_G0C1KCTX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1KCTX.build.board=GENERIC_G0C1KCTX
+GenG0.menu.pnum.GENERIC_G0C1KCTX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1KCTX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
+GenG0.menu.pnum.GENERIC_G0C1KCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
+
+# Generic G0C1KETx
+GenG0.menu.pnum.GENERIC_G0C1KETX=Generic G0C1KETx
+GenG0.menu.pnum.GENERIC_G0C1KETX.upload.maximum_size=524288
+GenG0.menu.pnum.GENERIC_G0C1KETX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1KETX.build.board=GENERIC_G0C1KETX
+GenG0.menu.pnum.GENERIC_G0C1KETX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1KETX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
+GenG0.menu.pnum.GENERIC_G0C1KETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
+
+# Generic G0C1KCUx
+GenG0.menu.pnum.GENERIC_G0C1KCUX=Generic G0C1KCUx
+GenG0.menu.pnum.GENERIC_G0C1KCUX.upload.maximum_size=262144
+GenG0.menu.pnum.GENERIC_G0C1KCUX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1KCUX.build.board=GENERIC_G0C1KCUX
+GenG0.menu.pnum.GENERIC_G0C1KCUX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1KCUX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
+GenG0.menu.pnum.GENERIC_G0C1KCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
+
+# Generic G0C1KEUx
+GenG0.menu.pnum.GENERIC_G0C1KEUX=Generic G0C1KEUx
+GenG0.menu.pnum.GENERIC_G0C1KEUX.upload.maximum_size=524288
+GenG0.menu.pnum.GENERIC_G0C1KEUX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1KEUX.build.board=GENERIC_G0C1KEUX
+GenG0.menu.pnum.GENERIC_G0C1KEUX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1KEUX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
+GenG0.menu.pnum.GENERIC_G0C1KEUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
 
 # Generic G0B1MBTx
 GenG0.menu.pnum.GENERIC_G0B1MBTX=Generic G0B1MBTx
@@ -7698,6 +7742,24 @@ GenG0.menu.pnum.GENERIC_G0B1METX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1METX.build.variant=STM32G0xx/G0B1M(B-C-E)T_G0C1M(C-E)T
 GenG0.menu.pnum.GENERIC_G0B1METX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
+# Generic G0C1MCTx
+GenG0.menu.pnum.GENERIC_G0C1MCTX=Generic G0C1MCTx
+GenG0.menu.pnum.GENERIC_G0C1MCTX.upload.maximum_size=262144
+GenG0.menu.pnum.GENERIC_G0C1MCTX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1MCTX.build.board=GENERIC_G0C1MCTX
+GenG0.menu.pnum.GENERIC_G0C1MCTX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1MCTX.build.variant=STM32G0xx/G0B1M(B-C-E)T_G0C1M(C-E)T
+GenG0.menu.pnum.GENERIC_G0C1MCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
+
+# Generic G0C1METx
+GenG0.menu.pnum.GENERIC_G0C1METX=Generic G0C1METx
+GenG0.menu.pnum.GENERIC_G0C1METX.upload.maximum_size=524288
+GenG0.menu.pnum.GENERIC_G0C1METX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1METX.build.board=GENERIC_G0C1METX
+GenG0.menu.pnum.GENERIC_G0C1METX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1METX.build.variant=STM32G0xx/G0B1M(B-C-E)T_G0C1M(C-E)T
+GenG0.menu.pnum.GENERIC_G0C1METX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
+
 # Generic G0B1NEYx
 GenG0.menu.pnum.GENERIC_G0B1NEYX=Generic G0B1NEYx
 GenG0.menu.pnum.GENERIC_G0B1NEYX.upload.maximum_size=524288
@@ -7706,6 +7768,15 @@ GenG0.menu.pnum.GENERIC_G0B1NEYX.build.board=GENERIC_G0B1NEYX
 GenG0.menu.pnum.GENERIC_G0B1NEYX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1NEYX.build.variant=STM32G0xx/G0B1NEY_G0C1NEY
 GenG0.menu.pnum.GENERIC_G0B1NEYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
+
+# Generic G0C1NEYx
+GenG0.menu.pnum.GENERIC_G0C1NEYX=Generic G0C1NEYx
+GenG0.menu.pnum.GENERIC_G0C1NEYX.upload.maximum_size=524288
+GenG0.menu.pnum.GENERIC_G0C1NEYX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1NEYX.build.board=GENERIC_G0C1NEYX
+GenG0.menu.pnum.GENERIC_G0C1NEYX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1NEYX.build.variant=STM32G0xx/G0B1NEY_G0C1NEY
+GenG0.menu.pnum.GENERIC_G0C1NEYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
 
 # Generic G0B1RBTx
 GenG0.menu.pnum.GENERIC_G0B1RBTX=Generic G0B1RBTx
@@ -7743,15 +7814,6 @@ GenG0.menu.pnum.GENERIC_G0B1VBIX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1VBIX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
 GenG0.menu.pnum.GENERIC_G0B1VBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
-# Generic G0B1VBTx
-GenG0.menu.pnum.GENERIC_G0B1VBTX=Generic G0B1VBTx
-GenG0.menu.pnum.GENERIC_G0B1VBTX.upload.maximum_size=131072
-GenG0.menu.pnum.GENERIC_G0B1VBTX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0B1VBTX.build.board=GENERIC_G0B1VBTX
-GenG0.menu.pnum.GENERIC_G0B1VBTX.build.product_line=STM32G0B1xx
-GenG0.menu.pnum.GENERIC_G0B1VBTX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
-GenG0.menu.pnum.GENERIC_G0B1VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
-
 # Generic G0B1VCIx
 GenG0.menu.pnum.GENERIC_G0B1VCIX=Generic G0B1VCIx
 GenG0.menu.pnum.GENERIC_G0B1VCIX.upload.maximum_size=262144
@@ -7760,15 +7822,6 @@ GenG0.menu.pnum.GENERIC_G0B1VCIX.build.board=GENERIC_G0B1VCIX
 GenG0.menu.pnum.GENERIC_G0B1VCIX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1VCIX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
 GenG0.menu.pnum.GENERIC_G0B1VCIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
-
-# Generic G0B1VCTx
-GenG0.menu.pnum.GENERIC_G0B1VCTX=Generic G0B1VCTx
-GenG0.menu.pnum.GENERIC_G0B1VCTX.upload.maximum_size=262144
-GenG0.menu.pnum.GENERIC_G0B1VCTX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0B1VCTX.build.board=GENERIC_G0B1VCTX
-GenG0.menu.pnum.GENERIC_G0B1VCTX.build.product_line=STM32G0B1xx
-GenG0.menu.pnum.GENERIC_G0B1VCTX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
-GenG0.menu.pnum.GENERIC_G0B1VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
 # Generic G0B1VEIx
 GenG0.menu.pnum.GENERIC_G0B1VEIX=Generic G0B1VEIx
@@ -7779,6 +7832,24 @@ GenG0.menu.pnum.GENERIC_G0B1VEIX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1VEIX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
 GenG0.menu.pnum.GENERIC_G0B1VEIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
+# Generic G0B1VBTx
+GenG0.menu.pnum.GENERIC_G0B1VBTX=Generic G0B1VBTx
+GenG0.menu.pnum.GENERIC_G0B1VBTX.upload.maximum_size=131072
+GenG0.menu.pnum.GENERIC_G0B1VBTX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0B1VBTX.build.board=GENERIC_G0B1VBTX
+GenG0.menu.pnum.GENERIC_G0B1VBTX.build.product_line=STM32G0B1xx
+GenG0.menu.pnum.GENERIC_G0B1VBTX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
+GenG0.menu.pnum.GENERIC_G0B1VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
+
+# Generic G0B1VCTx
+GenG0.menu.pnum.GENERIC_G0B1VCTX=Generic G0B1VCTx
+GenG0.menu.pnum.GENERIC_G0B1VCTX.upload.maximum_size=262144
+GenG0.menu.pnum.GENERIC_G0B1VCTX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0B1VCTX.build.board=GENERIC_G0B1VCTX
+GenG0.menu.pnum.GENERIC_G0B1VCTX.build.product_line=STM32G0B1xx
+GenG0.menu.pnum.GENERIC_G0B1VCTX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
+GenG0.menu.pnum.GENERIC_G0B1VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
+
 # Generic G0B1VETx
 GenG0.menu.pnum.GENERIC_G0B1VETX=Generic G0B1VETx
 GenG0.menu.pnum.GENERIC_G0B1VETX.upload.maximum_size=524288
@@ -7787,6 +7858,42 @@ GenG0.menu.pnum.GENERIC_G0B1VETX.build.board=GENERIC_G0B1VETX
 GenG0.menu.pnum.GENERIC_G0B1VETX.build.product_line=STM32G0B1xx
 GenG0.menu.pnum.GENERIC_G0B1VETX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
 GenG0.menu.pnum.GENERIC_G0B1VETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
+
+# Generic G0C1VCIx
+GenG0.menu.pnum.GENERIC_G0C1VCIX=Generic G0C1VCIx
+GenG0.menu.pnum.GENERIC_G0C1VCIX.upload.maximum_size=262144
+GenG0.menu.pnum.GENERIC_G0C1VCIX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1VCIX.build.board=GENERIC_G0C1VCIX
+GenG0.menu.pnum.GENERIC_G0C1VCIX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1VCIX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
+GenG0.menu.pnum.GENERIC_G0C1VCIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
+
+# Generic G0C1VEIx
+GenG0.menu.pnum.GENERIC_G0C1VEIX=Generic G0C1VEIx
+GenG0.menu.pnum.GENERIC_G0C1VEIX.upload.maximum_size=524288
+GenG0.menu.pnum.GENERIC_G0C1VEIX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1VEIX.build.board=GENERIC_G0C1VEIX
+GenG0.menu.pnum.GENERIC_G0C1VEIX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1VEIX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
+GenG0.menu.pnum.GENERIC_G0C1VEIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
+
+# Generic G0C1VCTx
+GenG0.menu.pnum.GENERIC_G0C1VCTX=Generic G0C1VCTx
+GenG0.menu.pnum.GENERIC_G0C1VCTX.upload.maximum_size=262144
+GenG0.menu.pnum.GENERIC_G0C1VCTX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1VCTX.build.board=GENERIC_G0C1VCTX
+GenG0.menu.pnum.GENERIC_G0C1VCTX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1VCTX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
+GenG0.menu.pnum.GENERIC_G0C1VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
+
+# Generic G0C1VETx
+GenG0.menu.pnum.GENERIC_G0C1VETX=Generic G0C1VETx
+GenG0.menu.pnum.GENERIC_G0C1VETX.upload.maximum_size=524288
+GenG0.menu.pnum.GENERIC_G0C1VETX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1VETX.build.board=GENERIC_G0C1VETX
+GenG0.menu.pnum.GENERIC_G0C1VETX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1VETX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
+GenG0.menu.pnum.GENERIC_G0C1VETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
 
 # Generic G0C1CCTx
 GenG0.menu.pnum.GENERIC_G0C1CCTX=Generic G0C1CCTx
@@ -7797,15 +7904,6 @@ GenG0.menu.pnum.GENERIC_G0C1CCTX.build.product_line=STM32G0C1xx
 GenG0.menu.pnum.GENERIC_G0C1CCTX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0C1CCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
 
-# Generic G0C1CCUx
-GenG0.menu.pnum.GENERIC_G0C1CCUX=Generic G0C1CCUx
-GenG0.menu.pnum.GENERIC_G0C1CCUX.upload.maximum_size=262144
-GenG0.menu.pnum.GENERIC_G0C1CCUX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1CCUX.build.board=GENERIC_G0C1CCUX
-GenG0.menu.pnum.GENERIC_G0C1CCUX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1CCUX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
-GenG0.menu.pnum.GENERIC_G0C1CCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
 # Generic G0C1CETx
 GenG0.menu.pnum.GENERIC_G0C1CETX=Generic G0C1CETx
 GenG0.menu.pnum.GENERIC_G0C1CETX.upload.maximum_size=524288
@@ -7815,6 +7913,15 @@ GenG0.menu.pnum.GENERIC_G0C1CETX.build.product_line=STM32G0C1xx
 GenG0.menu.pnum.GENERIC_G0C1CETX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0C1CETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
 
+# Generic G0C1CCUx
+GenG0.menu.pnum.GENERIC_G0C1CCUX=Generic G0C1CCUx
+GenG0.menu.pnum.GENERIC_G0C1CCUX.upload.maximum_size=262144
+GenG0.menu.pnum.GENERIC_G0C1CCUX.upload.maximum_data_size=147456
+GenG0.menu.pnum.GENERIC_G0C1CCUX.build.board=GENERIC_G0C1CCUX
+GenG0.menu.pnum.GENERIC_G0C1CCUX.build.product_line=STM32G0C1xx
+GenG0.menu.pnum.GENERIC_G0C1CCUX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
+GenG0.menu.pnum.GENERIC_G0C1CCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
+
 # Generic G0C1CEUx
 GenG0.menu.pnum.GENERIC_G0C1CEUX=Generic G0C1CEUx
 GenG0.menu.pnum.GENERIC_G0C1CEUX.upload.maximum_size=524288
@@ -7823,69 +7930,6 @@ GenG0.menu.pnum.GENERIC_G0C1CEUX.build.board=GENERIC_G0C1CEUX
 GenG0.menu.pnum.GENERIC_G0C1CEUX.build.product_line=STM32G0C1xx
 GenG0.menu.pnum.GENERIC_G0C1CEUX.build.variant=STM32G0xx/G0B1C(B-C-E)(T-U)_G0C1C(C-E)(T-U)
 GenG0.menu.pnum.GENERIC_G0C1CEUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1KCTx
-GenG0.menu.pnum.GENERIC_G0C1KCTX=Generic G0C1KCTx
-GenG0.menu.pnum.GENERIC_G0C1KCTX.upload.maximum_size=262144
-GenG0.menu.pnum.GENERIC_G0C1KCTX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1KCTX.build.board=GENERIC_G0C1KCTX
-GenG0.menu.pnum.GENERIC_G0C1KCTX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1KCTX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
-GenG0.menu.pnum.GENERIC_G0C1KCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1KCUx
-GenG0.menu.pnum.GENERIC_G0C1KCUX=Generic G0C1KCUx
-GenG0.menu.pnum.GENERIC_G0C1KCUX.upload.maximum_size=262144
-GenG0.menu.pnum.GENERIC_G0C1KCUX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1KCUX.build.board=GENERIC_G0C1KCUX
-GenG0.menu.pnum.GENERIC_G0C1KCUX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1KCUX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
-GenG0.menu.pnum.GENERIC_G0C1KCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1KETx
-GenG0.menu.pnum.GENERIC_G0C1KETX=Generic G0C1KETx
-GenG0.menu.pnum.GENERIC_G0C1KETX.upload.maximum_size=524288
-GenG0.menu.pnum.GENERIC_G0C1KETX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1KETX.build.board=GENERIC_G0C1KETX
-GenG0.menu.pnum.GENERIC_G0C1KETX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1KETX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
-GenG0.menu.pnum.GENERIC_G0C1KETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1KEUx
-GenG0.menu.pnum.GENERIC_G0C1KEUX=Generic G0C1KEUx
-GenG0.menu.pnum.GENERIC_G0C1KEUX.upload.maximum_size=524288
-GenG0.menu.pnum.GENERIC_G0C1KEUX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1KEUX.build.board=GENERIC_G0C1KEUX
-GenG0.menu.pnum.GENERIC_G0C1KEUX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1KEUX.build.variant=STM32G0xx/G0B1K(B-C-E)(T-U)_G0C1K(C-E)(T-U)
-GenG0.menu.pnum.GENERIC_G0C1KEUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1MCTx
-GenG0.menu.pnum.GENERIC_G0C1MCTX=Generic G0C1MCTx
-GenG0.menu.pnum.GENERIC_G0C1MCTX.upload.maximum_size=262144
-GenG0.menu.pnum.GENERIC_G0C1MCTX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1MCTX.build.board=GENERIC_G0C1MCTX
-GenG0.menu.pnum.GENERIC_G0C1MCTX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1MCTX.build.variant=STM32G0xx/G0B1M(B-C-E)T_G0C1M(C-E)T
-GenG0.menu.pnum.GENERIC_G0C1MCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1METx
-GenG0.menu.pnum.GENERIC_G0C1METX=Generic G0C1METx
-GenG0.menu.pnum.GENERIC_G0C1METX.upload.maximum_size=524288
-GenG0.menu.pnum.GENERIC_G0C1METX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1METX.build.board=GENERIC_G0C1METX
-GenG0.menu.pnum.GENERIC_G0C1METX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1METX.build.variant=STM32G0xx/G0B1M(B-C-E)T_G0C1M(C-E)T
-GenG0.menu.pnum.GENERIC_G0C1METX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1NEYx
-GenG0.menu.pnum.GENERIC_G0C1NEYX=Generic G0C1NEYx
-GenG0.menu.pnum.GENERIC_G0C1NEYX.upload.maximum_size=524288
-GenG0.menu.pnum.GENERIC_G0C1NEYX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1NEYX.build.board=GENERIC_G0C1NEYX
-GenG0.menu.pnum.GENERIC_G0C1NEYX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1NEYX.build.variant=STM32G0xx/G0B1NEY_G0C1NEY
-GenG0.menu.pnum.GENERIC_G0C1NEYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
 
 # Generic G0C1RCTx
 GenG0.menu.pnum.GENERIC_G0C1RCTX=Generic G0C1RCTx
@@ -7904,42 +7948,6 @@ GenG0.menu.pnum.GENERIC_G0C1RETX.build.board=GENERIC_G0C1RETX
 GenG0.menu.pnum.GENERIC_G0C1RETX.build.product_line=STM32G0C1xx
 GenG0.menu.pnum.GENERIC_G0C1RETX.build.variant=STM32G0xx/G0B1R(B-C-E)T_G0C1R(C-E)T
 GenG0.menu.pnum.GENERIC_G0C1RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1VCIx
-GenG0.menu.pnum.GENERIC_G0C1VCIX=Generic G0C1VCIx
-GenG0.menu.pnum.GENERIC_G0C1VCIX.upload.maximum_size=262144
-GenG0.menu.pnum.GENERIC_G0C1VCIX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1VCIX.build.board=GENERIC_G0C1VCIX
-GenG0.menu.pnum.GENERIC_G0C1VCIX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1VCIX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
-GenG0.menu.pnum.GENERIC_G0C1VCIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1VCTx
-GenG0.menu.pnum.GENERIC_G0C1VCTX=Generic G0C1VCTx
-GenG0.menu.pnum.GENERIC_G0C1VCTX.upload.maximum_size=262144
-GenG0.menu.pnum.GENERIC_G0C1VCTX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1VCTX.build.board=GENERIC_G0C1VCTX
-GenG0.menu.pnum.GENERIC_G0C1VCTX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1VCTX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
-GenG0.menu.pnum.GENERIC_G0C1VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1VEIx
-GenG0.menu.pnum.GENERIC_G0C1VEIX=Generic G0C1VEIx
-GenG0.menu.pnum.GENERIC_G0C1VEIX.upload.maximum_size=524288
-GenG0.menu.pnum.GENERIC_G0C1VEIX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1VEIX.build.board=GENERIC_G0C1VEIX
-GenG0.menu.pnum.GENERIC_G0C1VEIX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1VEIX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
-GenG0.menu.pnum.GENERIC_G0C1VEIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
-
-# Generic G0C1VETx
-GenG0.menu.pnum.GENERIC_G0C1VETX=Generic G0C1VETx
-GenG0.menu.pnum.GENERIC_G0C1VETX.upload.maximum_size=524288
-GenG0.menu.pnum.GENERIC_G0C1VETX.upload.maximum_data_size=147456
-GenG0.menu.pnum.GENERIC_G0C1VETX.build.board=GENERIC_G0C1VETX
-GenG0.menu.pnum.GENERIC_G0C1VETX.build.product_line=STM32G0C1xx
-GenG0.menu.pnum.GENERIC_G0C1VETX.build.variant=STM32G0xx/G0B1V(B-C-E)(I-T)_G0C1V(C-E)(I-T)
-GenG0.menu.pnum.GENERIC_G0C1VETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0C1.svd
 
 # Upload menu
 GenG0.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
@@ -8013,15 +8021,6 @@ GenG4.menu.pnum.GENERIC_G431C6TX.build.product_line=STM32G431xx
 GenG4.menu.pnum.GENERIC_G431C6TX.build.variant=STM32G4xx/G431C(6-8-B)T_G441CBT
 GenG4.menu.pnum.GENERIC_G431C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
 
-# Generic G431C6Ux
-GenG4.menu.pnum.GENERIC_G431C6UX=Generic G431C6Ux
-GenG4.menu.pnum.GENERIC_G431C6UX.upload.maximum_size=32768
-GenG4.menu.pnum.GENERIC_G431C6UX.upload.maximum_data_size=32768
-GenG4.menu.pnum.GENERIC_G431C6UX.build.board=GENERIC_G431C6UX
-GenG4.menu.pnum.GENERIC_G431C6UX.build.product_line=STM32G431xx
-GenG4.menu.pnum.GENERIC_G431C6UX.build.variant=STM32G4xx/G431C(6-8-B)U_G441CBU
-GenG4.menu.pnum.GENERIC_G431C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
-
 # Generic G431C8Tx
 GenG4.menu.pnum.GENERIC_G431C8TX=Generic G431C8Tx
 GenG4.menu.pnum.GENERIC_G431C8TX.upload.maximum_size=65536
@@ -8031,15 +8030,6 @@ GenG4.menu.pnum.GENERIC_G431C8TX.build.product_line=STM32G431xx
 GenG4.menu.pnum.GENERIC_G431C8TX.build.variant=STM32G4xx/G431C(6-8-B)T_G441CBT
 GenG4.menu.pnum.GENERIC_G431C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
 
-# Generic G431C8Ux
-GenG4.menu.pnum.GENERIC_G431C8UX=Generic G431C8Ux
-GenG4.menu.pnum.GENERIC_G431C8UX.upload.maximum_size=65536
-GenG4.menu.pnum.GENERIC_G431C8UX.upload.maximum_data_size=32768
-GenG4.menu.pnum.GENERIC_G431C8UX.build.board=GENERIC_G431C8UX
-GenG4.menu.pnum.GENERIC_G431C8UX.build.product_line=STM32G431xx
-GenG4.menu.pnum.GENERIC_G431C8UX.build.variant=STM32G4xx/G431C(6-8-B)U_G441CBU
-GenG4.menu.pnum.GENERIC_G431C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
-
 # Generic G431CBTx
 GenG4.menu.pnum.GENERIC_G431CBTX=Generic G431CBTx
 GenG4.menu.pnum.GENERIC_G431CBTX.upload.maximum_size=131072
@@ -8048,6 +8038,24 @@ GenG4.menu.pnum.GENERIC_G431CBTX.build.board=GENERIC_G431CBTX
 GenG4.menu.pnum.GENERIC_G431CBTX.build.product_line=STM32G431xx
 GenG4.menu.pnum.GENERIC_G431CBTX.build.variant=STM32G4xx/G431C(6-8-B)T_G441CBT
 GenG4.menu.pnum.GENERIC_G431CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
+
+# Generic G431C6Ux
+GenG4.menu.pnum.GENERIC_G431C6UX=Generic G431C6Ux
+GenG4.menu.pnum.GENERIC_G431C6UX.upload.maximum_size=32768
+GenG4.menu.pnum.GENERIC_G431C6UX.upload.maximum_data_size=32768
+GenG4.menu.pnum.GENERIC_G431C6UX.build.board=GENERIC_G431C6UX
+GenG4.menu.pnum.GENERIC_G431C6UX.build.product_line=STM32G431xx
+GenG4.menu.pnum.GENERIC_G431C6UX.build.variant=STM32G4xx/G431C(6-8-B)U_G441CBU
+GenG4.menu.pnum.GENERIC_G431C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
+
+# Generic G431C8Ux
+GenG4.menu.pnum.GENERIC_G431C8UX=Generic G431C8Ux
+GenG4.menu.pnum.GENERIC_G431C8UX.upload.maximum_size=65536
+GenG4.menu.pnum.GENERIC_G431C8UX.upload.maximum_data_size=32768
+GenG4.menu.pnum.GENERIC_G431C8UX.build.board=GENERIC_G431C8UX
+GenG4.menu.pnum.GENERIC_G431C8UX.build.product_line=STM32G431xx
+GenG4.menu.pnum.GENERIC_G431C8UX.build.variant=STM32G4xx/G431C(6-8-B)U_G441CBU
+GenG4.menu.pnum.GENERIC_G431C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
 
 # Generic G431CBUx
 GenG4.menu.pnum.GENERIC_G431CBUX=Generic G431CBUx
@@ -8067,15 +8075,6 @@ GenG4.menu.pnum.GENERIC_G431K6TX.build.product_line=STM32G431xx
 GenG4.menu.pnum.GENERIC_G431K6TX.build.variant=STM32G4xx/G431K(6-8-B)(T-U)_G441KB(T-U)
 GenG4.menu.pnum.GENERIC_G431K6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
 
-# Generic G431K6Ux
-GenG4.menu.pnum.GENERIC_G431K6UX=Generic G431K6Ux
-GenG4.menu.pnum.GENERIC_G431K6UX.upload.maximum_size=32768
-GenG4.menu.pnum.GENERIC_G431K6UX.upload.maximum_data_size=32768
-GenG4.menu.pnum.GENERIC_G431K6UX.build.board=GENERIC_G431K6UX
-GenG4.menu.pnum.GENERIC_G431K6UX.build.product_line=STM32G431xx
-GenG4.menu.pnum.GENERIC_G431K6UX.build.variant=STM32G4xx/G431K(6-8-B)(T-U)_G441KB(T-U)
-GenG4.menu.pnum.GENERIC_G431K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
-
 # Generic G431K8Tx
 GenG4.menu.pnum.GENERIC_G431K8TX=Generic G431K8Tx
 GenG4.menu.pnum.GENERIC_G431K8TX.upload.maximum_size=65536
@@ -8085,15 +8084,6 @@ GenG4.menu.pnum.GENERIC_G431K8TX.build.product_line=STM32G431xx
 GenG4.menu.pnum.GENERIC_G431K8TX.build.variant=STM32G4xx/G431K(6-8-B)(T-U)_G441KB(T-U)
 GenG4.menu.pnum.GENERIC_G431K8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
 
-# Generic G431K8Ux
-GenG4.menu.pnum.GENERIC_G431K8UX=Generic G431K8Ux
-GenG4.menu.pnum.GENERIC_G431K8UX.upload.maximum_size=65536
-GenG4.menu.pnum.GENERIC_G431K8UX.upload.maximum_data_size=32768
-GenG4.menu.pnum.GENERIC_G431K8UX.build.board=GENERIC_G431K8UX
-GenG4.menu.pnum.GENERIC_G431K8UX.build.product_line=STM32G431xx
-GenG4.menu.pnum.GENERIC_G431K8UX.build.variant=STM32G4xx/G431K(6-8-B)(T-U)_G441KB(T-U)
-GenG4.menu.pnum.GENERIC_G431K8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
-
 # Generic G431KBTx
 GenG4.menu.pnum.GENERIC_G431KBTX=Generic G431KBTx
 GenG4.menu.pnum.GENERIC_G431KBTX.upload.maximum_size=131072
@@ -8102,6 +8092,24 @@ GenG4.menu.pnum.GENERIC_G431KBTX.build.board=GENERIC_G431KBTX
 GenG4.menu.pnum.GENERIC_G431KBTX.build.product_line=STM32G431xx
 GenG4.menu.pnum.GENERIC_G431KBTX.build.variant=STM32G4xx/G431K(6-8-B)(T-U)_G441KB(T-U)
 GenG4.menu.pnum.GENERIC_G431KBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
+
+# Generic G431K6Ux
+GenG4.menu.pnum.GENERIC_G431K6UX=Generic G431K6Ux
+GenG4.menu.pnum.GENERIC_G431K6UX.upload.maximum_size=32768
+GenG4.menu.pnum.GENERIC_G431K6UX.upload.maximum_data_size=32768
+GenG4.menu.pnum.GENERIC_G431K6UX.build.board=GENERIC_G431K6UX
+GenG4.menu.pnum.GENERIC_G431K6UX.build.product_line=STM32G431xx
+GenG4.menu.pnum.GENERIC_G431K6UX.build.variant=STM32G4xx/G431K(6-8-B)(T-U)_G441KB(T-U)
+GenG4.menu.pnum.GENERIC_G431K6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
+
+# Generic G431K8Ux
+GenG4.menu.pnum.GENERIC_G431K8UX=Generic G431K8Ux
+GenG4.menu.pnum.GENERIC_G431K8UX.upload.maximum_size=65536
+GenG4.menu.pnum.GENERIC_G431K8UX.upload.maximum_data_size=32768
+GenG4.menu.pnum.GENERIC_G431K8UX.build.board=GENERIC_G431K8UX
+GenG4.menu.pnum.GENERIC_G431K8UX.build.product_line=STM32G431xx
+GenG4.menu.pnum.GENERIC_G431K8UX.build.variant=STM32G4xx/G431K(6-8-B)(T-U)_G441KB(T-U)
+GenG4.menu.pnum.GENERIC_G431K8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
 
 # Generic G431KBUx
 GenG4.menu.pnum.GENERIC_G431KBUX=Generic G431KBUx
@@ -8148,15 +8156,6 @@ GenG4.menu.pnum.GENERIC_G431R6IX.build.product_line=STM32G431xx
 GenG4.menu.pnum.GENERIC_G431R6IX.build.variant=STM32G4xx/G431R(6-8)(I-T)_G431RB(I-T)x(Z)_G441RB(I-T)
 GenG4.menu.pnum.GENERIC_G431R6IX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
 
-# Generic G431R6Tx
-GenG4.menu.pnum.GENERIC_G431R6TX=Generic G431R6Tx
-GenG4.menu.pnum.GENERIC_G431R6TX.upload.maximum_size=32768
-GenG4.menu.pnum.GENERIC_G431R6TX.upload.maximum_data_size=32768
-GenG4.menu.pnum.GENERIC_G431R6TX.build.board=GENERIC_G431R6TX
-GenG4.menu.pnum.GENERIC_G431R6TX.build.product_line=STM32G431xx
-GenG4.menu.pnum.GENERIC_G431R6TX.build.variant=STM32G4xx/G431R(6-8)(I-T)_G431RB(I-T)x(Z)_G441RB(I-T)
-GenG4.menu.pnum.GENERIC_G431R6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
-
 # Generic G431R8Ix
 GenG4.menu.pnum.GENERIC_G431R8IX=Generic G431R8Ix
 GenG4.menu.pnum.GENERIC_G431R8IX.upload.maximum_size=65536
@@ -8166,15 +8165,6 @@ GenG4.menu.pnum.GENERIC_G431R8IX.build.product_line=STM32G431xx
 GenG4.menu.pnum.GENERIC_G431R8IX.build.variant=STM32G4xx/G431R(6-8)(I-T)_G431RB(I-T)x(Z)_G441RB(I-T)
 GenG4.menu.pnum.GENERIC_G431R8IX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
 
-# Generic G431R8Tx
-GenG4.menu.pnum.GENERIC_G431R8TX=Generic G431R8Tx
-GenG4.menu.pnum.GENERIC_G431R8TX.upload.maximum_size=65536
-GenG4.menu.pnum.GENERIC_G431R8TX.upload.maximum_data_size=32768
-GenG4.menu.pnum.GENERIC_G431R8TX.build.board=GENERIC_G431R8TX
-GenG4.menu.pnum.GENERIC_G431R8TX.build.product_line=STM32G431xx
-GenG4.menu.pnum.GENERIC_G431R8TX.build.variant=STM32G4xx/G431R(6-8)(I-T)_G431RB(I-T)x(Z)_G441RB(I-T)
-GenG4.menu.pnum.GENERIC_G431R8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
-
 # Generic G431RBIx
 GenG4.menu.pnum.GENERIC_G431RBIX=Generic G431RBIx
 GenG4.menu.pnum.GENERIC_G431RBIX.upload.maximum_size=131072
@@ -8183,6 +8173,24 @@ GenG4.menu.pnum.GENERIC_G431RBIX.build.board=GENERIC_G431RBIX
 GenG4.menu.pnum.GENERIC_G431RBIX.build.product_line=STM32G431xx
 GenG4.menu.pnum.GENERIC_G431RBIX.build.variant=STM32G4xx/G431R(6-8)(I-T)_G431RB(I-T)x(Z)_G441RB(I-T)
 GenG4.menu.pnum.GENERIC_G431RBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
+
+# Generic G431R6Tx
+GenG4.menu.pnum.GENERIC_G431R6TX=Generic G431R6Tx
+GenG4.menu.pnum.GENERIC_G431R6TX.upload.maximum_size=32768
+GenG4.menu.pnum.GENERIC_G431R6TX.upload.maximum_data_size=32768
+GenG4.menu.pnum.GENERIC_G431R6TX.build.board=GENERIC_G431R6TX
+GenG4.menu.pnum.GENERIC_G431R6TX.build.product_line=STM32G431xx
+GenG4.menu.pnum.GENERIC_G431R6TX.build.variant=STM32G4xx/G431R(6-8)(I-T)_G431RB(I-T)x(Z)_G441RB(I-T)
+GenG4.menu.pnum.GENERIC_G431R6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
+
+# Generic G431R8Tx
+GenG4.menu.pnum.GENERIC_G431R8TX=Generic G431R8Tx
+GenG4.menu.pnum.GENERIC_G431R8TX.upload.maximum_size=65536
+GenG4.menu.pnum.GENERIC_G431R8TX.upload.maximum_data_size=32768
+GenG4.menu.pnum.GENERIC_G431R8TX.build.board=GENERIC_G431R8TX
+GenG4.menu.pnum.GENERIC_G431R8TX.build.product_line=STM32G431xx
+GenG4.menu.pnum.GENERIC_G431R8TX.build.variant=STM32G4xx/G431R(6-8)(I-T)_G431RB(I-T)x(Z)_G441RB(I-T)
+GenG4.menu.pnum.GENERIC_G431R8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
 
 # Generic G431RBTx
 GenG4.menu.pnum.GENERIC_G431RBTX=Generic G431RBTx
@@ -8247,6 +8255,15 @@ GenG4.menu.pnum.GENERIC_G441CBUX.build.product_line=STM32G441xx
 GenG4.menu.pnum.GENERIC_G441CBUX.build.variant=STM32G4xx/G431C(6-8-B)U_G441CBU
 GenG4.menu.pnum.GENERIC_G441CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G441.svd
 
+# Generic G441MBTx
+GenG4.menu.pnum.GENERIC_G441MBTX=Generic G441MBTx
+GenG4.menu.pnum.GENERIC_G441MBTX.upload.maximum_size=131072
+GenG4.menu.pnum.GENERIC_G441MBTX.upload.maximum_data_size=32768
+GenG4.menu.pnum.GENERIC_G441MBTX.build.board=GENERIC_G441MBTX
+GenG4.menu.pnum.GENERIC_G441MBTX.build.product_line=STM32G441xx
+GenG4.menu.pnum.GENERIC_G441MBTX.build.variant=STM32G4xx/G431M(6-8-B)T_G441MBT
+GenG4.menu.pnum.GENERIC_G441MBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G441.svd
+
 # Generic G441KBTx
 GenG4.menu.pnum.GENERIC_G441KBTX=Generic G441KBTx
 GenG4.menu.pnum.GENERIC_G441KBTX.upload.maximum_size=131072
@@ -8264,15 +8281,6 @@ GenG4.menu.pnum.GENERIC_G441KBUX.build.board=GENERIC_G441KBUX
 GenG4.menu.pnum.GENERIC_G441KBUX.build.product_line=STM32G441xx
 GenG4.menu.pnum.GENERIC_G441KBUX.build.variant=STM32G4xx/G431K(6-8-B)(T-U)_G441KB(T-U)
 GenG4.menu.pnum.GENERIC_G441KBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G441.svd
-
-# Generic G441MBTx
-GenG4.menu.pnum.GENERIC_G441MBTX=Generic G441MBTx
-GenG4.menu.pnum.GENERIC_G441MBTX.upload.maximum_size=131072
-GenG4.menu.pnum.GENERIC_G441MBTX.upload.maximum_data_size=32768
-GenG4.menu.pnum.GENERIC_G441MBTX.build.board=GENERIC_G441MBTX
-GenG4.menu.pnum.GENERIC_G441MBTX.build.product_line=STM32G441xx
-GenG4.menu.pnum.GENERIC_G441MBTX.build.variant=STM32G4xx/G431M(6-8-B)T_G441MBT
-GenG4.menu.pnum.GENERIC_G441MBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G441.svd
 
 # Generic G441RBIx
 GenG4.menu.pnum.GENERIC_G441RBIX=Generic G441RBIx
@@ -8382,24 +8390,6 @@ GenG4.menu.pnum.GENERIC_G471VCHX.build.product_line=STM32G471xx
 GenG4.menu.pnum.GENERIC_G471VCHX.build.variant=STM32G4xx/G471V(C-E)(H-I-T)
 GenG4.menu.pnum.GENERIC_G471VCHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G471.svd
 
-# Generic G471VCIx
-GenG4.menu.pnum.GENERIC_G471VCIX=Generic G471VCIx
-GenG4.menu.pnum.GENERIC_G471VCIX.upload.maximum_size=262144
-GenG4.menu.pnum.GENERIC_G471VCIX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G471VCIX.build.board=GENERIC_G471VCIX
-GenG4.menu.pnum.GENERIC_G471VCIX.build.product_line=STM32G471xx
-GenG4.menu.pnum.GENERIC_G471VCIX.build.variant=STM32G4xx/G471V(C-E)(H-I-T)
-GenG4.menu.pnum.GENERIC_G471VCIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G471.svd
-
-# Generic G471VCTx
-GenG4.menu.pnum.GENERIC_G471VCTX=Generic G471VCTx
-GenG4.menu.pnum.GENERIC_G471VCTX.upload.maximum_size=262144
-GenG4.menu.pnum.GENERIC_G471VCTX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G471VCTX.build.board=GENERIC_G471VCTX
-GenG4.menu.pnum.GENERIC_G471VCTX.build.product_line=STM32G471xx
-GenG4.menu.pnum.GENERIC_G471VCTX.build.variant=STM32G4xx/G471V(C-E)(H-I-T)
-GenG4.menu.pnum.GENERIC_G471VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G471.svd
-
 # Generic G471VEHx
 GenG4.menu.pnum.GENERIC_G471VEHX=Generic G471VEHx
 GenG4.menu.pnum.GENERIC_G471VEHX.upload.maximum_size=524288
@@ -8409,6 +8399,15 @@ GenG4.menu.pnum.GENERIC_G471VEHX.build.product_line=STM32G471xx
 GenG4.menu.pnum.GENERIC_G471VEHX.build.variant=STM32G4xx/G471V(C-E)(H-I-T)
 GenG4.menu.pnum.GENERIC_G471VEHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G471.svd
 
+# Generic G471VCIx
+GenG4.menu.pnum.GENERIC_G471VCIX=Generic G471VCIx
+GenG4.menu.pnum.GENERIC_G471VCIX.upload.maximum_size=262144
+GenG4.menu.pnum.GENERIC_G471VCIX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G471VCIX.build.board=GENERIC_G471VCIX
+GenG4.menu.pnum.GENERIC_G471VCIX.build.product_line=STM32G471xx
+GenG4.menu.pnum.GENERIC_G471VCIX.build.variant=STM32G4xx/G471V(C-E)(H-I-T)
+GenG4.menu.pnum.GENERIC_G471VCIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G471.svd
+
 # Generic G471VEIx
 GenG4.menu.pnum.GENERIC_G471VEIX=Generic G471VEIx
 GenG4.menu.pnum.GENERIC_G471VEIX.upload.maximum_size=524288
@@ -8417,6 +8416,15 @@ GenG4.menu.pnum.GENERIC_G471VEIX.build.board=GENERIC_G471VEIX
 GenG4.menu.pnum.GENERIC_G471VEIX.build.product_line=STM32G471xx
 GenG4.menu.pnum.GENERIC_G471VEIX.build.variant=STM32G4xx/G471V(C-E)(H-I-T)
 GenG4.menu.pnum.GENERIC_G471VEIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G471.svd
+
+# Generic G471VCTx
+GenG4.menu.pnum.GENERIC_G471VCTX=Generic G471VCTx
+GenG4.menu.pnum.GENERIC_G471VCTX.upload.maximum_size=262144
+GenG4.menu.pnum.GENERIC_G471VCTX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G471VCTX.build.board=GENERIC_G471VCTX
+GenG4.menu.pnum.GENERIC_G471VCTX.build.product_line=STM32G471xx
+GenG4.menu.pnum.GENERIC_G471VCTX.build.variant=STM32G4xx/G471V(C-E)(H-I-T)
+GenG4.menu.pnum.GENERIC_G471VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G471.svd
 
 # Generic G471VETx
 GenG4.menu.pnum.GENERIC_G471VETX=Generic G471VETx
@@ -8535,6 +8543,33 @@ GenG4.menu.pnum.GENERIC_G473PEIX.build.product_line=STM32G473xx
 GenG4.menu.pnum.GENERIC_G473PEIX.build.variant=STM32G4xx/G473P(B-C-E)I_G474P(B-C-E)I_G483PEI_G484PEI
 GenG4.menu.pnum.GENERIC_G473PEIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
 
+# Generic G473RBTx
+GenG4.menu.pnum.GENERIC_G473RBTX=Generic G473RBTx
+GenG4.menu.pnum.GENERIC_G473RBTX.upload.maximum_size=131072
+GenG4.menu.pnum.GENERIC_G473RBTX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G473RBTX.build.board=GENERIC_G473RBTX
+GenG4.menu.pnum.GENERIC_G473RBTX.build.product_line=STM32G473xx
+GenG4.menu.pnum.GENERIC_G473RBTX.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
+GenG4.menu.pnum.GENERIC_G473RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
+
+# Generic G473RCTx
+GenG4.menu.pnum.GENERIC_G473RCTX=Generic G473RCTx
+GenG4.menu.pnum.GENERIC_G473RCTX.upload.maximum_size=262144
+GenG4.menu.pnum.GENERIC_G473RCTX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G473RCTX.build.board=GENERIC_G473RCTX
+GenG4.menu.pnum.GENERIC_G473RCTX.build.product_line=STM32G473xx
+GenG4.menu.pnum.GENERIC_G473RCTX.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
+GenG4.menu.pnum.GENERIC_G473RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
+
+# Generic G473RETx
+GenG4.menu.pnum.GENERIC_G473RETX=Generic G473RETx
+GenG4.menu.pnum.GENERIC_G473RETX.upload.maximum_size=524288
+GenG4.menu.pnum.GENERIC_G473RETX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G473RETX.build.board=GENERIC_G473RETX
+GenG4.menu.pnum.GENERIC_G473RETX.build.product_line=STM32G473xx
+GenG4.menu.pnum.GENERIC_G473RETX.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
+GenG4.menu.pnum.GENERIC_G473RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
+
 # Generic G473QBTx
 GenG4.menu.pnum.GENERIC_G473QBTX=Generic G473QBTx
 GenG4.menu.pnum.GENERIC_G473QBTX.upload.maximum_size=131072
@@ -8571,42 +8606,6 @@ GenG4.menu.pnum.GENERIC_G473QETXZ.build.product_line=STM32G473xx
 GenG4.menu.pnum.GENERIC_G473QETXZ.build.variant=STM32G4xx/G473Q(B-C)T_G473QETx(Z)_G474Q(B-C-E)T_G483QET_G484QET
 GenG4.menu.pnum.GENERIC_G473QETXZ.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
 
-# Generic G473RBTx
-GenG4.menu.pnum.GENERIC_G473RBTX=Generic G473RBTx
-GenG4.menu.pnum.GENERIC_G473RBTX.upload.maximum_size=131072
-GenG4.menu.pnum.GENERIC_G473RBTX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G473RBTX.build.board=GENERIC_G473RBTX
-GenG4.menu.pnum.GENERIC_G473RBTX.build.product_line=STM32G473xx
-GenG4.menu.pnum.GENERIC_G473RBTX.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
-GenG4.menu.pnum.GENERIC_G473RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
-
-# Generic G473RCTx
-GenG4.menu.pnum.GENERIC_G473RCTX=Generic G473RCTx
-GenG4.menu.pnum.GENERIC_G473RCTX.upload.maximum_size=262144
-GenG4.menu.pnum.GENERIC_G473RCTX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G473RCTX.build.board=GENERIC_G473RCTX
-GenG4.menu.pnum.GENERIC_G473RCTX.build.product_line=STM32G473xx
-GenG4.menu.pnum.GENERIC_G473RCTX.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
-GenG4.menu.pnum.GENERIC_G473RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
-
-# Generic G473RETx
-GenG4.menu.pnum.GENERIC_G473RETX=Generic G473RETx
-GenG4.menu.pnum.GENERIC_G473RETX.upload.maximum_size=524288
-GenG4.menu.pnum.GENERIC_G473RETX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G473RETX.build.board=GENERIC_G473RETX
-GenG4.menu.pnum.GENERIC_G473RETX.build.product_line=STM32G473xx
-GenG4.menu.pnum.GENERIC_G473RETX.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
-GenG4.menu.pnum.GENERIC_G473RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
-
-# Generic G473RETxZ
-GenG4.menu.pnum.GENERIC_G473RETXZ=Generic G473RETxZ
-GenG4.menu.pnum.GENERIC_G473RETXZ.upload.maximum_size=524288
-GenG4.menu.pnum.GENERIC_G473RETXZ.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G473RETXZ.build.board=GENERIC_G473RETXZ
-GenG4.menu.pnum.GENERIC_G473RETXZ.build.product_line=STM32G473xx
-GenG4.menu.pnum.GENERIC_G473RETXZ.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
-GenG4.menu.pnum.GENERIC_G473RETXZ.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
-
 # Generic G473VBHx
 GenG4.menu.pnum.GENERIC_G473VBHX=Generic G473VBHx
 GenG4.menu.pnum.GENERIC_G473VBHX.upload.maximum_size=131072
@@ -8615,15 +8614,6 @@ GenG4.menu.pnum.GENERIC_G473VBHX.build.board=GENERIC_G473VBHX
 GenG4.menu.pnum.GENERIC_G473VBHX.build.product_line=STM32G473xx
 GenG4.menu.pnum.GENERIC_G473VBHX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
 GenG4.menu.pnum.GENERIC_G473VBHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
-
-# Generic G473VBTx
-GenG4.menu.pnum.GENERIC_G473VBTX=Generic G473VBTx
-GenG4.menu.pnum.GENERIC_G473VBTX.upload.maximum_size=131072
-GenG4.menu.pnum.GENERIC_G473VBTX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G473VBTX.build.board=GENERIC_G473VBTX
-GenG4.menu.pnum.GENERIC_G473VBTX.build.product_line=STM32G473xx
-GenG4.menu.pnum.GENERIC_G473VBTX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
-GenG4.menu.pnum.GENERIC_G473VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
 
 # Generic G473VCHx
 GenG4.menu.pnum.GENERIC_G473VCHX=Generic G473VCHx
@@ -8634,15 +8624,6 @@ GenG4.menu.pnum.GENERIC_G473VCHX.build.product_line=STM32G473xx
 GenG4.menu.pnum.GENERIC_G473VCHX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
 GenG4.menu.pnum.GENERIC_G473VCHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
 
-# Generic G473VCTx
-GenG4.menu.pnum.GENERIC_G473VCTX=Generic G473VCTx
-GenG4.menu.pnum.GENERIC_G473VCTX.upload.maximum_size=262144
-GenG4.menu.pnum.GENERIC_G473VCTX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G473VCTX.build.board=GENERIC_G473VCTX
-GenG4.menu.pnum.GENERIC_G473VCTX.build.product_line=STM32G473xx
-GenG4.menu.pnum.GENERIC_G473VCTX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
-GenG4.menu.pnum.GENERIC_G473VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
-
 # Generic G473VEHx
 GenG4.menu.pnum.GENERIC_G473VEHX=Generic G473VEHx
 GenG4.menu.pnum.GENERIC_G473VEHX.upload.maximum_size=524288
@@ -8651,6 +8632,24 @@ GenG4.menu.pnum.GENERIC_G473VEHX.build.board=GENERIC_G473VEHX
 GenG4.menu.pnum.GENERIC_G473VEHX.build.product_line=STM32G473xx
 GenG4.menu.pnum.GENERIC_G473VEHX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
 GenG4.menu.pnum.GENERIC_G473VEHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
+
+# Generic G473VBTx
+GenG4.menu.pnum.GENERIC_G473VBTX=Generic G473VBTx
+GenG4.menu.pnum.GENERIC_G473VBTX.upload.maximum_size=131072
+GenG4.menu.pnum.GENERIC_G473VBTX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G473VBTX.build.board=GENERIC_G473VBTX
+GenG4.menu.pnum.GENERIC_G473VBTX.build.product_line=STM32G473xx
+GenG4.menu.pnum.GENERIC_G473VBTX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
+GenG4.menu.pnum.GENERIC_G473VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
+
+# Generic G473VCTx
+GenG4.menu.pnum.GENERIC_G473VCTX=Generic G473VCTx
+GenG4.menu.pnum.GENERIC_G473VCTX.upload.maximum_size=262144
+GenG4.menu.pnum.GENERIC_G473VCTX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G473VCTX.build.board=GENERIC_G473VCTX
+GenG4.menu.pnum.GENERIC_G473VCTX.build.product_line=STM32G473xx
+GenG4.menu.pnum.GENERIC_G473VCTX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
+GenG4.menu.pnum.GENERIC_G473VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
 
 # Generic G473VETx
 GenG4.menu.pnum.GENERIC_G473VETX=Generic G473VETx
@@ -8769,33 +8768,6 @@ GenG4.menu.pnum.GENERIC_G474PEIX.build.product_line=STM32G474xx
 GenG4.menu.pnum.GENERIC_G474PEIX.build.variant=STM32G4xx/G473P(B-C-E)I_G474P(B-C-E)I_G483PEI_G484PEI
 GenG4.menu.pnum.GENERIC_G474PEIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
 
-# Generic G474QBTx
-GenG4.menu.pnum.GENERIC_G474QBTX=Generic G474QBTx
-GenG4.menu.pnum.GENERIC_G474QBTX.upload.maximum_size=131072
-GenG4.menu.pnum.GENERIC_G474QBTX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G474QBTX.build.board=GENERIC_G474QBTX
-GenG4.menu.pnum.GENERIC_G474QBTX.build.product_line=STM32G474xx
-GenG4.menu.pnum.GENERIC_G474QBTX.build.variant=STM32G4xx/G473Q(B-C)T_G473QETx(Z)_G474Q(B-C-E)T_G483QET_G484QET
-GenG4.menu.pnum.GENERIC_G474QBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
-
-# Generic G474QCTx
-GenG4.menu.pnum.GENERIC_G474QCTX=Generic G474QCTx
-GenG4.menu.pnum.GENERIC_G474QCTX.upload.maximum_size=262144
-GenG4.menu.pnum.GENERIC_G474QCTX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G474QCTX.build.board=GENERIC_G474QCTX
-GenG4.menu.pnum.GENERIC_G474QCTX.build.product_line=STM32G474xx
-GenG4.menu.pnum.GENERIC_G474QCTX.build.variant=STM32G4xx/G473Q(B-C)T_G473QETx(Z)_G474Q(B-C-E)T_G483QET_G484QET
-GenG4.menu.pnum.GENERIC_G474QCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
-
-# Generic G474QETx
-GenG4.menu.pnum.GENERIC_G474QETX=Generic G474QETx
-GenG4.menu.pnum.GENERIC_G474QETX.upload.maximum_size=524288
-GenG4.menu.pnum.GENERIC_G474QETX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G474QETX.build.board=GENERIC_G474QETX
-GenG4.menu.pnum.GENERIC_G474QETX.build.product_line=STM32G474xx
-GenG4.menu.pnum.GENERIC_G474QETX.build.variant=STM32G4xx/G473Q(B-C)T_G473QETx(Z)_G474Q(B-C-E)T_G483QET_G484QET
-GenG4.menu.pnum.GENERIC_G474QETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
-
 # Generic G474RBTx
 GenG4.menu.pnum.GENERIC_G474RBTX=Generic G474RBTx
 GenG4.menu.pnum.GENERIC_G474RBTX.upload.maximum_size=131072
@@ -8823,6 +8795,42 @@ GenG4.menu.pnum.GENERIC_G474RETX.build.product_line=STM32G474xx
 GenG4.menu.pnum.GENERIC_G474RETX.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
 GenG4.menu.pnum.GENERIC_G474RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
 
+# Generic G473RETxZ
+GenG4.menu.pnum.GENERIC_G473RETXZ=Generic G473RETxZ
+GenG4.menu.pnum.GENERIC_G473RETXZ.upload.maximum_size=524288
+GenG4.menu.pnum.GENERIC_G473RETXZ.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G473RETXZ.build.board=GENERIC_G473RETXZ
+GenG4.menu.pnum.GENERIC_G473RETXZ.build.product_line=STM32G473xx
+GenG4.menu.pnum.GENERIC_G473RETXZ.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
+GenG4.menu.pnum.GENERIC_G473RETXZ.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G473.svd
+
+# Generic G474QBTx
+GenG4.menu.pnum.GENERIC_G474QBTX=Generic G474QBTx
+GenG4.menu.pnum.GENERIC_G474QBTX.upload.maximum_size=131072
+GenG4.menu.pnum.GENERIC_G474QBTX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G474QBTX.build.board=GENERIC_G474QBTX
+GenG4.menu.pnum.GENERIC_G474QBTX.build.product_line=STM32G474xx
+GenG4.menu.pnum.GENERIC_G474QBTX.build.variant=STM32G4xx/G473Q(B-C)T_G473QETx(Z)_G474Q(B-C-E)T_G483QET_G484QET
+GenG4.menu.pnum.GENERIC_G474QBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
+
+# Generic G474QCTx
+GenG4.menu.pnum.GENERIC_G474QCTX=Generic G474QCTx
+GenG4.menu.pnum.GENERIC_G474QCTX.upload.maximum_size=262144
+GenG4.menu.pnum.GENERIC_G474QCTX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G474QCTX.build.board=GENERIC_G474QCTX
+GenG4.menu.pnum.GENERIC_G474QCTX.build.product_line=STM32G474xx
+GenG4.menu.pnum.GENERIC_G474QCTX.build.variant=STM32G4xx/G473Q(B-C)T_G473QETx(Z)_G474Q(B-C-E)T_G483QET_G484QET
+GenG4.menu.pnum.GENERIC_G474QCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
+
+# Generic G474QETx
+GenG4.menu.pnum.GENERIC_G474QETX=Generic G474QETx
+GenG4.menu.pnum.GENERIC_G474QETX.upload.maximum_size=524288
+GenG4.menu.pnum.GENERIC_G474QETX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G474QETX.build.board=GENERIC_G474QETX
+GenG4.menu.pnum.GENERIC_G474QETX.build.product_line=STM32G474xx
+GenG4.menu.pnum.GENERIC_G474QETX.build.variant=STM32G4xx/G473Q(B-C)T_G473QETx(Z)_G474Q(B-C-E)T_G483QET_G484QET
+GenG4.menu.pnum.GENERIC_G474QETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
+
 # Generic G474VBHx
 GenG4.menu.pnum.GENERIC_G474VBHX=Generic G474VBHx
 GenG4.menu.pnum.GENERIC_G474VBHX.upload.maximum_size=131072
@@ -8831,15 +8839,6 @@ GenG4.menu.pnum.GENERIC_G474VBHX.build.board=GENERIC_G474VBHX
 GenG4.menu.pnum.GENERIC_G474VBHX.build.product_line=STM32G474xx
 GenG4.menu.pnum.GENERIC_G474VBHX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
 GenG4.menu.pnum.GENERIC_G474VBHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
-
-# Generic G474VBTx
-GenG4.menu.pnum.GENERIC_G474VBTX=Generic G474VBTx
-GenG4.menu.pnum.GENERIC_G474VBTX.upload.maximum_size=131072
-GenG4.menu.pnum.GENERIC_G474VBTX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G474VBTX.build.board=GENERIC_G474VBTX
-GenG4.menu.pnum.GENERIC_G474VBTX.build.product_line=STM32G474xx
-GenG4.menu.pnum.GENERIC_G474VBTX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
-GenG4.menu.pnum.GENERIC_G474VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
 
 # Generic G474VCHx
 GenG4.menu.pnum.GENERIC_G474VCHX=Generic G474VCHx
@@ -8850,15 +8849,6 @@ GenG4.menu.pnum.GENERIC_G474VCHX.build.product_line=STM32G474xx
 GenG4.menu.pnum.GENERIC_G474VCHX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
 GenG4.menu.pnum.GENERIC_G474VCHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
 
-# Generic G474VCTx
-GenG4.menu.pnum.GENERIC_G474VCTX=Generic G474VCTx
-GenG4.menu.pnum.GENERIC_G474VCTX.upload.maximum_size=262144
-GenG4.menu.pnum.GENERIC_G474VCTX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G474VCTX.build.board=GENERIC_G474VCTX
-GenG4.menu.pnum.GENERIC_G474VCTX.build.product_line=STM32G474xx
-GenG4.menu.pnum.GENERIC_G474VCTX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
-GenG4.menu.pnum.GENERIC_G474VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
-
 # Generic G474VEHx
 GenG4.menu.pnum.GENERIC_G474VEHX=Generic G474VEHx
 GenG4.menu.pnum.GENERIC_G474VEHX.upload.maximum_size=524288
@@ -8867,6 +8857,24 @@ GenG4.menu.pnum.GENERIC_G474VEHX.build.board=GENERIC_G474VEHX
 GenG4.menu.pnum.GENERIC_G474VEHX.build.product_line=STM32G474xx
 GenG4.menu.pnum.GENERIC_G474VEHX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
 GenG4.menu.pnum.GENERIC_G474VEHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
+
+# Generic G474VBTx
+GenG4.menu.pnum.GENERIC_G474VBTX=Generic G474VBTx
+GenG4.menu.pnum.GENERIC_G474VBTX.upload.maximum_size=131072
+GenG4.menu.pnum.GENERIC_G474VBTX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G474VBTX.build.board=GENERIC_G474VBTX
+GenG4.menu.pnum.GENERIC_G474VBTX.build.product_line=STM32G474xx
+GenG4.menu.pnum.GENERIC_G474VBTX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
+GenG4.menu.pnum.GENERIC_G474VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
+
+# Generic G474VCTx
+GenG4.menu.pnum.GENERIC_G474VCTX=Generic G474VCTx
+GenG4.menu.pnum.GENERIC_G474VCTX.upload.maximum_size=262144
+GenG4.menu.pnum.GENERIC_G474VCTX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G474VCTX.build.board=GENERIC_G474VCTX
+GenG4.menu.pnum.GENERIC_G474VCTX.build.product_line=STM32G474xx
+GenG4.menu.pnum.GENERIC_G474VCTX.build.variant=STM32G4xx/G473V(B-C-E)(H-T)_G474V(B-C-E)(H-T)_G483VE(H-T)_G484VE(H-T)
+GenG4.menu.pnum.GENERIC_G474VCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G474.svd
 
 # Generic G474VETx
 GenG4.menu.pnum.GENERIC_G474VETX=Generic G474VETx
@@ -8913,15 +8921,6 @@ GenG4.menu.pnum.GENERIC_G483PEIX.build.product_line=STM32G483xx
 GenG4.menu.pnum.GENERIC_G483PEIX.build.variant=STM32G4xx/G473P(B-C-E)I_G474P(B-C-E)I_G483PEI_G484PEI
 GenG4.menu.pnum.GENERIC_G483PEIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G483.svd
 
-# Generic G483QETx
-GenG4.menu.pnum.GENERIC_G483QETX=Generic G483QETx
-GenG4.menu.pnum.GENERIC_G483QETX.upload.maximum_size=524288
-GenG4.menu.pnum.GENERIC_G483QETX.upload.maximum_data_size=131072
-GenG4.menu.pnum.GENERIC_G483QETX.build.board=GENERIC_G483QETX
-GenG4.menu.pnum.GENERIC_G483QETX.build.product_line=STM32G483xx
-GenG4.menu.pnum.GENERIC_G483QETX.build.variant=STM32G4xx/G473Q(B-C)T_G473QETx(Z)_G474Q(B-C-E)T_G483QET_G484QET
-GenG4.menu.pnum.GENERIC_G483QETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G483.svd
-
 # Generic G483RETx
 GenG4.menu.pnum.GENERIC_G483RETX=Generic G483RETx
 GenG4.menu.pnum.GENERIC_G483RETX.upload.maximum_size=524288
@@ -8930,6 +8929,15 @@ GenG4.menu.pnum.GENERIC_G483RETX.build.board=GENERIC_G483RETX
 GenG4.menu.pnum.GENERIC_G483RETX.build.product_line=STM32G483xx
 GenG4.menu.pnum.GENERIC_G483RETX.build.variant=STM32G4xx/G473R(B-C)T_G473RETx(Z)_G474R(B-C-E)T_G483RET_G484RET
 GenG4.menu.pnum.GENERIC_G483RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G483.svd
+
+# Generic G483QETx
+GenG4.menu.pnum.GENERIC_G483QETX=Generic G483QETx
+GenG4.menu.pnum.GENERIC_G483QETX.upload.maximum_size=524288
+GenG4.menu.pnum.GENERIC_G483QETX.upload.maximum_data_size=131072
+GenG4.menu.pnum.GENERIC_G483QETX.build.board=GENERIC_G483QETX
+GenG4.menu.pnum.GENERIC_G483QETX.build.product_line=STM32G483xx
+GenG4.menu.pnum.GENERIC_G483QETX.build.variant=STM32G4xx/G473Q(B-C)T_G473QETx(Z)_G474Q(B-C-E)T_G483QET_G484QET
+GenG4.menu.pnum.GENERIC_G483QETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G483.svd
 
 # Generic G483VEHx
 GenG4.menu.pnum.GENERIC_G483VEHX=Generic G483VEHx
@@ -9066,15 +9074,6 @@ GenG4.menu.pnum.GENERIC_G491MCSX.build.product_line=STM32G491xx
 GenG4.menu.pnum.GENERIC_G491MCSX.build.variant=STM32G4xx/G491M(C-E)(S-T)_G4A1ME(S-T)
 GenG4.menu.pnum.GENERIC_G491MCSX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G491.svd
 
-# Generic G491MCTx
-GenG4.menu.pnum.GENERIC_G491MCTX=Generic G491MCTx
-GenG4.menu.pnum.GENERIC_G491MCTX.upload.maximum_size=262144
-GenG4.menu.pnum.GENERIC_G491MCTX.upload.maximum_data_size=114688
-GenG4.menu.pnum.GENERIC_G491MCTX.build.board=GENERIC_G491MCTX
-GenG4.menu.pnum.GENERIC_G491MCTX.build.product_line=STM32G491xx
-GenG4.menu.pnum.GENERIC_G491MCTX.build.variant=STM32G4xx/G491M(C-E)(S-T)_G4A1ME(S-T)
-GenG4.menu.pnum.GENERIC_G491MCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G491.svd
-
 # Generic G491MESx
 GenG4.menu.pnum.GENERIC_G491MESX=Generic G491MESx
 GenG4.menu.pnum.GENERIC_G491MESX.upload.maximum_size=524288
@@ -9083,6 +9082,15 @@ GenG4.menu.pnum.GENERIC_G491MESX.build.board=GENERIC_G491MESX
 GenG4.menu.pnum.GENERIC_G491MESX.build.product_line=STM32G491xx
 GenG4.menu.pnum.GENERIC_G491MESX.build.variant=STM32G4xx/G491M(C-E)(S-T)_G4A1ME(S-T)
 GenG4.menu.pnum.GENERIC_G491MESX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G491.svd
+
+# Generic G491MCTx
+GenG4.menu.pnum.GENERIC_G491MCTX=Generic G491MCTx
+GenG4.menu.pnum.GENERIC_G491MCTX.upload.maximum_size=262144
+GenG4.menu.pnum.GENERIC_G491MCTX.upload.maximum_data_size=114688
+GenG4.menu.pnum.GENERIC_G491MCTX.build.board=GENERIC_G491MCTX
+GenG4.menu.pnum.GENERIC_G491MCTX.build.product_line=STM32G491xx
+GenG4.menu.pnum.GENERIC_G491MCTX.build.variant=STM32G4xx/G491M(C-E)(S-T)_G4A1ME(S-T)
+GenG4.menu.pnum.GENERIC_G491MCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G491.svd
 
 # Generic G491METx
 GenG4.menu.pnum.GENERIC_G491METX=Generic G491METx
@@ -9102,15 +9110,6 @@ GenG4.menu.pnum.GENERIC_G491RCIX.build.product_line=STM32G491xx
 GenG4.menu.pnum.GENERIC_G491RCIX.build.variant=STM32G4xx/G491RC(I-T)_G491RE(I-T-Y)x(Z)_G4A1RE(I-T-Y)
 GenG4.menu.pnum.GENERIC_G491RCIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G491.svd
 
-# Generic G491RCTx
-GenG4.menu.pnum.GENERIC_G491RCTX=Generic G491RCTx
-GenG4.menu.pnum.GENERIC_G491RCTX.upload.maximum_size=262144
-GenG4.menu.pnum.GENERIC_G491RCTX.upload.maximum_data_size=114688
-GenG4.menu.pnum.GENERIC_G491RCTX.build.board=GENERIC_G491RCTX
-GenG4.menu.pnum.GENERIC_G491RCTX.build.product_line=STM32G491xx
-GenG4.menu.pnum.GENERIC_G491RCTX.build.variant=STM32G4xx/G491RC(I-T)_G491RE(I-T-Y)x(Z)_G4A1RE(I-T-Y)
-GenG4.menu.pnum.GENERIC_G491RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G491.svd
-
 # Generic G491REIx
 GenG4.menu.pnum.GENERIC_G491REIX=Generic G491REIx
 GenG4.menu.pnum.GENERIC_G491REIX.upload.maximum_size=524288
@@ -9119,6 +9118,15 @@ GenG4.menu.pnum.GENERIC_G491REIX.build.board=GENERIC_G491REIX
 GenG4.menu.pnum.GENERIC_G491REIX.build.product_line=STM32G491xx
 GenG4.menu.pnum.GENERIC_G491REIX.build.variant=STM32G4xx/G491RC(I-T)_G491RE(I-T-Y)x(Z)_G4A1RE(I-T-Y)
 GenG4.menu.pnum.GENERIC_G491REIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G491.svd
+
+# Generic G491RCTx
+GenG4.menu.pnum.GENERIC_G491RCTX=Generic G491RCTx
+GenG4.menu.pnum.GENERIC_G491RCTX.upload.maximum_size=262144
+GenG4.menu.pnum.GENERIC_G491RCTX.upload.maximum_data_size=114688
+GenG4.menu.pnum.GENERIC_G491RCTX.build.board=GENERIC_G491RCTX
+GenG4.menu.pnum.GENERIC_G491RCTX.build.product_line=STM32G491xx
+GenG4.menu.pnum.GENERIC_G491RCTX.build.variant=STM32G4xx/G491RC(I-T)_G491RE(I-T-Y)x(Z)_G4A1RE(I-T-Y)
+GenG4.menu.pnum.GENERIC_G491RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G491.svd
 
 # Generic G491RETx
 GenG4.menu.pnum.GENERIC_G491RETX=Generic G491RETx
@@ -9164,6 +9172,15 @@ GenG4.menu.pnum.GENERIC_G491VETX.build.product_line=STM32G491xx
 GenG4.menu.pnum.GENERIC_G491VETX.build.variant=STM32G4xx/G491V(C-E)T_G4A1VET
 GenG4.menu.pnum.GENERIC_G491VETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G491.svd
 
+# Generic G4A1REIx
+GenG4.menu.pnum.GENERIC_G4A1REIX=Generic G4A1REIx
+GenG4.menu.pnum.GENERIC_G4A1REIX.upload.maximum_size=524288
+GenG4.menu.pnum.GENERIC_G4A1REIX.upload.maximum_data_size=114688
+GenG4.menu.pnum.GENERIC_G4A1REIX.build.board=GENERIC_G4A1REIX
+GenG4.menu.pnum.GENERIC_G4A1REIX.build.product_line=STM32G4A1xx
+GenG4.menu.pnum.GENERIC_G4A1REIX.build.variant=STM32G4xx/G491RC(I-T)_G491RE(I-T-Y)x(Z)_G4A1RE(I-T-Y)
+GenG4.menu.pnum.GENERIC_G4A1REIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G4A1.svd
+
 # Generic G4A1CETx
 GenG4.menu.pnum.GENERIC_G4A1CETX=Generic G4A1CETx
 GenG4.menu.pnum.GENERIC_G4A1CETX.upload.maximum_size=524288
@@ -9199,15 +9216,6 @@ GenG4.menu.pnum.GENERIC_G4A1METX.build.board=GENERIC_G4A1METX
 GenG4.menu.pnum.GENERIC_G4A1METX.build.product_line=STM32G4A1xx
 GenG4.menu.pnum.GENERIC_G4A1METX.build.variant=STM32G4xx/G491M(C-E)(S-T)_G4A1ME(S-T)
 GenG4.menu.pnum.GENERIC_G4A1METX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G4A1.svd
-
-# Generic G4A1REIx
-GenG4.menu.pnum.GENERIC_G4A1REIX=Generic G4A1REIx
-GenG4.menu.pnum.GENERIC_G4A1REIX.upload.maximum_size=524288
-GenG4.menu.pnum.GENERIC_G4A1REIX.upload.maximum_data_size=114688
-GenG4.menu.pnum.GENERIC_G4A1REIX.build.board=GENERIC_G4A1REIX
-GenG4.menu.pnum.GENERIC_G4A1REIX.build.product_line=STM32G4A1xx
-GenG4.menu.pnum.GENERIC_G4A1REIX.build.variant=STM32G4xx/G491RC(I-T)_G491RE(I-T-Y)x(Z)_G4A1RE(I-T-Y)
-GenG4.menu.pnum.GENERIC_G4A1REIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G4A1.svd
 
 # Generic G4A1RETx
 GenG4.menu.pnum.GENERIC_G4A1RETX=Generic G4A1RETx
@@ -9480,6 +9488,18 @@ GenH7.openocd.target=stm32h7x
 GenH7.vid.0=0x0483
 GenH7.pid.0=0x5740
 
+# Daisy Seed board
+GenH7.menu.pnum.DAISY_SEED=Daisy Seed
+GenH7.menu.pnum.DAISY_SEED.upload.maximum_size=131072
+GenH7.menu.pnum.DAISY_SEED.upload.maximum_data_size=524288
+GenH7.menu.pnum.DAISY_SEED.build.board=DAISY_SEED
+GenH7.menu.pnum.DAISY_SEED.build.product_line=STM32H750xx
+GenH7.menu.pnum.DAISY_SEED.build.variant_h=variant_{build.board}.h
+GenH7.menu.pnum.DAISY_SEED.build.variant=STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)
+GenH7.menu.pnum.DAISY_SEED.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+GenH7.menu.pnum.DAISY_SEED.build.ldscript=DAISY_SEED.ld
+GenH7.menu.pnum.DAISY_SEED.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H750.svd
+
 # Daisy Patch SM board
 GenH7.menu.pnum.DAISY_PATCH_SM=Daisy Patch SM
 GenH7.menu.pnum.DAISY_PATCH_SM.upload.maximum_size=131072
@@ -9503,18 +9523,6 @@ GenH7.menu.pnum.DAISY_PETAL_SM.build.variant=STM32H7xx/H742I(G-I)(K-T)_H743I(G-I
 GenH7.menu.pnum.DAISY_PETAL_SM.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 GenH7.menu.pnum.DAISY_PETAL_SM.build.ldscript=DAISY_SEED.ld
 GenH7.menu.pnum.DAISY_PETAL_SM.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H750.svd
-
-# Daisy Seed board
-GenH7.menu.pnum.DAISY_SEED=Daisy Seed
-GenH7.menu.pnum.DAISY_SEED.upload.maximum_size=131072
-GenH7.menu.pnum.DAISY_SEED.upload.maximum_data_size=524288
-GenH7.menu.pnum.DAISY_SEED.build.board=DAISY_SEED
-GenH7.menu.pnum.DAISY_SEED.build.product_line=STM32H750xx
-GenH7.menu.pnum.DAISY_SEED.build.variant_h=variant_{build.board}.h
-GenH7.menu.pnum.DAISY_SEED.build.variant=STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)
-GenH7.menu.pnum.DAISY_SEED.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-GenH7.menu.pnum.DAISY_SEED.build.ldscript=DAISY_SEED.ld
-GenH7.menu.pnum.DAISY_SEED.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H750.svd
 
 # DevEBoxH743VITX
 GenH7.menu.pnum.DevEBoxH743VITX=DevEBox H743VITX
@@ -9544,7 +9552,7 @@ GenH7.menu.pnum.WeActMiniH723VGTX.upload.maximum_size=1048576
 GenH7.menu.pnum.WeActMiniH723VGTX.upload.maximum_data_size=327680
 GenH7.menu.pnum.WeActMiniH723VGTX.build.board=WeActMiniH723VGTX
 GenH7.menu.pnum.WeActMiniH723VGTX.build.product_line=STM32H723xx
-GenH7.menu.pnum.WeActMiniH723VGTX.build.variant_h=variant_WeActMiniH723VGTX.h
+GenH7.menu.pnum.WeActMiniH750VBTX.build.variant_h=variant_WeActMiniH7xx.h
 GenH7.menu.pnum.WeActMiniH723VGTX.build.variant=STM32H7xx/H723V(E-G)(H-T)_H730VB(H-T)_H733VG(H-T)
 GenH7.menu.pnum.WeActMiniH723VGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H723.svd
 
@@ -9687,15 +9695,6 @@ GenH7.menu.pnum.GENERIC_H742IGKX.build.product_line=STM32H742xx
 GenH7.menu.pnum.GENERIC_H742IGKX.build.variant=STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)
 GenH7.menu.pnum.GENERIC_H742IGKX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H742.svd
 
-# Generic H742IGTx
-GenH7.menu.pnum.GENERIC_H742IGTX=Generic H742IGTx
-GenH7.menu.pnum.GENERIC_H742IGTX.upload.maximum_size=1048576
-GenH7.menu.pnum.GENERIC_H742IGTX.upload.maximum_data_size=524288
-GenH7.menu.pnum.GENERIC_H742IGTX.build.board=GENERIC_H742IGTX
-GenH7.menu.pnum.GENERIC_H742IGTX.build.product_line=STM32H742xx
-GenH7.menu.pnum.GENERIC_H742IGTX.build.variant=STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)
-GenH7.menu.pnum.GENERIC_H742IGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H742.svd
-
 # Generic H742IIKx
 GenH7.menu.pnum.GENERIC_H742IIKX=Generic H742IIKx
 GenH7.menu.pnum.GENERIC_H742IIKX.upload.maximum_size=2097152
@@ -9704,6 +9703,15 @@ GenH7.menu.pnum.GENERIC_H742IIKX.build.board=GENERIC_H742IIKX
 GenH7.menu.pnum.GENERIC_H742IIKX.build.product_line=STM32H742xx
 GenH7.menu.pnum.GENERIC_H742IIKX.build.variant=STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)
 GenH7.menu.pnum.GENERIC_H742IIKX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H742.svd
+
+# Generic H742IGTx
+GenH7.menu.pnum.GENERIC_H742IGTX=Generic H742IGTx
+GenH7.menu.pnum.GENERIC_H742IGTX.upload.maximum_size=1048576
+GenH7.menu.pnum.GENERIC_H742IGTX.upload.maximum_data_size=524288
+GenH7.menu.pnum.GENERIC_H742IGTX.build.board=GENERIC_H742IGTX
+GenH7.menu.pnum.GENERIC_H742IGTX.build.product_line=STM32H742xx
+GenH7.menu.pnum.GENERIC_H742IGTX.build.variant=STM32H7xx/H742I(G-I)(K-T)_H743I(G-I)(K-T)_H750IB(K-T)_H753II(K-T)
+GenH7.menu.pnum.GENERIC_H742IGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H742.svd
 
 # Generic H742IITx
 GenH7.menu.pnum.GENERIC_H742IITX=Generic H742IITx
@@ -9723,15 +9731,6 @@ GenH7.menu.pnum.GENERIC_H742VGHX.build.product_line=STM32H742xx
 GenH7.menu.pnum.GENERIC_H742VGHX.build.variant=STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)
 GenH7.menu.pnum.GENERIC_H742VGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H742.svd
 
-# Generic H742VGTx
-GenH7.menu.pnum.GENERIC_H742VGTX=Generic H742VGTx
-GenH7.menu.pnum.GENERIC_H742VGTX.upload.maximum_size=1048576
-GenH7.menu.pnum.GENERIC_H742VGTX.upload.maximum_data_size=524288
-GenH7.menu.pnum.GENERIC_H742VGTX.build.board=GENERIC_H742VGTX
-GenH7.menu.pnum.GENERIC_H742VGTX.build.product_line=STM32H742xx
-GenH7.menu.pnum.GENERIC_H742VGTX.build.variant=STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)
-GenH7.menu.pnum.GENERIC_H742VGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H742.svd
-
 # Generic H742VIHx
 GenH7.menu.pnum.GENERIC_H742VIHX=Generic H742VIHx
 GenH7.menu.pnum.GENERIC_H742VIHX.upload.maximum_size=2097152
@@ -9740,6 +9739,15 @@ GenH7.menu.pnum.GENERIC_H742VIHX.build.board=GENERIC_H742VIHX
 GenH7.menu.pnum.GENERIC_H742VIHX.build.product_line=STM32H742xx
 GenH7.menu.pnum.GENERIC_H742VIHX.build.variant=STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)
 GenH7.menu.pnum.GENERIC_H742VIHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H742.svd
+
+# Generic H742VGTx
+GenH7.menu.pnum.GENERIC_H742VGTX=Generic H742VGTx
+GenH7.menu.pnum.GENERIC_H742VGTX.upload.maximum_size=1048576
+GenH7.menu.pnum.GENERIC_H742VGTX.upload.maximum_data_size=524288
+GenH7.menu.pnum.GENERIC_H742VGTX.build.board=GENERIC_H742VGTX
+GenH7.menu.pnum.GENERIC_H742VGTX.build.product_line=STM32H742xx
+GenH7.menu.pnum.GENERIC_H742VGTX.build.variant=STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)
+GenH7.menu.pnum.GENERIC_H742VGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H742.svd
 
 # Generic H742VITx
 GenH7.menu.pnum.GENERIC_H742VITX=Generic H742VITx
@@ -9831,15 +9839,6 @@ GenH7.menu.pnum.GENERIC_H743VGHX.build.product_line=STM32H743xx
 GenH7.menu.pnum.GENERIC_H743VGHX.build.variant=STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)
 GenH7.menu.pnum.GENERIC_H743VGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H743.svd
 
-# Generic H743VGTx
-GenH7.menu.pnum.GENERIC_H743VGTX=Generic H743VGTx
-GenH7.menu.pnum.GENERIC_H743VGTX.upload.maximum_size=1048576
-GenH7.menu.pnum.GENERIC_H743VGTX.upload.maximum_data_size=524288
-GenH7.menu.pnum.GENERIC_H743VGTX.build.board=GENERIC_H743VGTX
-GenH7.menu.pnum.GENERIC_H743VGTX.build.product_line=STM32H743xx
-GenH7.menu.pnum.GENERIC_H743VGTX.build.variant=STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)
-GenH7.menu.pnum.GENERIC_H743VGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H743.svd
-
 # Generic H743VIHx
 GenH7.menu.pnum.GENERIC_H743VIHX=Generic H743VIHx
 GenH7.menu.pnum.GENERIC_H743VIHX.upload.maximum_size=2097152
@@ -9848,6 +9847,15 @@ GenH7.menu.pnum.GENERIC_H743VIHX.build.board=GENERIC_H743VIHX
 GenH7.menu.pnum.GENERIC_H743VIHX.build.product_line=STM32H743xx
 GenH7.menu.pnum.GENERIC_H743VIHX.build.variant=STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)
 GenH7.menu.pnum.GENERIC_H743VIHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H743.svd
+
+# Generic H743VGTx
+GenH7.menu.pnum.GENERIC_H743VGTX=Generic H743VGTx
+GenH7.menu.pnum.GENERIC_H743VGTX.upload.maximum_size=1048576
+GenH7.menu.pnum.GENERIC_H743VGTX.upload.maximum_data_size=524288
+GenH7.menu.pnum.GENERIC_H743VGTX.build.board=GENERIC_H743VGTX
+GenH7.menu.pnum.GENERIC_H743VGTX.build.product_line=STM32H743xx
+GenH7.menu.pnum.GENERIC_H743VGTX.build.variant=STM32H7xx/H742V(G-I)(H-T)_H743V(G-I)(H-T)_H750VBT_H753VI(H-T)
+GenH7.menu.pnum.GENERIC_H743VGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H743.svd
 
 # Generic H743VITx
 GenH7.menu.pnum.GENERIC_H743VITX=Generic H743VITx
@@ -10137,15 +10145,6 @@ GenH7.menu.pnum.GENERIC_H7A3VGHX.build.product_line=STM32H7A3xx
 GenH7.menu.pnum.GENERIC_H7A3VGHX.build.variant=STM32H7xx/H7A3V(G-I)(H-T)_H7B0VBT_H7B3VI(H-T)
 GenH7.menu.pnum.GENERIC_H7A3VGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H7A3.svd
 
-# Generic H7A3VGTx
-GenH7.menu.pnum.GENERIC_H7A3VGTX=Generic H7A3VGTx
-GenH7.menu.pnum.GENERIC_H7A3VGTX.upload.maximum_size=1048576
-GenH7.menu.pnum.GENERIC_H7A3VGTX.upload.maximum_data_size=1048576
-GenH7.menu.pnum.GENERIC_H7A3VGTX.build.board=GENERIC_H7A3VGTX
-GenH7.menu.pnum.GENERIC_H7A3VGTX.build.product_line=STM32H7A3xx
-GenH7.menu.pnum.GENERIC_H7A3VGTX.build.variant=STM32H7xx/H7A3V(G-I)(H-T)_H7B0VBT_H7B3VI(H-T)
-GenH7.menu.pnum.GENERIC_H7A3VGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H7A3.svd
-
 # Generic H7A3VIHx
 GenH7.menu.pnum.GENERIC_H7A3VIHX=Generic H7A3VIHx
 GenH7.menu.pnum.GENERIC_H7A3VIHX.upload.maximum_size=2097152
@@ -10154,6 +10153,15 @@ GenH7.menu.pnum.GENERIC_H7A3VIHX.build.board=GENERIC_H7A3VIHX
 GenH7.menu.pnum.GENERIC_H7A3VIHX.build.product_line=STM32H7A3xx
 GenH7.menu.pnum.GENERIC_H7A3VIHX.build.variant=STM32H7xx/H7A3V(G-I)(H-T)_H7B0VBT_H7B3VI(H-T)
 GenH7.menu.pnum.GENERIC_H7A3VIHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H7A3.svd
+
+# Generic H7A3VGTx
+GenH7.menu.pnum.GENERIC_H7A3VGTX=Generic H7A3VGTx
+GenH7.menu.pnum.GENERIC_H7A3VGTX.upload.maximum_size=1048576
+GenH7.menu.pnum.GENERIC_H7A3VGTX.upload.maximum_data_size=1048576
+GenH7.menu.pnum.GENERIC_H7A3VGTX.build.board=GENERIC_H7A3VGTX
+GenH7.menu.pnum.GENERIC_H7A3VGTX.build.product_line=STM32H7A3xx
+GenH7.menu.pnum.GENERIC_H7A3VGTX.build.variant=STM32H7xx/H7A3V(G-I)(H-T)_H7B0VBT_H7B3VI(H-T)
+GenH7.menu.pnum.GENERIC_H7A3VGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32H7xx/STM32H7A3.svd
 
 # Generic H7A3VITx
 GenH7.menu.pnum.GENERIC_H7A3VITX=Generic H7A3VITx
@@ -10381,15 +10389,6 @@ GenL0.menu.pnum.GENERIC_L011F3PX.build.product_line=STM32L011xx
 GenL0.menu.pnum.GENERIC_L011F3PX.build.variant=STM32L0xx/L010F4P_L011F(3-4)P_L021F4P
 GenL0.menu.pnum.GENERIC_L011F3PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
 
-# Generic L011F3Ux
-GenL0.menu.pnum.GENERIC_L011F3UX=Generic L011F3Ux
-GenL0.menu.pnum.GENERIC_L011F3UX.upload.maximum_size=8192
-GenL0.menu.pnum.GENERIC_L011F3UX.upload.maximum_data_size=2048
-GenL0.menu.pnum.GENERIC_L011F3UX.build.board=GENERIC_L011F3UX
-GenL0.menu.pnum.GENERIC_L011F3UX.build.product_line=STM32L011xx
-GenL0.menu.pnum.GENERIC_L011F3UX.build.variant=STM32L0xx/L011F(3-4)U_L021F4U
-GenL0.menu.pnum.GENERIC_L011F3UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
-
 # Generic L011F4Px
 GenL0.menu.pnum.GENERIC_L011F4PX=Generic L011F4Px
 GenL0.menu.pnum.GENERIC_L011F4PX.upload.maximum_size=16384
@@ -10398,6 +10397,15 @@ GenL0.menu.pnum.GENERIC_L011F4PX.build.board=GENERIC_L011F4PX
 GenL0.menu.pnum.GENERIC_L011F4PX.build.product_line=STM32L011xx
 GenL0.menu.pnum.GENERIC_L011F4PX.build.variant=STM32L0xx/L010F4P_L011F(3-4)P_L021F4P
 GenL0.menu.pnum.GENERIC_L011F4PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
+
+# Generic L011F3Ux
+GenL0.menu.pnum.GENERIC_L011F3UX=Generic L011F3Ux
+GenL0.menu.pnum.GENERIC_L011F3UX.upload.maximum_size=8192
+GenL0.menu.pnum.GENERIC_L011F3UX.upload.maximum_data_size=2048
+GenL0.menu.pnum.GENERIC_L011F3UX.build.board=GENERIC_L011F3UX
+GenL0.menu.pnum.GENERIC_L011F3UX.build.product_line=STM32L011xx
+GenL0.menu.pnum.GENERIC_L011F3UX.build.variant=STM32L0xx/L011F(3-4)U_L021F4U
+GenL0.menu.pnum.GENERIC_L011F3UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
 
 # Generic L011F4Ux
 GenL0.menu.pnum.GENERIC_L011F4UX=Generic L011F4Ux
@@ -10462,15 +10470,6 @@ GenL0.menu.pnum.GENERIC_L011K4UX.build.product_line=STM32L011xx
 GenL0.menu.pnum.GENERIC_L011K4UX.build.variant=STM32L0xx/L011K(3-4)U_L021K4U
 GenL0.menu.pnum.GENERIC_L011K4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
 
-# Generic L021D4Px
-GenL0.menu.pnum.GENERIC_L021D4PX=Generic L021D4Px
-GenL0.menu.pnum.GENERIC_L021D4PX.upload.maximum_size=16384
-GenL0.menu.pnum.GENERIC_L021D4PX.upload.maximum_data_size=2048
-GenL0.menu.pnum.GENERIC_L021D4PX.build.board=GENERIC_L021D4PX
-GenL0.menu.pnum.GENERIC_L021D4PX.build.product_line=STM32L021xx
-GenL0.menu.pnum.GENERIC_L021D4PX.build.variant=STM32L0xx/L011D(3-4)P_L021D4P
-GenL0.menu.pnum.GENERIC_L021D4PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
-
 # Generic L021F4Px
 GenL0.menu.pnum.GENERIC_L021F4PX=Generic L021F4Px
 GenL0.menu.pnum.GENERIC_L021F4PX.upload.maximum_size=16384
@@ -10479,6 +10478,24 @@ GenL0.menu.pnum.GENERIC_L021F4PX.build.board=GENERIC_L021F4PX
 GenL0.menu.pnum.GENERIC_L021F4PX.build.product_line=STM32L021xx
 GenL0.menu.pnum.GENERIC_L021F4PX.build.variant=STM32L0xx/L010F4P_L011F(3-4)P_L021F4P
 GenL0.menu.pnum.GENERIC_L021F4PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
+
+# Generic L021K4Tx
+GenL0.menu.pnum.GENERIC_L021K4TX=Generic L021K4Tx
+GenL0.menu.pnum.GENERIC_L021K4TX.upload.maximum_size=16384
+GenL0.menu.pnum.GENERIC_L021K4TX.upload.maximum_data_size=2048
+GenL0.menu.pnum.GENERIC_L021K4TX.build.board=GENERIC_L021K4TX
+GenL0.menu.pnum.GENERIC_L021K4TX.build.product_line=STM32L021xx
+GenL0.menu.pnum.GENERIC_L021K4TX.build.variant=STM32L0xx/L010K4T_L011K(3-4)T_L021K4T
+GenL0.menu.pnum.GENERIC_L021K4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
+
+# Generic L021D4Px
+GenL0.menu.pnum.GENERIC_L021D4PX=Generic L021D4Px
+GenL0.menu.pnum.GENERIC_L021D4PX.upload.maximum_size=16384
+GenL0.menu.pnum.GENERIC_L021D4PX.upload.maximum_data_size=2048
+GenL0.menu.pnum.GENERIC_L021D4PX.build.board=GENERIC_L021D4PX
+GenL0.menu.pnum.GENERIC_L021D4PX.build.product_line=STM32L021xx
+GenL0.menu.pnum.GENERIC_L021D4PX.build.variant=STM32L0xx/L011D(3-4)P_L021D4P
+GenL0.menu.pnum.GENERIC_L021D4PX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
 
 # Generic L021F4Ux
 GenL0.menu.pnum.GENERIC_L021F4UX=Generic L021F4Ux
@@ -10498,15 +10515,6 @@ GenL0.menu.pnum.GENERIC_L021G4UX.build.product_line=STM32L021xx
 GenL0.menu.pnum.GENERIC_L021G4UX.build.variant=STM32L0xx/L011G(3-4)U_L021G4U
 GenL0.menu.pnum.GENERIC_L021G4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
 
-# Generic L021K4Tx
-GenL0.menu.pnum.GENERIC_L021K4TX=Generic L021K4Tx
-GenL0.menu.pnum.GENERIC_L021K4TX.upload.maximum_size=16384
-GenL0.menu.pnum.GENERIC_L021K4TX.upload.maximum_data_size=2048
-GenL0.menu.pnum.GENERIC_L021K4TX.build.board=GENERIC_L021K4TX
-GenL0.menu.pnum.GENERIC_L021K4TX.build.product_line=STM32L021xx
-GenL0.menu.pnum.GENERIC_L021K4TX.build.variant=STM32L0xx/L010K4T_L011K(3-4)T_L021K4T
-GenL0.menu.pnum.GENERIC_L021K4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
-
 # Generic L021K4Ux
 GenL0.menu.pnum.GENERIC_L021K4UX=Generic L021K4Ux
 GenL0.menu.pnum.GENERIC_L021K4UX.upload.maximum_size=16384
@@ -10525,15 +10533,6 @@ GenL0.menu.pnum.GENERIC_L031C4TX.build.product_line=STM32L031xx
 GenL0.menu.pnum.GENERIC_L031C4TX.build.variant=STM32L0xx/L031C(4-6)(T-U)_L041C4T_L041C6(T-U)
 GenL0.menu.pnum.GENERIC_L031C4TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
 
-# Generic L031C4Ux
-GenL0.menu.pnum.GENERIC_L031C4UX=Generic L031C4Ux
-GenL0.menu.pnum.GENERIC_L031C4UX.upload.maximum_size=16384
-GenL0.menu.pnum.GENERIC_L031C4UX.upload.maximum_data_size=8192
-GenL0.menu.pnum.GENERIC_L031C4UX.build.board=GENERIC_L031C4UX
-GenL0.menu.pnum.GENERIC_L031C4UX.build.product_line=STM32L031xx
-GenL0.menu.pnum.GENERIC_L031C4UX.build.variant=STM32L0xx/L031C(4-6)(T-U)_L041C4T_L041C6(T-U)
-GenL0.menu.pnum.GENERIC_L031C4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
-
 # Generic L031C6Tx
 GenL0.menu.pnum.GENERIC_L031C6TX=Generic L031C6Tx
 GenL0.menu.pnum.GENERIC_L031C6TX.upload.maximum_size=32768
@@ -10542,6 +10541,15 @@ GenL0.menu.pnum.GENERIC_L031C6TX.build.board=GENERIC_L031C6TX
 GenL0.menu.pnum.GENERIC_L031C6TX.build.product_line=STM32L031xx
 GenL0.menu.pnum.GENERIC_L031C6TX.build.variant=STM32L0xx/L031C(4-6)(T-U)_L041C4T_L041C6(T-U)
 GenL0.menu.pnum.GENERIC_L031C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
+
+# Generic L031C4Ux
+GenL0.menu.pnum.GENERIC_L031C4UX=Generic L031C4Ux
+GenL0.menu.pnum.GENERIC_L031C4UX.upload.maximum_size=16384
+GenL0.menu.pnum.GENERIC_L031C4UX.upload.maximum_data_size=8192
+GenL0.menu.pnum.GENERIC_L031C4UX.build.board=GENERIC_L031C4UX
+GenL0.menu.pnum.GENERIC_L031C4UX.build.product_line=STM32L031xx
+GenL0.menu.pnum.GENERIC_L031C4UX.build.variant=STM32L0xx/L031C(4-6)(T-U)_L041C4T_L041C6(T-U)
+GenL0.menu.pnum.GENERIC_L031C4UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
 
 # Generic L031C6Ux
 GenL0.menu.pnum.GENERIC_L031C6UX=Generic L031C6Ux
@@ -10768,15 +10776,6 @@ GenL0.menu.pnum.GENERIC_L052C6TX.build.product_line=STM32L052xx
 GenL0.menu.pnum.GENERIC_L052C6TX.build.variant=STM32L0xx/L052C(6-8)(T-U)_L053C(6-8)(T-U)_L062C8U_L063C8(T-U)
 GenL0.menu.pnum.GENERIC_L052C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
 
-# Generic L052C6Ux
-GenL0.menu.pnum.GENERIC_L052C6UX=Generic L052C6Ux
-GenL0.menu.pnum.GENERIC_L052C6UX.upload.maximum_size=32768
-GenL0.menu.pnum.GENERIC_L052C6UX.upload.maximum_data_size=8192
-GenL0.menu.pnum.GENERIC_L052C6UX.build.board=GENERIC_L052C6UX
-GenL0.menu.pnum.GENERIC_L052C6UX.build.product_line=STM32L052xx
-GenL0.menu.pnum.GENERIC_L052C6UX.build.variant=STM32L0xx/L052C(6-8)(T-U)_L053C(6-8)(T-U)_L062C8U_L063C8(T-U)
-GenL0.menu.pnum.GENERIC_L052C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
-
 # Generic L052C8Tx
 GenL0.menu.pnum.GENERIC_L052C8TX=Generic L052C8Tx
 GenL0.menu.pnum.GENERIC_L052C8TX.upload.maximum_size=65536
@@ -10785,6 +10784,15 @@ GenL0.menu.pnum.GENERIC_L052C8TX.build.board=GENERIC_L052C8TX
 GenL0.menu.pnum.GENERIC_L052C8TX.build.product_line=STM32L052xx
 GenL0.menu.pnum.GENERIC_L052C8TX.build.variant=STM32L0xx/L052C(6-8)(T-U)_L053C(6-8)(T-U)_L062C8U_L063C8(T-U)
 GenL0.menu.pnum.GENERIC_L052C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
+
+# Generic L052C6Ux
+GenL0.menu.pnum.GENERIC_L052C6UX=Generic L052C6Ux
+GenL0.menu.pnum.GENERIC_L052C6UX.upload.maximum_size=32768
+GenL0.menu.pnum.GENERIC_L052C6UX.upload.maximum_data_size=8192
+GenL0.menu.pnum.GENERIC_L052C6UX.build.board=GENERIC_L052C6UX
+GenL0.menu.pnum.GENERIC_L052C6UX.build.product_line=STM32L052xx
+GenL0.menu.pnum.GENERIC_L052C6UX.build.variant=STM32L0xx/L052C(6-8)(T-U)_L053C(6-8)(T-U)_L062C8U_L063C8(T-U)
+GenL0.menu.pnum.GENERIC_L052C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
 
 # Generic L052C8Ux
 GenL0.menu.pnum.GENERIC_L052C8UX=Generic L052C8Ux
@@ -10822,15 +10830,6 @@ GenL0.menu.pnum.GENERIC_L052R6HX.build.product_line=STM32L052xx
 GenL0.menu.pnum.GENERIC_L052R6HX.build.variant=STM32L0xx/L052R(6-8)H_L053R(6-8)H
 GenL0.menu.pnum.GENERIC_L052R6HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
 
-# Generic L052R6Tx
-GenL0.menu.pnum.GENERIC_L052R6TX=Generic L052R6Tx
-GenL0.menu.pnum.GENERIC_L052R6TX.upload.maximum_size=32768
-GenL0.menu.pnum.GENERIC_L052R6TX.upload.maximum_data_size=8192
-GenL0.menu.pnum.GENERIC_L052R6TX.build.board=GENERIC_L052R6TX
-GenL0.menu.pnum.GENERIC_L052R6TX.build.product_line=STM32L052xx
-GenL0.menu.pnum.GENERIC_L052R6TX.build.variant=STM32L0xx/L052R(6-8)T_L053R(6-8)T_L063R8T
-GenL0.menu.pnum.GENERIC_L052R6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
-
 # Generic L052R8Hx
 GenL0.menu.pnum.GENERIC_L052R8HX=Generic L052R8Hx
 GenL0.menu.pnum.GENERIC_L052R8HX.upload.maximum_size=65536
@@ -10839,6 +10838,15 @@ GenL0.menu.pnum.GENERIC_L052R8HX.build.board=GENERIC_L052R8HX
 GenL0.menu.pnum.GENERIC_L052R8HX.build.product_line=STM32L052xx
 GenL0.menu.pnum.GENERIC_L052R8HX.build.variant=STM32L0xx/L052R(6-8)H_L053R(6-8)H
 GenL0.menu.pnum.GENERIC_L052R8HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
+
+# Generic L052R6Tx
+GenL0.menu.pnum.GENERIC_L052R6TX=Generic L052R6Tx
+GenL0.menu.pnum.GENERIC_L052R6TX.upload.maximum_size=32768
+GenL0.menu.pnum.GENERIC_L052R6TX.upload.maximum_data_size=8192
+GenL0.menu.pnum.GENERIC_L052R6TX.build.board=GENERIC_L052R6TX
+GenL0.menu.pnum.GENERIC_L052R6TX.build.product_line=STM32L052xx
+GenL0.menu.pnum.GENERIC_L052R6TX.build.variant=STM32L0xx/L052R(6-8)T_L053R(6-8)T_L063R8T
+GenL0.menu.pnum.GENERIC_L052R6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
 
 # Generic L052R8Tx
 GenL0.menu.pnum.GENERIC_L052R8TX=Generic L052R8Tx
@@ -10858,15 +10866,6 @@ GenL0.menu.pnum.GENERIC_L052T6YX.build.product_line=STM32L052xx
 GenL0.menu.pnum.GENERIC_L052T6YX.build.variant=STM32L0xx/L052T6Y_L052T8(F-Y)
 GenL0.menu.pnum.GENERIC_L052T6YX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
 
-# Generic L052T8Fx
-GenL0.menu.pnum.GENERIC_L052T8FX=Generic L052T8Fx
-GenL0.menu.pnum.GENERIC_L052T8FX.upload.maximum_size=65536
-GenL0.menu.pnum.GENERIC_L052T8FX.upload.maximum_data_size=8192
-GenL0.menu.pnum.GENERIC_L052T8FX.build.board=GENERIC_L052T8FX
-GenL0.menu.pnum.GENERIC_L052T8FX.build.product_line=STM32L052xx
-GenL0.menu.pnum.GENERIC_L052T8FX.build.variant=STM32L0xx/L052T6Y_L052T8(F-Y)
-GenL0.menu.pnum.GENERIC_L052T8FX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
-
 # Generic L052T8Yx
 GenL0.menu.pnum.GENERIC_L052T8YX=Generic L052T8Yx
 GenL0.menu.pnum.GENERIC_L052T8YX.upload.maximum_size=65536
@@ -10875,6 +10874,15 @@ GenL0.menu.pnum.GENERIC_L052T8YX.build.board=GENERIC_L052T8YX
 GenL0.menu.pnum.GENERIC_L052T8YX.build.product_line=STM32L052xx
 GenL0.menu.pnum.GENERIC_L052T8YX.build.variant=STM32L0xx/L052T6Y_L052T8(F-Y)
 GenL0.menu.pnum.GENERIC_L052T8YX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
+
+# Generic L052T8Fx
+GenL0.menu.pnum.GENERIC_L052T8FX=Generic L052T8Fx
+GenL0.menu.pnum.GENERIC_L052T8FX.upload.maximum_size=65536
+GenL0.menu.pnum.GENERIC_L052T8FX.upload.maximum_data_size=8192
+GenL0.menu.pnum.GENERIC_L052T8FX.build.board=GENERIC_L052T8FX
+GenL0.menu.pnum.GENERIC_L052T8FX.build.product_line=STM32L052xx
+GenL0.menu.pnum.GENERIC_L052T8FX.build.variant=STM32L0xx/L052T6Y_L052T8(F-Y)
+GenL0.menu.pnum.GENERIC_L052T8FX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L052.svd
 
 # Generic L053C6Tx
 GenL0.menu.pnum.GENERIC_L053C6TX=Generic L053C6Tx
@@ -10885,15 +10893,6 @@ GenL0.menu.pnum.GENERIC_L053C6TX.build.product_line=STM32L053xx
 GenL0.menu.pnum.GENERIC_L053C6TX.build.variant=STM32L0xx/L052C(6-8)(T-U)_L053C(6-8)(T-U)_L062C8U_L063C8(T-U)
 GenL0.menu.pnum.GENERIC_L053C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L053.svd
 
-# Generic L053C6Ux
-GenL0.menu.pnum.GENERIC_L053C6UX=Generic L053C6Ux
-GenL0.menu.pnum.GENERIC_L053C6UX.upload.maximum_size=32768
-GenL0.menu.pnum.GENERIC_L053C6UX.upload.maximum_data_size=8192
-GenL0.menu.pnum.GENERIC_L053C6UX.build.board=GENERIC_L053C6UX
-GenL0.menu.pnum.GENERIC_L053C6UX.build.product_line=STM32L053xx
-GenL0.menu.pnum.GENERIC_L053C6UX.build.variant=STM32L0xx/L052C(6-8)(T-U)_L053C(6-8)(T-U)_L062C8U_L063C8(T-U)
-GenL0.menu.pnum.GENERIC_L053C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L053.svd
-
 # Generic L053C8Tx
 GenL0.menu.pnum.GENERIC_L053C8TX=Generic L053C8Tx
 GenL0.menu.pnum.GENERIC_L053C8TX.upload.maximum_size=65536
@@ -10902,6 +10901,15 @@ GenL0.menu.pnum.GENERIC_L053C8TX.build.board=GENERIC_L053C8TX
 GenL0.menu.pnum.GENERIC_L053C8TX.build.product_line=STM32L053xx
 GenL0.menu.pnum.GENERIC_L053C8TX.build.variant=STM32L0xx/L052C(6-8)(T-U)_L053C(6-8)(T-U)_L062C8U_L063C8(T-U)
 GenL0.menu.pnum.GENERIC_L053C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L053.svd
+
+# Generic L053C6Ux
+GenL0.menu.pnum.GENERIC_L053C6UX=Generic L053C6Ux
+GenL0.menu.pnum.GENERIC_L053C6UX.upload.maximum_size=32768
+GenL0.menu.pnum.GENERIC_L053C6UX.upload.maximum_data_size=8192
+GenL0.menu.pnum.GENERIC_L053C6UX.build.board=GENERIC_L053C6UX
+GenL0.menu.pnum.GENERIC_L053C6UX.build.product_line=STM32L053xx
+GenL0.menu.pnum.GENERIC_L053C6UX.build.variant=STM32L0xx/L052C(6-8)(T-U)_L053C(6-8)(T-U)_L062C8U_L063C8(T-U)
+GenL0.menu.pnum.GENERIC_L053C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L053.svd
 
 # Generic L053C8Ux
 GenL0.menu.pnum.GENERIC_L053C8UX=Generic L053C8Ux
@@ -10921,15 +10929,6 @@ GenL0.menu.pnum.GENERIC_L053R6HX.build.product_line=STM32L053xx
 GenL0.menu.pnum.GENERIC_L053R6HX.build.variant=STM32L0xx/L052R(6-8)H_L053R(6-8)H
 GenL0.menu.pnum.GENERIC_L053R6HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L053.svd
 
-# Generic L053R6Tx
-GenL0.menu.pnum.GENERIC_L053R6TX=Generic L053R6Tx
-GenL0.menu.pnum.GENERIC_L053R6TX.upload.maximum_size=32768
-GenL0.menu.pnum.GENERIC_L053R6TX.upload.maximum_data_size=8192
-GenL0.menu.pnum.GENERIC_L053R6TX.build.board=GENERIC_L053R6TX
-GenL0.menu.pnum.GENERIC_L053R6TX.build.product_line=STM32L053xx
-GenL0.menu.pnum.GENERIC_L053R6TX.build.variant=STM32L0xx/L052R(6-8)T_L053R(6-8)T_L063R8T
-GenL0.menu.pnum.GENERIC_L053R6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L053.svd
-
 # Generic L053R8Hx
 GenL0.menu.pnum.GENERIC_L053R8HX=Generic L053R8Hx
 GenL0.menu.pnum.GENERIC_L053R8HX.upload.maximum_size=65536
@@ -10938,6 +10937,15 @@ GenL0.menu.pnum.GENERIC_L053R8HX.build.board=GENERIC_L053R8HX
 GenL0.menu.pnum.GENERIC_L053R8HX.build.product_line=STM32L053xx
 GenL0.menu.pnum.GENERIC_L053R8HX.build.variant=STM32L0xx/L052R(6-8)H_L053R(6-8)H
 GenL0.menu.pnum.GENERIC_L053R8HX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L053.svd
+
+# Generic L053R6Tx
+GenL0.menu.pnum.GENERIC_L053R6TX=Generic L053R6Tx
+GenL0.menu.pnum.GENERIC_L053R6TX.upload.maximum_size=32768
+GenL0.menu.pnum.GENERIC_L053R6TX.upload.maximum_data_size=8192
+GenL0.menu.pnum.GENERIC_L053R6TX.build.board=GENERIC_L053R6TX
+GenL0.menu.pnum.GENERIC_L053R6TX.build.product_line=STM32L053xx
+GenL0.menu.pnum.GENERIC_L053R6TX.build.variant=STM32L0xx/L052R(6-8)T_L053R(6-8)T_L063R8T
+GenL0.menu.pnum.GENERIC_L053R6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L053.svd
 
 # Generic L053R8Tx
 GenL0.menu.pnum.GENERIC_L053R8TX=Generic L053R8Tx
@@ -11146,6 +11154,42 @@ GenL0.menu.pnum.GENERIC_L072RZTX.build.product_line=STM32L072xx
 GenL0.menu.pnum.GENERIC_L072RZTX.build.variant=STM32L0xx/L072R(B-Z)T_L073R(B-Z)T_L083R(B-Z)T
 GenL0.menu.pnum.GENERIC_L072RZTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
 
+# Generic L072VBIx
+GenL0.menu.pnum.GENERIC_L072VBIX=Generic L072VBIx
+GenL0.menu.pnum.GENERIC_L072VBIX.upload.maximum_size=131072
+GenL0.menu.pnum.GENERIC_L072VBIX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L072VBIX.build.board=GENERIC_L072VBIX
+GenL0.menu.pnum.GENERIC_L072VBIX.build.product_line=STM32L072xx
+GenL0.menu.pnum.GENERIC_L072VBIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L072VBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
+
+# Generic L072VZIx
+GenL0.menu.pnum.GENERIC_L072VZIX=Generic L072VZIx
+GenL0.menu.pnum.GENERIC_L072VZIX.upload.maximum_size=196608
+GenL0.menu.pnum.GENERIC_L072VZIX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L072VZIX.build.board=GENERIC_L072VZIX
+GenL0.menu.pnum.GENERIC_L072VZIX.build.product_line=STM32L072xx
+GenL0.menu.pnum.GENERIC_L072VZIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L072VZIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
+
+# Generic L072VBTx
+GenL0.menu.pnum.GENERIC_L072VBTX=Generic L072VBTx
+GenL0.menu.pnum.GENERIC_L072VBTX.upload.maximum_size=131072
+GenL0.menu.pnum.GENERIC_L072VBTX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L072VBTX.build.board=GENERIC_L072VBTX
+GenL0.menu.pnum.GENERIC_L072VBTX.build.product_line=STM32L072xx
+GenL0.menu.pnum.GENERIC_L072VBTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L072VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
+
+# Generic L072VZTx
+GenL0.menu.pnum.GENERIC_L072VZTX=Generic L072VZTx
+GenL0.menu.pnum.GENERIC_L072VZTX.upload.maximum_size=196608
+GenL0.menu.pnum.GENERIC_L072VZTX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L072VZTX.build.board=GENERIC_L072VZTX
+GenL0.menu.pnum.GENERIC_L072VZTX.build.product_line=STM32L072xx
+GenL0.menu.pnum.GENERIC_L072VZTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L072VZTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
+
 # Generic L072V8Ix
 GenL0.menu.pnum.GENERIC_L072V8IX=Generic L072V8Ix
 GenL0.menu.pnum.GENERIC_L072V8IX.upload.maximum_size=65536
@@ -11163,42 +11207,6 @@ GenL0.menu.pnum.GENERIC_L072V8TX.build.board=GENERIC_L072V8TX
 GenL0.menu.pnum.GENERIC_L072V8TX.build.product_line=STM32L072xx
 GenL0.menu.pnum.GENERIC_L072V8TX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
 GenL0.menu.pnum.GENERIC_L072V8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
-
-# Generic L072VBIx
-GenL0.menu.pnum.GENERIC_L072VBIX=Generic L072VBIx
-GenL0.menu.pnum.GENERIC_L072VBIX.upload.maximum_size=131072
-GenL0.menu.pnum.GENERIC_L072VBIX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L072VBIX.build.board=GENERIC_L072VBIX
-GenL0.menu.pnum.GENERIC_L072VBIX.build.product_line=STM32L072xx
-GenL0.menu.pnum.GENERIC_L072VBIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L072VBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
-
-# Generic L072VBTx
-GenL0.menu.pnum.GENERIC_L072VBTX=Generic L072VBTx
-GenL0.menu.pnum.GENERIC_L072VBTX.upload.maximum_size=131072
-GenL0.menu.pnum.GENERIC_L072VBTX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L072VBTX.build.board=GENERIC_L072VBTX
-GenL0.menu.pnum.GENERIC_L072VBTX.build.product_line=STM32L072xx
-GenL0.menu.pnum.GENERIC_L072VBTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L072VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
-
-# Generic L072VZIx
-GenL0.menu.pnum.GENERIC_L072VZIX=Generic L072VZIx
-GenL0.menu.pnum.GENERIC_L072VZIX.upload.maximum_size=196608
-GenL0.menu.pnum.GENERIC_L072VZIX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L072VZIX.build.board=GENERIC_L072VZIX
-GenL0.menu.pnum.GENERIC_L072VZIX.build.product_line=STM32L072xx
-GenL0.menu.pnum.GENERIC_L072VZIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L072VZIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
-
-# Generic L072VZTx
-GenL0.menu.pnum.GENERIC_L072VZTX=Generic L072VZTx
-GenL0.menu.pnum.GENERIC_L072VZTX.upload.maximum_size=196608
-GenL0.menu.pnum.GENERIC_L072VZTX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L072VZTX.build.board=GENERIC_L072VZTX
-GenL0.menu.pnum.GENERIC_L072VZTX.build.product_line=STM32L072xx
-GenL0.menu.pnum.GENERIC_L072VZTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L072VZTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x2.svd
 
 # Generic L073CBTx
 GenL0.menu.pnum.GENERIC_L073CBTX=Generic L073CBTx
@@ -11245,15 +11253,6 @@ GenL0.menu.pnum.GENERIC_L073CZYX.build.product_line=STM32L073xx
 GenL0.menu.pnum.GENERIC_L073CZYX.build.variant=STM32L0xx/L072CBY_L072CZ(E-Y)_L073CZY_L082CZY
 GenL0.menu.pnum.GENERIC_L073CZYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
 
-# Generic L073RBHx
-GenL0.menu.pnum.GENERIC_L073RBHX=Generic L073RBHx
-GenL0.menu.pnum.GENERIC_L073RBHX.upload.maximum_size=131072
-GenL0.menu.pnum.GENERIC_L073RBHX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L073RBHX.build.board=GENERIC_L073RBHX
-GenL0.menu.pnum.GENERIC_L073RBHX.build.product_line=STM32L073xx
-GenL0.menu.pnum.GENERIC_L073RBHX.build.variant=STM32L0xx/L072R(B-Z)(H-I)_L073RBH_L073RZ(H-I)_L083R(B-Z)H
-GenL0.menu.pnum.GENERIC_L073RBHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
-
 # Generic L073RBTx
 GenL0.menu.pnum.GENERIC_L073RBTX=Generic L073RBTx
 GenL0.menu.pnum.GENERIC_L073RBTX.upload.maximum_size=131072
@@ -11262,6 +11261,15 @@ GenL0.menu.pnum.GENERIC_L073RBTX.build.board=GENERIC_L073RBTX
 GenL0.menu.pnum.GENERIC_L073RBTX.build.product_line=STM32L073xx
 GenL0.menu.pnum.GENERIC_L073RBTX.build.variant=STM32L0xx/L072R(B-Z)T_L073R(B-Z)T_L083R(B-Z)T
 GenL0.menu.pnum.GENERIC_L073RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
+
+# Generic L073RBHx
+GenL0.menu.pnum.GENERIC_L073RBHX=Generic L073RBHx
+GenL0.menu.pnum.GENERIC_L073RBHX.upload.maximum_size=131072
+GenL0.menu.pnum.GENERIC_L073RBHX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L073RBHX.build.board=GENERIC_L073RBHX
+GenL0.menu.pnum.GENERIC_L073RBHX.build.product_line=STM32L073xx
+GenL0.menu.pnum.GENERIC_L073RBHX.build.variant=STM32L0xx/L072R(B-Z)(H-I)_L073RBH_L073RZ(H-I)_L083R(B-Z)H
+GenL0.menu.pnum.GENERIC_L073RBHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
 
 # Generic L073RZHx
 GenL0.menu.pnum.GENERIC_L073RZHX=Generic L073RZHx
@@ -11290,6 +11298,42 @@ GenL0.menu.pnum.GENERIC_L073RZTX.build.product_line=STM32L073xx
 GenL0.menu.pnum.GENERIC_L073RZTX.build.variant=STM32L0xx/L072R(B-Z)T_L073R(B-Z)T_L083R(B-Z)T
 GenL0.menu.pnum.GENERIC_L073RZTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
 
+# Generic L073VBIx
+GenL0.menu.pnum.GENERIC_L073VBIX=Generic L073VBIx
+GenL0.menu.pnum.GENERIC_L073VBIX.upload.maximum_size=131072
+GenL0.menu.pnum.GENERIC_L073VBIX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L073VBIX.build.board=GENERIC_L073VBIX
+GenL0.menu.pnum.GENERIC_L073VBIX.build.product_line=STM32L073xx
+GenL0.menu.pnum.GENERIC_L073VBIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L073VBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
+
+# Generic L073VZIx
+GenL0.menu.pnum.GENERIC_L073VZIX=Generic L073VZIx
+GenL0.menu.pnum.GENERIC_L073VZIX.upload.maximum_size=196608
+GenL0.menu.pnum.GENERIC_L073VZIX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L073VZIX.build.board=GENERIC_L073VZIX
+GenL0.menu.pnum.GENERIC_L073VZIX.build.product_line=STM32L073xx
+GenL0.menu.pnum.GENERIC_L073VZIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L073VZIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
+
+# Generic L073VBTx
+GenL0.menu.pnum.GENERIC_L073VBTX=Generic L073VBTx
+GenL0.menu.pnum.GENERIC_L073VBTX.upload.maximum_size=131072
+GenL0.menu.pnum.GENERIC_L073VBTX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L073VBTX.build.board=GENERIC_L073VBTX
+GenL0.menu.pnum.GENERIC_L073VBTX.build.product_line=STM32L073xx
+GenL0.menu.pnum.GENERIC_L073VBTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L073VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
+
+# Generic L073VZTx
+GenL0.menu.pnum.GENERIC_L073VZTX=Generic L073VZTx
+GenL0.menu.pnum.GENERIC_L073VZTX.upload.maximum_size=196608
+GenL0.menu.pnum.GENERIC_L073VZTX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L073VZTX.build.board=GENERIC_L073VZTX
+GenL0.menu.pnum.GENERIC_L073VZTX.build.product_line=STM32L073xx
+GenL0.menu.pnum.GENERIC_L073VZTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L073VZTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
+
 # Generic L073V8Ix
 GenL0.menu.pnum.GENERIC_L073V8IX=Generic L073V8Ix
 GenL0.menu.pnum.GENERIC_L073V8IX.upload.maximum_size=65536
@@ -11307,42 +11351,6 @@ GenL0.menu.pnum.GENERIC_L073V8TX.build.board=GENERIC_L073V8TX
 GenL0.menu.pnum.GENERIC_L073V8TX.build.product_line=STM32L073xx
 GenL0.menu.pnum.GENERIC_L073V8TX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
 GenL0.menu.pnum.GENERIC_L073V8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
-
-# Generic L073VBIx
-GenL0.menu.pnum.GENERIC_L073VBIX=Generic L073VBIx
-GenL0.menu.pnum.GENERIC_L073VBIX.upload.maximum_size=131072
-GenL0.menu.pnum.GENERIC_L073VBIX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L073VBIX.build.board=GENERIC_L073VBIX
-GenL0.menu.pnum.GENERIC_L073VBIX.build.product_line=STM32L073xx
-GenL0.menu.pnum.GENERIC_L073VBIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L073VBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
-
-# Generic L073VBTx
-GenL0.menu.pnum.GENERIC_L073VBTX=Generic L073VBTx
-GenL0.menu.pnum.GENERIC_L073VBTX.upload.maximum_size=131072
-GenL0.menu.pnum.GENERIC_L073VBTX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L073VBTX.build.board=GENERIC_L073VBTX
-GenL0.menu.pnum.GENERIC_L073VBTX.build.product_line=STM32L073xx
-GenL0.menu.pnum.GENERIC_L073VBTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L073VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
-
-# Generic L073VZIx
-GenL0.menu.pnum.GENERIC_L073VZIX=Generic L073VZIx
-GenL0.menu.pnum.GENERIC_L073VZIX.upload.maximum_size=196608
-GenL0.menu.pnum.GENERIC_L073VZIX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L073VZIX.build.board=GENERIC_L073VZIX
-GenL0.menu.pnum.GENERIC_L073VZIX.build.product_line=STM32L073xx
-GenL0.menu.pnum.GENERIC_L073VZIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L073VZIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
-
-# Generic L073VZTx
-GenL0.menu.pnum.GENERIC_L073VZTX=Generic L073VZTx
-GenL0.menu.pnum.GENERIC_L073VZTX.upload.maximum_size=196608
-GenL0.menu.pnum.GENERIC_L073VZTX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L073VZTX.build.board=GENERIC_L073VZTX
-GenL0.menu.pnum.GENERIC_L073VZTX.build.product_line=STM32L073xx
-GenL0.menu.pnum.GENERIC_L073VZTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L073VZTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
 
 # Generic L082CZUx
 GenL0.menu.pnum.GENERIC_L082CZUX=Generic L082CZUx
@@ -11461,6 +11469,42 @@ GenL0.menu.pnum.GENERIC_L083RZTX.build.product_line=STM32L083xx
 GenL0.menu.pnum.GENERIC_L083RZTX.build.variant=STM32L0xx/L072R(B-Z)T_L073R(B-Z)T_L083R(B-Z)T
 GenL0.menu.pnum.GENERIC_L083RZTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
 
+# Generic L083VBIx
+GenL0.menu.pnum.GENERIC_L083VBIX=Generic L083VBIx
+GenL0.menu.pnum.GENERIC_L083VBIX.upload.maximum_size=131072
+GenL0.menu.pnum.GENERIC_L083VBIX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L083VBIX.build.board=GENERIC_L083VBIX
+GenL0.menu.pnum.GENERIC_L083VBIX.build.product_line=STM32L083xx
+GenL0.menu.pnum.GENERIC_L083VBIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L083VBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
+
+# Generic L083VZIx
+GenL0.menu.pnum.GENERIC_L083VZIX=Generic L083VZIx
+GenL0.menu.pnum.GENERIC_L083VZIX.upload.maximum_size=196608
+GenL0.menu.pnum.GENERIC_L083VZIX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L083VZIX.build.board=GENERIC_L083VZIX
+GenL0.menu.pnum.GENERIC_L083VZIX.build.product_line=STM32L083xx
+GenL0.menu.pnum.GENERIC_L083VZIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L083VZIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
+
+# Generic L083VBTx
+GenL0.menu.pnum.GENERIC_L083VBTX=Generic L083VBTx
+GenL0.menu.pnum.GENERIC_L083VBTX.upload.maximum_size=131072
+GenL0.menu.pnum.GENERIC_L083VBTX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L083VBTX.build.board=GENERIC_L083VBTX
+GenL0.menu.pnum.GENERIC_L083VBTX.build.product_line=STM32L083xx
+GenL0.menu.pnum.GENERIC_L083VBTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L083VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
+
+# Generic L083VZTx
+GenL0.menu.pnum.GENERIC_L083VZTX=Generic L083VZTx
+GenL0.menu.pnum.GENERIC_L083VZTX.upload.maximum_size=196608
+GenL0.menu.pnum.GENERIC_L083VZTX.upload.maximum_data_size=20480
+GenL0.menu.pnum.GENERIC_L083VZTX.build.board=GENERIC_L083VZTX
+GenL0.menu.pnum.GENERIC_L083VZTX.build.product_line=STM32L083xx
+GenL0.menu.pnum.GENERIC_L083VZTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
+GenL0.menu.pnum.GENERIC_L083VZTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
+
 # Generic L083V8Ix
 GenL0.menu.pnum.GENERIC_L083V8IX=Generic L083V8Ix
 GenL0.menu.pnum.GENERIC_L083V8IX.upload.maximum_size=65536
@@ -11478,42 +11522,6 @@ GenL0.menu.pnum.GENERIC_L083V8TX.build.board=GENERIC_L083V8TX
 GenL0.menu.pnum.GENERIC_L083V8TX.build.product_line=STM32L083xx
 GenL0.menu.pnum.GENERIC_L083V8TX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
 GenL0.menu.pnum.GENERIC_L083V8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
-
-# Generic L083VBIx
-GenL0.menu.pnum.GENERIC_L083VBIX=Generic L083VBIx
-GenL0.menu.pnum.GENERIC_L083VBIX.upload.maximum_size=131072
-GenL0.menu.pnum.GENERIC_L083VBIX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L083VBIX.build.board=GENERIC_L083VBIX
-GenL0.menu.pnum.GENERIC_L083VBIX.build.product_line=STM32L083xx
-GenL0.menu.pnum.GENERIC_L083VBIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L083VBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
-
-# Generic L083VBTx
-GenL0.menu.pnum.GENERIC_L083VBTX=Generic L083VBTx
-GenL0.menu.pnum.GENERIC_L083VBTX.upload.maximum_size=131072
-GenL0.menu.pnum.GENERIC_L083VBTX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L083VBTX.build.board=GENERIC_L083VBTX
-GenL0.menu.pnum.GENERIC_L083VBTX.build.product_line=STM32L083xx
-GenL0.menu.pnum.GENERIC_L083VBTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L083VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
-
-# Generic L083VZIx
-GenL0.menu.pnum.GENERIC_L083VZIX=Generic L083VZIx
-GenL0.menu.pnum.GENERIC_L083VZIX.upload.maximum_size=196608
-GenL0.menu.pnum.GENERIC_L083VZIX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L083VZIX.build.board=GENERIC_L083VZIX
-GenL0.menu.pnum.GENERIC_L083VZIX.build.product_line=STM32L083xx
-GenL0.menu.pnum.GENERIC_L083VZIX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L083VZIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
-
-# Generic L083VZTx
-GenL0.menu.pnum.GENERIC_L083VZTX=Generic L083VZTx
-GenL0.menu.pnum.GENERIC_L083VZTX.upload.maximum_size=196608
-GenL0.menu.pnum.GENERIC_L083VZTX.upload.maximum_data_size=20480
-GenL0.menu.pnum.GENERIC_L083VZTX.build.board=GENERIC_L083VZTX
-GenL0.menu.pnum.GENERIC_L083VZTX.build.product_line=STM32L083xx
-GenL0.menu.pnum.GENERIC_L083VZTX.build.variant=STM32L0xx/L072V(8-B-Z)(I-T)_L073V(8-B-Z)(I-T)_L083V(8-B-Z)(I-T)
-GenL0.menu.pnum.GENERIC_L083VZTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
 
 # Upload menu
 GenL0.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
@@ -11593,33 +11601,6 @@ GenL1.menu.pnum.GENERIC_L151C6TX.build.product_line=STM32L151xB
 GenL1.menu.pnum.GENERIC_L151C6TX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L151C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
 
-# Generic L151C6TxA
-GenL1.menu.pnum.GENERIC_L151C6TXA=Generic L151C6TxA
-GenL1.menu.pnum.GENERIC_L151C6TXA.upload.maximum_size=32768
-GenL1.menu.pnum.GENERIC_L151C6TXA.upload.maximum_data_size=16384
-GenL1.menu.pnum.GENERIC_L151C6TXA.build.board=GENERIC_L151C6TXA
-GenL1.menu.pnum.GENERIC_L151C6TXA.build.product_line=STM32L151xBA
-GenL1.menu.pnum.GENERIC_L151C6TXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L151C6TXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
-
-# Generic L151C6Ux
-GenL1.menu.pnum.GENERIC_L151C6UX=Generic L151C6Ux
-GenL1.menu.pnum.GENERIC_L151C6UX.upload.maximum_size=32768
-GenL1.menu.pnum.GENERIC_L151C6UX.upload.maximum_data_size=10240
-GenL1.menu.pnum.GENERIC_L151C6UX.build.board=GENERIC_L151C6UX
-GenL1.menu.pnum.GENERIC_L151C6UX.build.product_line=STM32L151xB
-GenL1.menu.pnum.GENERIC_L151C6UX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L151C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
-
-# Generic L151C6UxA
-GenL1.menu.pnum.GENERIC_L151C6UXA=Generic L151C6UxA
-GenL1.menu.pnum.GENERIC_L151C6UXA.upload.maximum_size=32768
-GenL1.menu.pnum.GENERIC_L151C6UXA.upload.maximum_data_size=16384
-GenL1.menu.pnum.GENERIC_L151C6UXA.build.board=GENERIC_L151C6UXA
-GenL1.menu.pnum.GENERIC_L151C6UXA.build.product_line=STM32L151xBA
-GenL1.menu.pnum.GENERIC_L151C6UXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L151C6UXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
-
 # Generic L151C8Tx
 GenL1.menu.pnum.GENERIC_L151C8TX=Generic L151C8Tx
 GenL1.menu.pnum.GENERIC_L151C8TX.upload.maximum_size=65536
@@ -11628,33 +11609,6 @@ GenL1.menu.pnum.GENERIC_L151C8TX.build.board=GENERIC_L151C8TX
 GenL1.menu.pnum.GENERIC_L151C8TX.build.product_line=STM32L151xB
 GenL1.menu.pnum.GENERIC_L151C8TX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L151C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
-
-# Generic L151C8TxA
-GenL1.menu.pnum.GENERIC_L151C8TXA=Generic L151C8TxA
-GenL1.menu.pnum.GENERIC_L151C8TXA.upload.maximum_size=65536
-GenL1.menu.pnum.GENERIC_L151C8TXA.upload.maximum_data_size=32768
-GenL1.menu.pnum.GENERIC_L151C8TXA.build.board=GENERIC_L151C8TXA
-GenL1.menu.pnum.GENERIC_L151C8TXA.build.product_line=STM32L151xBA
-GenL1.menu.pnum.GENERIC_L151C8TXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L151C8TXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
-
-# Generic L151C8Ux
-GenL1.menu.pnum.GENERIC_L151C8UX=Generic L151C8Ux
-GenL1.menu.pnum.GENERIC_L151C8UX.upload.maximum_size=65536
-GenL1.menu.pnum.GENERIC_L151C8UX.upload.maximum_data_size=10240
-GenL1.menu.pnum.GENERIC_L151C8UX.build.board=GENERIC_L151C8UX
-GenL1.menu.pnum.GENERIC_L151C8UX.build.product_line=STM32L151xB
-GenL1.menu.pnum.GENERIC_L151C8UX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L151C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
-
-# Generic L151C8UxA
-GenL1.menu.pnum.GENERIC_L151C8UXA=Generic L151C8UxA
-GenL1.menu.pnum.GENERIC_L151C8UXA.upload.maximum_size=65536
-GenL1.menu.pnum.GENERIC_L151C8UXA.upload.maximum_data_size=32768
-GenL1.menu.pnum.GENERIC_L151C8UXA.build.board=GENERIC_L151C8UXA
-GenL1.menu.pnum.GENERIC_L151C8UXA.build.product_line=STM32L151xBA
-GenL1.menu.pnum.GENERIC_L151C8UXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L151C8UXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
 
 # Generic L151CBTx
 GenL1.menu.pnum.GENERIC_L151CBTX=Generic L151CBTx
@@ -11665,6 +11619,24 @@ GenL1.menu.pnum.GENERIC_L151CBTX.build.product_line=STM32L151xB
 GenL1.menu.pnum.GENERIC_L151CBTX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L151CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
 
+# Generic L151C6TxA
+GenL1.menu.pnum.GENERIC_L151C6TXA=Generic L151C6TxA
+GenL1.menu.pnum.GENERIC_L151C6TXA.upload.maximum_size=32768
+GenL1.menu.pnum.GENERIC_L151C6TXA.upload.maximum_data_size=16384
+GenL1.menu.pnum.GENERIC_L151C6TXA.build.board=GENERIC_L151C6TXA
+GenL1.menu.pnum.GENERIC_L151C6TXA.build.product_line=STM32L151xBA
+GenL1.menu.pnum.GENERIC_L151C6TXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L151C6TXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
+
+# Generic L151C8TxA
+GenL1.menu.pnum.GENERIC_L151C8TXA=Generic L151C8TxA
+GenL1.menu.pnum.GENERIC_L151C8TXA.upload.maximum_size=65536
+GenL1.menu.pnum.GENERIC_L151C8TXA.upload.maximum_data_size=32768
+GenL1.menu.pnum.GENERIC_L151C8TXA.build.board=GENERIC_L151C8TXA
+GenL1.menu.pnum.GENERIC_L151C8TXA.build.product_line=STM32L151xBA
+GenL1.menu.pnum.GENERIC_L151C8TXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L151C8TXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
+
 # Generic L151CBTxA
 GenL1.menu.pnum.GENERIC_L151CBTXA=Generic L151CBTxA
 GenL1.menu.pnum.GENERIC_L151CBTXA.upload.maximum_size=131072
@@ -11673,6 +11645,24 @@ GenL1.menu.pnum.GENERIC_L151CBTXA.build.board=GENERIC_L151CBTXA
 GenL1.menu.pnum.GENERIC_L151CBTXA.build.product_line=STM32L151xBA
 GenL1.menu.pnum.GENERIC_L151CBTXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L151CBTXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
+
+# Generic L151C6Ux
+GenL1.menu.pnum.GENERIC_L151C6UX=Generic L151C6Ux
+GenL1.menu.pnum.GENERIC_L151C6UX.upload.maximum_size=32768
+GenL1.menu.pnum.GENERIC_L151C6UX.upload.maximum_data_size=10240
+GenL1.menu.pnum.GENERIC_L151C6UX.build.board=GENERIC_L151C6UX
+GenL1.menu.pnum.GENERIC_L151C6UX.build.product_line=STM32L151xB
+GenL1.menu.pnum.GENERIC_L151C6UX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L151C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
+
+# Generic L151C8Ux
+GenL1.menu.pnum.GENERIC_L151C8UX=Generic L151C8Ux
+GenL1.menu.pnum.GENERIC_L151C8UX.upload.maximum_size=65536
+GenL1.menu.pnum.GENERIC_L151C8UX.upload.maximum_data_size=10240
+GenL1.menu.pnum.GENERIC_L151C8UX.build.board=GENERIC_L151C8UX
+GenL1.menu.pnum.GENERIC_L151C8UX.build.product_line=STM32L151xB
+GenL1.menu.pnum.GENERIC_L151C8UX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L151C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
 
 # Generic L151CBUx
 GenL1.menu.pnum.GENERIC_L151CBUX=Generic L151CBUx
@@ -11683,6 +11673,24 @@ GenL1.menu.pnum.GENERIC_L151CBUX.build.product_line=STM32L151xB
 GenL1.menu.pnum.GENERIC_L151CBUX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L151CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
 
+# Generic L151C6UxA
+GenL1.menu.pnum.GENERIC_L151C6UXA=Generic L151C6UxA
+GenL1.menu.pnum.GENERIC_L151C6UXA.upload.maximum_size=32768
+GenL1.menu.pnum.GENERIC_L151C6UXA.upload.maximum_data_size=16384
+GenL1.menu.pnum.GENERIC_L151C6UXA.build.board=GENERIC_L151C6UXA
+GenL1.menu.pnum.GENERIC_L151C6UXA.build.product_line=STM32L151xBA
+GenL1.menu.pnum.GENERIC_L151C6UXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L151C6UXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
+
+# Generic L151C8UxA
+GenL1.menu.pnum.GENERIC_L151C8UXA=Generic L151C8UxA
+GenL1.menu.pnum.GENERIC_L151C8UXA.upload.maximum_size=65536
+GenL1.menu.pnum.GENERIC_L151C8UXA.upload.maximum_data_size=32768
+GenL1.menu.pnum.GENERIC_L151C8UXA.build.board=GENERIC_L151C8UXA
+GenL1.menu.pnum.GENERIC_L151C8UXA.build.product_line=STM32L151xBA
+GenL1.menu.pnum.GENERIC_L151C8UXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L151C8UXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
+
 # Generic L151CBUxA
 GenL1.menu.pnum.GENERIC_L151CBUXA=Generic L151CBUxA
 GenL1.menu.pnum.GENERIC_L151CBUXA.upload.maximum_size=131072
@@ -11691,15 +11699,6 @@ GenL1.menu.pnum.GENERIC_L151CBUXA.build.board=GENERIC_L151CBUXA
 GenL1.menu.pnum.GENERIC_L151CBUXA.build.product_line=STM32L151xBA
 GenL1.menu.pnum.GENERIC_L151CBUXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L151CBUXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
-
-# Generic L151RETx
-GenL1.menu.pnum.GENERIC_L151RETX=Generic L151RETx
-GenL1.menu.pnum.GENERIC_L151RETX.upload.maximum_size=524288
-GenL1.menu.pnum.GENERIC_L151RETX.upload.maximum_data_size=81920
-GenL1.menu.pnum.GENERIC_L151RETX.build.board=GENERIC_L151RETX
-GenL1.menu.pnum.GENERIC_L151RETX.build.product_line=STM32L151xE
-GenL1.menu.pnum.GENERIC_L151RETX.build.variant=STM32L1xx/L151RET_L152RET_L162RET
-GenL1.menu.pnum.GENERIC_L151RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
 
 # Generic L151ZDTx
 GenL1.menu.pnum.GENERIC_L151ZDTX=Generic L151ZDTx
@@ -11719,33 +11718,6 @@ GenL1.menu.pnum.GENERIC_L152C6TX.build.product_line=STM32L152xB
 GenL1.menu.pnum.GENERIC_L152C6TX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L152C6TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
 
-# Generic L152C6TxA
-GenL1.menu.pnum.GENERIC_L152C6TXA=Generic L152C6TxA
-GenL1.menu.pnum.GENERIC_L152C6TXA.upload.maximum_size=32768
-GenL1.menu.pnum.GENERIC_L152C6TXA.upload.maximum_data_size=16384
-GenL1.menu.pnum.GENERIC_L152C6TXA.build.board=GENERIC_L152C6TXA
-GenL1.menu.pnum.GENERIC_L152C6TXA.build.product_line=STM32L152xBA
-GenL1.menu.pnum.GENERIC_L152C6TXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L152C6TXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
-
-# Generic L152C6Ux
-GenL1.menu.pnum.GENERIC_L152C6UX=Generic L152C6Ux
-GenL1.menu.pnum.GENERIC_L152C6UX.upload.maximum_size=32768
-GenL1.menu.pnum.GENERIC_L152C6UX.upload.maximum_data_size=10240
-GenL1.menu.pnum.GENERIC_L152C6UX.build.board=GENERIC_L152C6UX
-GenL1.menu.pnum.GENERIC_L152C6UX.build.product_line=STM32L152xB
-GenL1.menu.pnum.GENERIC_L152C6UX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L152C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
-
-# Generic L152C6UxA
-GenL1.menu.pnum.GENERIC_L152C6UXA=Generic L152C6UxA
-GenL1.menu.pnum.GENERIC_L152C6UXA.upload.maximum_size=32768
-GenL1.menu.pnum.GENERIC_L152C6UXA.upload.maximum_data_size=16384
-GenL1.menu.pnum.GENERIC_L152C6UXA.build.board=GENERIC_L152C6UXA
-GenL1.menu.pnum.GENERIC_L152C6UXA.build.product_line=STM32L152xBA
-GenL1.menu.pnum.GENERIC_L152C6UXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L152C6UXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
-
 # Generic L152C8Tx
 GenL1.menu.pnum.GENERIC_L152C8TX=Generic L152C8Tx
 GenL1.menu.pnum.GENERIC_L152C8TX.upload.maximum_size=65536
@@ -11754,33 +11726,6 @@ GenL1.menu.pnum.GENERIC_L152C8TX.build.board=GENERIC_L152C8TX
 GenL1.menu.pnum.GENERIC_L152C8TX.build.product_line=STM32L152xB
 GenL1.menu.pnum.GENERIC_L152C8TX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L152C8TX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
-
-# Generic L152C8TxA
-GenL1.menu.pnum.GENERIC_L152C8TXA=Generic L152C8TxA
-GenL1.menu.pnum.GENERIC_L152C8TXA.upload.maximum_size=65536
-GenL1.menu.pnum.GENERIC_L152C8TXA.upload.maximum_data_size=32768
-GenL1.menu.pnum.GENERIC_L152C8TXA.build.board=GENERIC_L152C8TXA
-GenL1.menu.pnum.GENERIC_L152C8TXA.build.product_line=STM32L152xBA
-GenL1.menu.pnum.GENERIC_L152C8TXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L152C8TXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
-
-# Generic L152C8Ux
-GenL1.menu.pnum.GENERIC_L152C8UX=Generic L152C8Ux
-GenL1.menu.pnum.GENERIC_L152C8UX.upload.maximum_size=65536
-GenL1.menu.pnum.GENERIC_L152C8UX.upload.maximum_data_size=10240
-GenL1.menu.pnum.GENERIC_L152C8UX.build.board=GENERIC_L152C8UX
-GenL1.menu.pnum.GENERIC_L152C8UX.build.product_line=STM32L152xB
-GenL1.menu.pnum.GENERIC_L152C8UX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L152C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
-
-# Generic L152C8UxA
-GenL1.menu.pnum.GENERIC_L152C8UXA=Generic L152C8UxA
-GenL1.menu.pnum.GENERIC_L152C8UXA.upload.maximum_size=65536
-GenL1.menu.pnum.GENERIC_L152C8UXA.upload.maximum_data_size=32768
-GenL1.menu.pnum.GENERIC_L152C8UXA.build.board=GENERIC_L152C8UXA
-GenL1.menu.pnum.GENERIC_L152C8UXA.build.product_line=STM32L152xBA
-GenL1.menu.pnum.GENERIC_L152C8UXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
-GenL1.menu.pnum.GENERIC_L152C8UXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
 
 # Generic L152CBTx
 GenL1.menu.pnum.GENERIC_L152CBTX=Generic L152CBTx
@@ -11791,6 +11736,24 @@ GenL1.menu.pnum.GENERIC_L152CBTX.build.product_line=STM32L152xB
 GenL1.menu.pnum.GENERIC_L152CBTX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L152CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
 
+# Generic L152C6TxA
+GenL1.menu.pnum.GENERIC_L152C6TXA=Generic L152C6TxA
+GenL1.menu.pnum.GENERIC_L152C6TXA.upload.maximum_size=32768
+GenL1.menu.pnum.GENERIC_L152C6TXA.upload.maximum_data_size=16384
+GenL1.menu.pnum.GENERIC_L152C6TXA.build.board=GENERIC_L152C6TXA
+GenL1.menu.pnum.GENERIC_L152C6TXA.build.product_line=STM32L152xBA
+GenL1.menu.pnum.GENERIC_L152C6TXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L152C6TXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
+
+# Generic L152C8TxA
+GenL1.menu.pnum.GENERIC_L152C8TXA=Generic L152C8TxA
+GenL1.menu.pnum.GENERIC_L152C8TXA.upload.maximum_size=65536
+GenL1.menu.pnum.GENERIC_L152C8TXA.upload.maximum_data_size=32768
+GenL1.menu.pnum.GENERIC_L152C8TXA.build.board=GENERIC_L152C8TXA
+GenL1.menu.pnum.GENERIC_L152C8TXA.build.product_line=STM32L152xBA
+GenL1.menu.pnum.GENERIC_L152C8TXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L152C8TXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
+
 # Generic L152CBTxA
 GenL1.menu.pnum.GENERIC_L152CBTXA=Generic L152CBTxA
 GenL1.menu.pnum.GENERIC_L152CBTXA.upload.maximum_size=131072
@@ -11799,6 +11762,24 @@ GenL1.menu.pnum.GENERIC_L152CBTXA.build.board=GENERIC_L152CBTXA
 GenL1.menu.pnum.GENERIC_L152CBTXA.build.product_line=STM32L152xBA
 GenL1.menu.pnum.GENERIC_L152CBTXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L152CBTXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
+
+# Generic L152C6Ux
+GenL1.menu.pnum.GENERIC_L152C6UX=Generic L152C6Ux
+GenL1.menu.pnum.GENERIC_L152C6UX.upload.maximum_size=32768
+GenL1.menu.pnum.GENERIC_L152C6UX.upload.maximum_data_size=10240
+GenL1.menu.pnum.GENERIC_L152C6UX.build.board=GENERIC_L152C6UX
+GenL1.menu.pnum.GENERIC_L152C6UX.build.product_line=STM32L152xB
+GenL1.menu.pnum.GENERIC_L152C6UX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L152C6UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
+
+# Generic L152C8Ux
+GenL1.menu.pnum.GENERIC_L152C8UX=Generic L152C8Ux
+GenL1.menu.pnum.GENERIC_L152C8UX.upload.maximum_size=65536
+GenL1.menu.pnum.GENERIC_L152C8UX.upload.maximum_data_size=10240
+GenL1.menu.pnum.GENERIC_L152C8UX.build.board=GENERIC_L152C8UX
+GenL1.menu.pnum.GENERIC_L152C8UX.build.product_line=STM32L152xB
+GenL1.menu.pnum.GENERIC_L152C8UX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L152C8UX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
 
 # Generic L152CBUx
 GenL1.menu.pnum.GENERIC_L152CBUX=Generic L152CBUx
@@ -11809,6 +11790,24 @@ GenL1.menu.pnum.GENERIC_L152CBUX.build.product_line=STM32L152xB
 GenL1.menu.pnum.GENERIC_L152CBUX.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L152CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
 
+# Generic L152C6UxA
+GenL1.menu.pnum.GENERIC_L152C6UXA=Generic L152C6UxA
+GenL1.menu.pnum.GENERIC_L152C6UXA.upload.maximum_size=32768
+GenL1.menu.pnum.GENERIC_L152C6UXA.upload.maximum_data_size=16384
+GenL1.menu.pnum.GENERIC_L152C6UXA.build.board=GENERIC_L152C6UXA
+GenL1.menu.pnum.GENERIC_L152C6UXA.build.product_line=STM32L152xBA
+GenL1.menu.pnum.GENERIC_L152C6UXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L152C6UXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
+
+# Generic L152C8UxA
+GenL1.menu.pnum.GENERIC_L152C8UXA=Generic L152C8UxA
+GenL1.menu.pnum.GENERIC_L152C8UXA.upload.maximum_size=65536
+GenL1.menu.pnum.GENERIC_L152C8UXA.upload.maximum_data_size=32768
+GenL1.menu.pnum.GENERIC_L152C8UXA.build.board=GENERIC_L152C8UXA
+GenL1.menu.pnum.GENERIC_L152C8UXA.build.product_line=STM32L152xBA
+GenL1.menu.pnum.GENERIC_L152C8UXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
+GenL1.menu.pnum.GENERIC_L152C8UXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
+
 # Generic L152CBUxA
 GenL1.menu.pnum.GENERIC_L152CBUXA=Generic L152CBUxA
 GenL1.menu.pnum.GENERIC_L152CBUXA.upload.maximum_size=131072
@@ -11817,6 +11816,15 @@ GenL1.menu.pnum.GENERIC_L152CBUXA.build.board=GENERIC_L152CBUXA
 GenL1.menu.pnum.GENERIC_L152CBUXA.build.product_line=STM32L152xBA
 GenL1.menu.pnum.GENERIC_L152CBUXA.build.variant=STM32L1xx/L100C6Ux(A)_L151C(6-8-B)(T-U)x(A)_L152C(6-8-B)(T-U)x(A)
 GenL1.menu.pnum.GENERIC_L152CBUXA.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L152.svd
+
+# Generic L151RETx
+GenL1.menu.pnum.GENERIC_L151RETX=Generic L151RETx
+GenL1.menu.pnum.GENERIC_L151RETX.upload.maximum_size=524288
+GenL1.menu.pnum.GENERIC_L151RETX.upload.maximum_data_size=81920
+GenL1.menu.pnum.GENERIC_L151RETX.build.board=GENERIC_L151RETX
+GenL1.menu.pnum.GENERIC_L151RETX.build.product_line=STM32L151xE
+GenL1.menu.pnum.GENERIC_L151RETX.build.variant=STM32L1xx/L151RET_L152RET_L162RET
+GenL1.menu.pnum.GENERIC_L151RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L1xx/STM32L151.svd
 
 # Generic L152RETx
 GenL1.menu.pnum.GENERIC_L152RETX=Generic L152RETx
@@ -12034,24 +12042,6 @@ GenL4.menu.pnum.GENERIC_L431RBIX.build.product_line=STM32L431xx
 GenL4.menu.pnum.GENERIC_L431RBIX.build.variant=STM32L4xx/L431R(B-C)(I-T-Y)
 GenL4.menu.pnum.GENERIC_L431RBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L431.svd
 
-# Generic L431RBTx
-GenL4.menu.pnum.GENERIC_L431RBTX=Generic L431RBTx
-GenL4.menu.pnum.GENERIC_L431RBTX.upload.maximum_size=131072
-GenL4.menu.pnum.GENERIC_L431RBTX.upload.maximum_data_size=65536
-GenL4.menu.pnum.GENERIC_L431RBTX.build.board=GENERIC_L431RBTX
-GenL4.menu.pnum.GENERIC_L431RBTX.build.product_line=STM32L431xx
-GenL4.menu.pnum.GENERIC_L431RBTX.build.variant=STM32L4xx/L431R(B-C)(I-T-Y)
-GenL4.menu.pnum.GENERIC_L431RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L431.svd
-
-# Generic L431RBYx
-GenL4.menu.pnum.GENERIC_L431RBYX=Generic L431RBYx
-GenL4.menu.pnum.GENERIC_L431RBYX.upload.maximum_size=131072
-GenL4.menu.pnum.GENERIC_L431RBYX.upload.maximum_data_size=65536
-GenL4.menu.pnum.GENERIC_L431RBYX.build.board=GENERIC_L431RBYX
-GenL4.menu.pnum.GENERIC_L431RBYX.build.product_line=STM32L431xx
-GenL4.menu.pnum.GENERIC_L431RBYX.build.variant=STM32L4xx/L431R(B-C)(I-T-Y)
-GenL4.menu.pnum.GENERIC_L431RBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L431.svd
-
 # Generic L431RCIx
 GenL4.menu.pnum.GENERIC_L431RCIX=Generic L431RCIx
 GenL4.menu.pnum.GENERIC_L431RCIX.upload.maximum_size=262144
@@ -12061,6 +12051,15 @@ GenL4.menu.pnum.GENERIC_L431RCIX.build.product_line=STM32L431xx
 GenL4.menu.pnum.GENERIC_L431RCIX.build.variant=STM32L4xx/L431R(B-C)(I-T-Y)
 GenL4.menu.pnum.GENERIC_L431RCIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L431.svd
 
+# Generic L431RBTx
+GenL4.menu.pnum.GENERIC_L431RBTX=Generic L431RBTx
+GenL4.menu.pnum.GENERIC_L431RBTX.upload.maximum_size=131072
+GenL4.menu.pnum.GENERIC_L431RBTX.upload.maximum_data_size=65536
+GenL4.menu.pnum.GENERIC_L431RBTX.build.board=GENERIC_L431RBTX
+GenL4.menu.pnum.GENERIC_L431RBTX.build.product_line=STM32L431xx
+GenL4.menu.pnum.GENERIC_L431RBTX.build.variant=STM32L4xx/L431R(B-C)(I-T-Y)
+GenL4.menu.pnum.GENERIC_L431RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L431.svd
+
 # Generic L431RCTx
 GenL4.menu.pnum.GENERIC_L431RCTX=Generic L431RCTx
 GenL4.menu.pnum.GENERIC_L431RCTX.upload.maximum_size=262144
@@ -12069,6 +12068,15 @@ GenL4.menu.pnum.GENERIC_L431RCTX.build.board=GENERIC_L431RCTX
 GenL4.menu.pnum.GENERIC_L431RCTX.build.product_line=STM32L431xx
 GenL4.menu.pnum.GENERIC_L431RCTX.build.variant=STM32L4xx/L431R(B-C)(I-T-Y)
 GenL4.menu.pnum.GENERIC_L431RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L431.svd
+
+# Generic L431RBYx
+GenL4.menu.pnum.GENERIC_L431RBYX=Generic L431RBYx
+GenL4.menu.pnum.GENERIC_L431RBYX.upload.maximum_size=131072
+GenL4.menu.pnum.GENERIC_L431RBYX.upload.maximum_data_size=65536
+GenL4.menu.pnum.GENERIC_L431RBYX.build.board=GENERIC_L431RBYX
+GenL4.menu.pnum.GENERIC_L431RBYX.build.product_line=STM32L431xx
+GenL4.menu.pnum.GENERIC_L431RBYX.build.variant=STM32L4xx/L431R(B-C)(I-T-Y)
+GenL4.menu.pnum.GENERIC_L431RBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L431.svd
 
 # Generic L431RCYx
 GenL4.menu.pnum.GENERIC_L431RCYX=Generic L431RCYx
@@ -12097,6 +12105,15 @@ GenL4.menu.pnum.GENERIC_L432KCUX.build.product_line=STM32L432xx
 GenL4.menu.pnum.GENERIC_L432KCUX.build.variant=STM32L4xx/L432K(B-C)U_L442KCU
 GenL4.menu.pnum.GENERIC_L432KCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L432.svd
 
+# Generic L442KCUx
+GenL4.menu.pnum.GENERIC_L442KCUX=Generic L442KCUx
+GenL4.menu.pnum.GENERIC_L442KCUX.upload.maximum_size=262144
+GenL4.menu.pnum.GENERIC_L442KCUX.upload.maximum_data_size=65536
+GenL4.menu.pnum.GENERIC_L442KCUX.build.board=GENERIC_L442KCUX
+GenL4.menu.pnum.GENERIC_L442KCUX.build.product_line=STM32L442xx
+GenL4.menu.pnum.GENERIC_L442KCUX.build.variant=STM32L4xx/L432K(B-C)U_L442KCU
+GenL4.menu.pnum.GENERIC_L442KCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L442.svd
+
 # Generic L433CBTx
 GenL4.menu.pnum.GENERIC_L433CBTX=Generic L433CBTx
 GenL4.menu.pnum.GENERIC_L433CBTX.upload.maximum_size=131072
@@ -12106,15 +12123,6 @@ GenL4.menu.pnum.GENERIC_L433CBTX.build.product_line=STM32L433xx
 GenL4.menu.pnum.GENERIC_L433CBTX.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
 GenL4.menu.pnum.GENERIC_L433CBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
 
-# Generic L433CBUx
-GenL4.menu.pnum.GENERIC_L433CBUX=Generic L433CBUx
-GenL4.menu.pnum.GENERIC_L433CBUX.upload.maximum_size=131072
-GenL4.menu.pnum.GENERIC_L433CBUX.upload.maximum_data_size=65536
-GenL4.menu.pnum.GENERIC_L433CBUX.build.board=GENERIC_L433CBUX
-GenL4.menu.pnum.GENERIC_L433CBUX.build.product_line=STM32L433xx
-GenL4.menu.pnum.GENERIC_L433CBUX.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
-GenL4.menu.pnum.GENERIC_L433CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
-
 # Generic L433CCTx
 GenL4.menu.pnum.GENERIC_L433CCTX=Generic L433CCTx
 GenL4.menu.pnum.GENERIC_L433CCTX.upload.maximum_size=262144
@@ -12123,6 +12131,15 @@ GenL4.menu.pnum.GENERIC_L433CCTX.build.board=GENERIC_L433CCTX
 GenL4.menu.pnum.GENERIC_L433CCTX.build.product_line=STM32L433xx
 GenL4.menu.pnum.GENERIC_L433CCTX.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
 GenL4.menu.pnum.GENERIC_L433CCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
+
+# Generic L433CBUx
+GenL4.menu.pnum.GENERIC_L433CBUX=Generic L433CBUx
+GenL4.menu.pnum.GENERIC_L433CBUX.upload.maximum_size=131072
+GenL4.menu.pnum.GENERIC_L433CBUX.upload.maximum_data_size=65536
+GenL4.menu.pnum.GENERIC_L433CBUX.build.board=GENERIC_L433CBUX
+GenL4.menu.pnum.GENERIC_L433CBUX.build.product_line=STM32L433xx
+GenL4.menu.pnum.GENERIC_L433CBUX.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
+GenL4.menu.pnum.GENERIC_L433CBUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
 
 # Generic L433CCUx
 GenL4.menu.pnum.GENERIC_L433CCUX=Generic L433CCUx
@@ -12142,24 +12159,6 @@ GenL4.menu.pnum.GENERIC_L433RBIX.build.product_line=STM32L433xx
 GenL4.menu.pnum.GENERIC_L433RBIX.build.variant=STM32L4xx/L433R(B-C)(I-T-Y)_L443RC(I-T-Y)
 GenL4.menu.pnum.GENERIC_L433RBIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
 
-# Generic L433RBTx
-GenL4.menu.pnum.GENERIC_L433RBTX=Generic L433RBTx
-GenL4.menu.pnum.GENERIC_L433RBTX.upload.maximum_size=131072
-GenL4.menu.pnum.GENERIC_L433RBTX.upload.maximum_data_size=65536
-GenL4.menu.pnum.GENERIC_L433RBTX.build.board=GENERIC_L433RBTX
-GenL4.menu.pnum.GENERIC_L433RBTX.build.product_line=STM32L433xx
-GenL4.menu.pnum.GENERIC_L433RBTX.build.variant=STM32L4xx/L433R(B-C)(I-T-Y)_L443RC(I-T-Y)
-GenL4.menu.pnum.GENERIC_L433RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
-
-# Generic L433RBYx
-GenL4.menu.pnum.GENERIC_L433RBYX=Generic L433RBYx
-GenL4.menu.pnum.GENERIC_L433RBYX.upload.maximum_size=131072
-GenL4.menu.pnum.GENERIC_L433RBYX.upload.maximum_data_size=65536
-GenL4.menu.pnum.GENERIC_L433RBYX.build.board=GENERIC_L433RBYX
-GenL4.menu.pnum.GENERIC_L433RBYX.build.product_line=STM32L433xx
-GenL4.menu.pnum.GENERIC_L433RBYX.build.variant=STM32L4xx/L433R(B-C)(I-T-Y)_L443RC(I-T-Y)
-GenL4.menu.pnum.GENERIC_L433RBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
-
 # Generic L433RCIx
 GenL4.menu.pnum.GENERIC_L433RCIX=Generic L433RCIx
 GenL4.menu.pnum.GENERIC_L433RCIX.upload.maximum_size=262144
@@ -12168,6 +12167,15 @@ GenL4.menu.pnum.GENERIC_L433RCIX.build.board=GENERIC_L433RCIX
 GenL4.menu.pnum.GENERIC_L433RCIX.build.product_line=STM32L433xx
 GenL4.menu.pnum.GENERIC_L433RCIX.build.variant=STM32L4xx/L433R(B-C)(I-T-Y)_L443RC(I-T-Y)
 GenL4.menu.pnum.GENERIC_L433RCIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
+
+# Generic L433RBTx
+GenL4.menu.pnum.GENERIC_L433RBTX=Generic L433RBTx
+GenL4.menu.pnum.GENERIC_L433RBTX.upload.maximum_size=131072
+GenL4.menu.pnum.GENERIC_L433RBTX.upload.maximum_data_size=65536
+GenL4.menu.pnum.GENERIC_L433RBTX.build.board=GENERIC_L433RBTX
+GenL4.menu.pnum.GENERIC_L433RBTX.build.product_line=STM32L433xx
+GenL4.menu.pnum.GENERIC_L433RBTX.build.variant=STM32L4xx/L433R(B-C)(I-T-Y)_L443RC(I-T-Y)
+GenL4.menu.pnum.GENERIC_L433RBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
 
 # Generic L433RCTx
 GenL4.menu.pnum.GENERIC_L433RCTX=Generic L433RCTx
@@ -12178,14 +12186,14 @@ GenL4.menu.pnum.GENERIC_L433RCTX.build.product_line=STM32L433xx
 GenL4.menu.pnum.GENERIC_L433RCTX.build.variant=STM32L4xx/L433R(B-C)(I-T-Y)_L443RC(I-T-Y)
 GenL4.menu.pnum.GENERIC_L433RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
 
-# Generic L433RCTxP
-GenL4.menu.pnum.GENERIC_L433RCTXP=Generic L433RCTxP
-GenL4.menu.pnum.GENERIC_L433RCTXP.upload.maximum_size=262144
-GenL4.menu.pnum.GENERIC_L433RCTXP.upload.maximum_data_size=65536
-GenL4.menu.pnum.GENERIC_L433RCTXP.build.board=GENERIC_L433RCTXP
-GenL4.menu.pnum.GENERIC_L433RCTXP.build.product_line=STM32L433xx
-GenL4.menu.pnum.GENERIC_L433RCTXP.build.variant=STM32L4xx/L433RCTxP
-GenL4.menu.pnum.GENERIC_L433RCTXP.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
+# Generic L433RBYx
+GenL4.menu.pnum.GENERIC_L433RBYX=Generic L433RBYx
+GenL4.menu.pnum.GENERIC_L433RBYX.upload.maximum_size=131072
+GenL4.menu.pnum.GENERIC_L433RBYX.upload.maximum_data_size=65536
+GenL4.menu.pnum.GENERIC_L433RBYX.build.board=GENERIC_L433RBYX
+GenL4.menu.pnum.GENERIC_L433RBYX.build.product_line=STM32L433xx
+GenL4.menu.pnum.GENERIC_L433RBYX.build.variant=STM32L4xx/L433R(B-C)(I-T-Y)_L443RC(I-T-Y)
+GenL4.menu.pnum.GENERIC_L433RBYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
 
 # Generic L433RCYx
 GenL4.menu.pnum.GENERIC_L433RCYX=Generic L433RCYx
@@ -12195,33 +12203,6 @@ GenL4.menu.pnum.GENERIC_L433RCYX.build.board=GENERIC_L433RCYX
 GenL4.menu.pnum.GENERIC_L433RCYX.build.product_line=STM32L433xx
 GenL4.menu.pnum.GENERIC_L433RCYX.build.variant=STM32L4xx/L433R(B-C)(I-T-Y)_L443RC(I-T-Y)
 GenL4.menu.pnum.GENERIC_L433RCYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
-
-# Generic L442KCUx
-GenL4.menu.pnum.GENERIC_L442KCUX=Generic L442KCUx
-GenL4.menu.pnum.GENERIC_L442KCUX.upload.maximum_size=262144
-GenL4.menu.pnum.GENERIC_L442KCUX.upload.maximum_data_size=65536
-GenL4.menu.pnum.GENERIC_L442KCUX.build.board=GENERIC_L442KCUX
-GenL4.menu.pnum.GENERIC_L442KCUX.build.product_line=STM32L442xx
-GenL4.menu.pnum.GENERIC_L442KCUX.build.variant=STM32L4xx/L432K(B-C)U_L442KCU
-GenL4.menu.pnum.GENERIC_L442KCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L442.svd
-
-# Generic L443CCTx
-GenL4.menu.pnum.GENERIC_L443CCTX=Generic L443CCTx
-GenL4.menu.pnum.GENERIC_L443CCTX.upload.maximum_size=262144
-GenL4.menu.pnum.GENERIC_L443CCTX.upload.maximum_data_size=65536
-GenL4.menu.pnum.GENERIC_L443CCTX.build.board=GENERIC_L443CCTX
-GenL4.menu.pnum.GENERIC_L443CCTX.build.product_line=STM32L443xx
-GenL4.menu.pnum.GENERIC_L443CCTX.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
-GenL4.menu.pnum.GENERIC_L443CCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L443.svd
-
-# Generic L443CCUx
-GenL4.menu.pnum.GENERIC_L443CCUX=Generic L443CCUx
-GenL4.menu.pnum.GENERIC_L443CCUX.upload.maximum_size=262144
-GenL4.menu.pnum.GENERIC_L443CCUX.upload.maximum_data_size=65536
-GenL4.menu.pnum.GENERIC_L443CCUX.build.board=GENERIC_L443CCUX
-GenL4.menu.pnum.GENERIC_L443CCUX.build.product_line=STM32L443xx
-GenL4.menu.pnum.GENERIC_L443CCUX.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
-GenL4.menu.pnum.GENERIC_L443CCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L443.svd
 
 # Generic L443RCIx
 GenL4.menu.pnum.GENERIC_L443RCIX=Generic L443RCIx
@@ -12250,6 +12231,33 @@ GenL4.menu.pnum.GENERIC_L443RCYX.build.product_line=STM32L443xx
 GenL4.menu.pnum.GENERIC_L443RCYX.build.variant=STM32L4xx/L433R(B-C)(I-T-Y)_L443RC(I-T-Y)
 GenL4.menu.pnum.GENERIC_L443RCYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L443.svd
 
+# Generic L433RCTxP
+GenL4.menu.pnum.GENERIC_L433RCTXP=Generic L433RCTxP
+GenL4.menu.pnum.GENERIC_L433RCTXP.upload.maximum_size=262144
+GenL4.menu.pnum.GENERIC_L433RCTXP.upload.maximum_data_size=65536
+GenL4.menu.pnum.GENERIC_L433RCTXP.build.board=GENERIC_L433RCTXP
+GenL4.menu.pnum.GENERIC_L433RCTXP.build.product_line=STM32L433xx
+GenL4.menu.pnum.GENERIC_L433RCTXP.build.variant=STM32L4xx/L433RCTxP
+GenL4.menu.pnum.GENERIC_L433RCTXP.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
+
+# Generic L443CCTx
+GenL4.menu.pnum.GENERIC_L443CCTX=Generic L443CCTx
+GenL4.menu.pnum.GENERIC_L443CCTX.upload.maximum_size=262144
+GenL4.menu.pnum.GENERIC_L443CCTX.upload.maximum_data_size=65536
+GenL4.menu.pnum.GENERIC_L443CCTX.build.board=GENERIC_L443CCTX
+GenL4.menu.pnum.GENERIC_L443CCTX.build.product_line=STM32L443xx
+GenL4.menu.pnum.GENERIC_L443CCTX.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
+GenL4.menu.pnum.GENERIC_L443CCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L443.svd
+
+# Generic L443CCUx
+GenL4.menu.pnum.GENERIC_L443CCUX=Generic L443CCUx
+GenL4.menu.pnum.GENERIC_L443CCUX.upload.maximum_size=262144
+GenL4.menu.pnum.GENERIC_L443CCUX.upload.maximum_data_size=65536
+GenL4.menu.pnum.GENERIC_L443CCUX.build.board=GENERIC_L443CCUX
+GenL4.menu.pnum.GENERIC_L443CCUX.build.product_line=STM32L443xx
+GenL4.menu.pnum.GENERIC_L443CCUX.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
+GenL4.menu.pnum.GENERIC_L443CCUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L443.svd
+
 # Generic L452RCIx
 GenL4.menu.pnum.GENERIC_L452RCIX=Generic L452RCIx
 GenL4.menu.pnum.GENERIC_L452RCIX.upload.maximum_size=262144
@@ -12258,24 +12266,6 @@ GenL4.menu.pnum.GENERIC_L452RCIX.build.board=GENERIC_L452RCIX
 GenL4.menu.pnum.GENERIC_L452RCIX.build.product_line=STM32L452xx
 GenL4.menu.pnum.GENERIC_L452RCIX.build.variant=STM32L4xx/L452RC(I-T-Y)_L452RE(I-T-Y)x(P)_L462RE(I-T-Y)
 GenL4.menu.pnum.GENERIC_L452RCIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
-
-# Generic L452RCTx
-GenL4.menu.pnum.GENERIC_L452RCTX=Generic L452RCTx
-GenL4.menu.pnum.GENERIC_L452RCTX.upload.maximum_size=262144
-GenL4.menu.pnum.GENERIC_L452RCTX.upload.maximum_data_size=163840
-GenL4.menu.pnum.GENERIC_L452RCTX.build.board=GENERIC_L452RCTX
-GenL4.menu.pnum.GENERIC_L452RCTX.build.product_line=STM32L452xx
-GenL4.menu.pnum.GENERIC_L452RCTX.build.variant=STM32L4xx/L452RC(I-T-Y)_L452RE(I-T-Y)x(P)_L462RE(I-T-Y)
-GenL4.menu.pnum.GENERIC_L452RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
-
-# Generic L452RCYx
-GenL4.menu.pnum.GENERIC_L452RCYX=Generic L452RCYx
-GenL4.menu.pnum.GENERIC_L452RCYX.upload.maximum_size=262144
-GenL4.menu.pnum.GENERIC_L452RCYX.upload.maximum_data_size=163840
-GenL4.menu.pnum.GENERIC_L452RCYX.build.board=GENERIC_L452RCYX
-GenL4.menu.pnum.GENERIC_L452RCYX.build.product_line=STM32L452xx
-GenL4.menu.pnum.GENERIC_L452RCYX.build.variant=STM32L4xx/L452RC(I-T-Y)_L452RE(I-T-Y)x(P)_L462RE(I-T-Y)
-GenL4.menu.pnum.GENERIC_L452RCYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
 
 # Generic L452REIx
 GenL4.menu.pnum.GENERIC_L452REIX=Generic L452REIx
@@ -12286,6 +12276,15 @@ GenL4.menu.pnum.GENERIC_L452REIX.build.product_line=STM32L452xx
 GenL4.menu.pnum.GENERIC_L452REIX.build.variant=STM32L4xx/L452RC(I-T-Y)_L452RE(I-T-Y)x(P)_L462RE(I-T-Y)
 GenL4.menu.pnum.GENERIC_L452REIX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
 
+# Generic L452RCTx
+GenL4.menu.pnum.GENERIC_L452RCTX=Generic L452RCTx
+GenL4.menu.pnum.GENERIC_L452RCTX.upload.maximum_size=262144
+GenL4.menu.pnum.GENERIC_L452RCTX.upload.maximum_data_size=163840
+GenL4.menu.pnum.GENERIC_L452RCTX.build.board=GENERIC_L452RCTX
+GenL4.menu.pnum.GENERIC_L452RCTX.build.product_line=STM32L452xx
+GenL4.menu.pnum.GENERIC_L452RCTX.build.variant=STM32L4xx/L452RC(I-T-Y)_L452RE(I-T-Y)x(P)_L462RE(I-T-Y)
+GenL4.menu.pnum.GENERIC_L452RCTX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
+
 # Generic L452RETx
 GenL4.menu.pnum.GENERIC_L452RETX=Generic L452RETx
 GenL4.menu.pnum.GENERIC_L452RETX.upload.maximum_size=524288
@@ -12295,14 +12294,14 @@ GenL4.menu.pnum.GENERIC_L452RETX.build.product_line=STM32L452xx
 GenL4.menu.pnum.GENERIC_L452RETX.build.variant=STM32L4xx/L452RC(I-T-Y)_L452RE(I-T-Y)x(P)_L462RE(I-T-Y)
 GenL4.menu.pnum.GENERIC_L452RETX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
 
-# Generic L452RETxP
-GenL4.menu.pnum.GENERIC_L452RETXP=Generic L452RETxP
-GenL4.menu.pnum.GENERIC_L452RETXP.upload.maximum_size=524288
-GenL4.menu.pnum.GENERIC_L452RETXP.upload.maximum_data_size=163840
-GenL4.menu.pnum.GENERIC_L452RETXP.build.board=GENERIC_L452RETXP
-GenL4.menu.pnum.GENERIC_L452RETXP.build.product_line=STM32L452xx
-GenL4.menu.pnum.GENERIC_L452RETXP.build.variant=STM32L4xx/L452RETxP
-GenL4.menu.pnum.GENERIC_L452RETXP.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
+# Generic L452RCYx
+GenL4.menu.pnum.GENERIC_L452RCYX=Generic L452RCYx
+GenL4.menu.pnum.GENERIC_L452RCYX.upload.maximum_size=262144
+GenL4.menu.pnum.GENERIC_L452RCYX.upload.maximum_data_size=163840
+GenL4.menu.pnum.GENERIC_L452RCYX.build.board=GENERIC_L452RCYX
+GenL4.menu.pnum.GENERIC_L452RCYX.build.product_line=STM32L452xx
+GenL4.menu.pnum.GENERIC_L452RCYX.build.variant=STM32L4xx/L452RC(I-T-Y)_L452RE(I-T-Y)x(P)_L462RE(I-T-Y)
+GenL4.menu.pnum.GENERIC_L452RCYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
 
 # Generic L452REYx
 GenL4.menu.pnum.GENERIC_L452REYX=Generic L452REYx
@@ -12312,6 +12311,15 @@ GenL4.menu.pnum.GENERIC_L452REYX.build.board=GENERIC_L452REYX
 GenL4.menu.pnum.GENERIC_L452REYX.build.product_line=STM32L452xx
 GenL4.menu.pnum.GENERIC_L452REYX.build.variant=STM32L4xx/L452RC(I-T-Y)_L452RE(I-T-Y)x(P)_L462RE(I-T-Y)
 GenL4.menu.pnum.GENERIC_L452REYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
+
+# Generic L452RETxP
+GenL4.menu.pnum.GENERIC_L452RETXP=Generic L452RETxP
+GenL4.menu.pnum.GENERIC_L452RETXP.upload.maximum_size=524288
+GenL4.menu.pnum.GENERIC_L452RETXP.upload.maximum_data_size=163840
+GenL4.menu.pnum.GENERIC_L452RETXP.build.board=GENERIC_L452RETXP
+GenL4.menu.pnum.GENERIC_L452RETXP.build.product_line=STM32L452xx
+GenL4.menu.pnum.GENERIC_L452RETXP.build.variant=STM32L4xx/L452RETxP
+GenL4.menu.pnum.GENERIC_L452RETXP.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L452.svd
 
 # Generic L462REIx
 GenL4.menu.pnum.GENERIC_L462REIX=Generic L462REIx
@@ -12556,15 +12564,6 @@ GenL4.menu.pnum.GENERIC_L4R5ZITX.build.product_line=STM32L4R5xx
 GenL4.menu.pnum.GENERIC_L4R5ZITX.build.variant=STM32L4xx/L4R5Z(G-I)T_L4R7ZIT_L4S5ZIT_L4S7ZIT
 GenL4.menu.pnum.GENERIC_L4R5ZITX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L4R5.svd
 
-# Generic L4R5ZITxP
-GenL4.menu.pnum.GENERIC_L4R5ZITXP=Generic L4R5ZITxP
-GenL4.menu.pnum.GENERIC_L4R5ZITXP.upload.maximum_size=2097152
-GenL4.menu.pnum.GENERIC_L4R5ZITXP.upload.maximum_data_size=655360
-GenL4.menu.pnum.GENERIC_L4R5ZITXP.build.board=GENERIC_L4R5ZITXP
-GenL4.menu.pnum.GENERIC_L4R5ZITXP.build.product_line=STM32L4R5xx
-GenL4.menu.pnum.GENERIC_L4R5ZITXP.build.variant=STM32L4xx/L4R5ZITxP
-GenL4.menu.pnum.GENERIC_L4R5ZITXP.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L4R5.svd
-
 # Generic L4R5ZIYx
 GenL4.menu.pnum.GENERIC_L4R5ZIYX=Generic L4R5ZIYx
 GenL4.menu.pnum.GENERIC_L4R5ZIYX.upload.maximum_size=2097152
@@ -12573,6 +12572,15 @@ GenL4.menu.pnum.GENERIC_L4R5ZIYX.build.board=GENERIC_L4R5ZIYX
 GenL4.menu.pnum.GENERIC_L4R5ZIYX.build.product_line=STM32L4R5xx
 GenL4.menu.pnum.GENERIC_L4R5ZIYX.build.variant=STM32L4xx/L4R5Z(G-I)Y_L4R9Z(G-I)Y_L4S5ZIY_L4S9ZIY
 GenL4.menu.pnum.GENERIC_L4R5ZIYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L4R5.svd
+
+# Generic L4R5ZITxP
+GenL4.menu.pnum.GENERIC_L4R5ZITXP=Generic L4R5ZITxP
+GenL4.menu.pnum.GENERIC_L4R5ZITXP.upload.maximum_size=2097152
+GenL4.menu.pnum.GENERIC_L4R5ZITXP.upload.maximum_data_size=655360
+GenL4.menu.pnum.GENERIC_L4R5ZITXP.build.board=GENERIC_L4R5ZITXP
+GenL4.menu.pnum.GENERIC_L4R5ZITXP.build.product_line=STM32L4R5xx
+GenL4.menu.pnum.GENERIC_L4R5ZITXP.build.variant=STM32L4xx/L4R5ZITxP
+GenL4.menu.pnum.GENERIC_L4R5ZITXP.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L4R5.svd
 
 # Generic L4R7VITx
 GenL4.menu.pnum.GENERIC_L4R7VITX=Generic L4R7VITx
@@ -13407,6 +13415,15 @@ GenWB.menu.pnum.GENERIC_WB55CGUX.build.product_line=STM32WB55xx
 GenWB.menu.pnum.GENERIC_WB55CGUX.build.variant=STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U
 GenWB.menu.pnum.GENERIC_WB55CGUX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
 
+# Generic WB5MMGHx
+GenWB.menu.pnum.GENERIC_WB5MMGHX=Generic WB5MMGHx
+GenWB.menu.pnum.GENERIC_WB5MMGHX.upload.maximum_size=827392
+GenWB.menu.pnum.GENERIC_WB5MMGHX.upload.maximum_data_size=196608
+GenWB.menu.pnum.GENERIC_WB5MMGHX.build.board=GENERIC_WB5MMGHX
+GenWB.menu.pnum.GENERIC_WB5MMGHX.build.product_line=STM32WB5Mxx
+GenWB.menu.pnum.GENERIC_WB5MMGHX.build.variant=STM32WBxx/WB5MMGH
+GenWB.menu.pnum.GENERIC_WB5MMGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
+
 # Generic WB55RCVx
 GenWB.menu.pnum.GENERIC_WB55RCVX=Generic WB55RCVx
 GenWB.menu.pnum.GENERIC_WB55RCVX.upload.maximum_size=131072
@@ -13496,15 +13513,6 @@ GenWB.menu.pnum.GENERIC_WB55VYYX.build.board=GENERIC_WB55VYYX
 GenWB.menu.pnum.GENERIC_WB55VYYX.build.product_line=STM32WB55xx
 GenWB.menu.pnum.GENERIC_WB55VYYX.build.variant=STM32WBxx/WB55V(C-E-G)(Q-Y)_WB55VYY
 GenWB.menu.pnum.GENERIC_WB55VYYX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
-
-# Generic WB5MMGHx
-GenWB.menu.pnum.GENERIC_WB5MMGHX=Generic WB5MMGHx
-GenWB.menu.pnum.GENERIC_WB5MMGHX.upload.maximum_size=827392
-GenWB.menu.pnum.GENERIC_WB5MMGHX.upload.maximum_data_size=196608
-GenWB.menu.pnum.GENERIC_WB5MMGHX.build.board=GENERIC_WB5MMGHX
-GenWB.menu.pnum.GENERIC_WB5MMGHX.build.product_line=STM32WB5Mxx
-GenWB.menu.pnum.GENERIC_WB5MMGHX.build.variant=STM32WBxx/WB5MMGH
-GenWB.menu.pnum.GENERIC_WB5MMGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
 
 
 # Upload menu
@@ -14008,6 +14016,83 @@ GenWL.menu.upload_method.OpenOCDDapLink.debug.server.openocd.scripts.1={runtime.
 3dprinter.menu.pnum.EBB42_V1_1.openocd.target=stm32g0x
 3dprinter.menu.pnum.EBB42_V1_1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G0xx/STM32G0B1.svd
 
+# REMRAM_V1 board
+3dprinter.menu.pnum.REMRAM_V1=RemRam v1
+3dprinter.menu.pnum.REMRAM_V1.upload.maximum_size=2097152
+3dprinter.menu.pnum.REMRAM_V1.upload.maximum_data_size=524288
+3dprinter.menu.pnum.REMRAM_V1.build.mcu=cortex-m7
+3dprinter.menu.pnum.REMRAM_V1.build.fpu=-mfpu=fpv4-sp-d16
+3dprinter.menu.pnum.REMRAM_V1.build.float-abi=-mfloat-abi=hard
+3dprinter.menu.pnum.REMRAM_V1.build.board=REMRAM_V1
+3dprinter.menu.pnum.REMRAM_V1.build.series=STM32F7xx
+3dprinter.menu.pnum.REMRAM_V1.build.product_line=STM32F765xx
+3dprinter.menu.pnum.REMRAM_V1.build.variant=STM32F7xx/F765V(G-I)(H-T)_F767V(G-I)(H-T)_F777VI(H-T)
+3dprinter.menu.pnum.REMRAM_V1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+3dprinter.menu.pnum.REMRAM_V1.openocd.target=stm32f7x
+3dprinter.menu.pnum.REMRAM_V1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F765.svd
+
+# RUMBA32 board
+3dprinter.menu.pnum.RUMBA32=RUMBA32
+3dprinter.menu.pnum.RUMBA32.upload.maximum_size=524288
+3dprinter.menu.pnum.RUMBA32.upload.maximum_data_size=131072
+3dprinter.menu.pnum.RUMBA32.build.mcu=cortex-m4
+3dprinter.menu.pnum.RUMBA32.build.fpu=-mfpu=fpv4-sp-d16
+3dprinter.menu.pnum.RUMBA32.build.float-abi=-mfloat-abi=hard
+3dprinter.menu.pnum.RUMBA32.build.board=RUMBA32
+3dprinter.menu.pnum.RUMBA32.build.series=STM32F4xx
+3dprinter.menu.pnum.RUMBA32.build.product_line=STM32F446xx
+3dprinter.menu.pnum.RUMBA32.build.variant=STM32F4xx/F446V(C-E)T
+3dprinter.menu.pnum.RUMBA32.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+3dprinter.menu.pnum.RUMBA32.openocd.target=stm32f4x
+3dprinter.menu.pnum.RUMBA32.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F446.svd
+
+# STEVAL-3DP001V1 board
+3dprinter.menu.pnum.ST3DP001_EVAL=STEVAL-3DP001V1
+3dprinter.menu.pnum.ST3DP001_EVAL.upload.maximum_size=524288
+3dprinter.menu.pnum.ST3DP001_EVAL.upload.maximum_data_size=98304
+3dprinter.menu.pnum.ST3DP001_EVAL.build.mcu=cortex-m4
+3dprinter.menu.pnum.ST3DP001_EVAL.build.fpu=-mfpu=fpv4-sp-d16
+3dprinter.menu.pnum.ST3DP001_EVAL.build.float-abi=-mfloat-abi=hard
+3dprinter.menu.pnum.ST3DP001_EVAL.build.board=ST3DP001_EVAL
+3dprinter.menu.pnum.ST3DP001_EVAL.build.series=STM32F4xx
+3dprinter.menu.pnum.ST3DP001_EVAL.build.product_line=STM32F401xE
+3dprinter.menu.pnum.ST3DP001_EVAL.build.variant=STM32F4xx/F401V(B-C-D-E)T
+3dprinter.menu.pnum.ST3DP001_EVAL.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+3dprinter.menu.pnum.ST3DP001_EVAL.openocd.target=stm32f4x
+3dprinter.menu.pnum.ST3DP001_EVAL.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
+
+# PRNTR_V1 board
+3dprinter.menu.pnum.PRNTR_V1=PRNTR v1
+3dprinter.menu.pnum.PRNTR_V1.upload.maximum_size=524288
+3dprinter.menu.pnum.PRNTR_V1.upload.maximum_data_size=131072
+3dprinter.menu.pnum.PRNTR_V1.build.mcu=cortex-m4
+3dprinter.menu.pnum.PRNTR_V1.build.fpu=-mfpu=fpv4-sp-d16
+3dprinter.menu.pnum.PRNTR_V1.build.float-abi=-mfloat-abi=hard
+3dprinter.menu.pnum.PRNTR_V1.build.board=PRNTR_V1
+3dprinter.menu.pnum.PRNTR_V1.build.series=STM32F4xx
+3dprinter.menu.pnum.PRNTR_V1.build.product_line=STM32F407xx
+3dprinter.menu.pnum.PRNTR_V1.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
+3dprinter.menu.pnum.PRNTR_V1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+3dprinter.menu.pnum.PRNTR_V1.openocd.target=stm32f4x
+3dprinter.menu.pnum.PRNTR_V1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
+
+# PRNTR_V2 board
+3dprinter.menu.pnum.PRNTR_V2=PRNTR v2
+3dprinter.menu.pnum.PRNTR_V2.upload.maximum_size=524288
+3dprinter.menu.pnum.PRNTR_V2.upload.maximum_data_size=131072
+3dprinter.menu.pnum.PRNTR_V2.build.mcu=cortex-m4
+3dprinter.menu.pnum.PRNTR_V2.build.fpu=-mfpu=fpv4-sp-d16
+3dprinter.menu.pnum.PRNTR_V2.build.float-abi=-mfloat-abi=hard
+3dprinter.menu.pnum.PRNTR_V2.build.board=PRNTR_V2
+3dprinter.menu.pnum.PRNTR_V2.build.series=STM32F4xx
+3dprinter.menu.pnum.PRNTR_V2.build.product_line=STM32F407xx
+3dprinter.menu.pnum.PRNTR_V2.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
+3dprinter.menu.pnum.PRNTR_V2.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+3dprinter.menu.pnum.PRNTR_V2.build.flash_offset=0x8000
+3dprinter.menu.pnum.PRNTR_V2.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+3dprinter.menu.pnum.PRNTR_V2.openocd.target=stm32f4x
+3dprinter.menu.pnum.PRNTR_V2.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
+
 # EEXTR_F030_V1 board
 3dprinter.menu.pnum.EEXTR_F030_V1=EExtruder F030 V1
 3dprinter.menu.pnum.EEXTR_F030_V1.upload.maximum_size=65536
@@ -14020,23 +14105,6 @@ GenWL.menu.upload_method.OpenOCDDapLink.debug.server.openocd.scripts.1={runtime.
 3dprinter.menu.pnum.EEXTR_F030_V1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 3dprinter.menu.pnum.EEXTR_F030_V1.openocd.target=stm32f0x
 3dprinter.menu.pnum.EEXTR_F030_V1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x0.svd
-
-# FYSETC_S6 board
-3dprinter.menu.pnum.FYSETC_S6=FYSETC_S6
-3dprinter.menu.pnum.FYSETC_S6.upload.maximum_size=458752
-3dprinter.menu.pnum.FYSETC_S6.upload.maximum_data_size=131072
-3dprinter.menu.pnum.FYSETC_S6.build.mcu=cortex-m4
-3dprinter.menu.pnum.FYSETC_S6.build.fpu=-mfpu=fpv4-sp-d16
-3dprinter.menu.pnum.FYSETC_S6.build.float-abi=-mfloat-abi=hard
-3dprinter.menu.pnum.FYSETC_S6.build.board=FYSETC_S6
-3dprinter.menu.pnum.FYSETC_S6.build.series=STM32F4xx
-3dprinter.menu.pnum.FYSETC_S6.build.product_line=STM32F446xx
-3dprinter.menu.pnum.FYSETC_S6.build.variant=STM32F4xx/F446V(C-E)T
-3dprinter.menu.pnum.FYSETC_S6.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-3dprinter.menu.pnum.FYSETC_S6.build.flash_offset=0x10000
-3dprinter.menu.pnum.FYSETC_S6.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-3dprinter.menu.pnum.FYSETC_S6.openocd.target=stm32f4x
-3dprinter.menu.pnum.FYSETC_S6.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F446.svd
 
 # MALYANM200_F103CB board
 3dprinter.menu.pnum.MALYANM200_F103CB=Malyan M200 V1
@@ -14088,83 +14156,6 @@ GenWL.menu.upload_method.OpenOCDDapLink.debug.server.openocd.scripts.1={runtime.
 3dprinter.menu.pnum.MALYANM300_F070CB.openocd.target=stm32f0x
 3dprinter.menu.pnum.MALYANM300_F070CB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x0.svd
 
-# PRNTR_V1 board
-3dprinter.menu.pnum.PRNTR_V1=PRNTR v1
-3dprinter.menu.pnum.PRNTR_V1.upload.maximum_size=524288
-3dprinter.menu.pnum.PRNTR_V1.upload.maximum_data_size=131072
-3dprinter.menu.pnum.PRNTR_V1.build.mcu=cortex-m4
-3dprinter.menu.pnum.PRNTR_V1.build.fpu=-mfpu=fpv4-sp-d16
-3dprinter.menu.pnum.PRNTR_V1.build.float-abi=-mfloat-abi=hard
-3dprinter.menu.pnum.PRNTR_V1.build.board=PRNTR_V1
-3dprinter.menu.pnum.PRNTR_V1.build.series=STM32F4xx
-3dprinter.menu.pnum.PRNTR_V1.build.product_line=STM32F407xx
-3dprinter.menu.pnum.PRNTR_V1.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
-3dprinter.menu.pnum.PRNTR_V1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-3dprinter.menu.pnum.PRNTR_V1.openocd.target=stm32f4x
-3dprinter.menu.pnum.PRNTR_V1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
-
-# PRNTR_V2 board
-3dprinter.menu.pnum.PRNTR_V2=PRNTR v2
-3dprinter.menu.pnum.PRNTR_V2.upload.maximum_size=524288
-3dprinter.menu.pnum.PRNTR_V2.upload.maximum_data_size=131072
-3dprinter.menu.pnum.PRNTR_V2.build.mcu=cortex-m4
-3dprinter.menu.pnum.PRNTR_V2.build.fpu=-mfpu=fpv4-sp-d16
-3dprinter.menu.pnum.PRNTR_V2.build.float-abi=-mfloat-abi=hard
-3dprinter.menu.pnum.PRNTR_V2.build.board=PRNTR_V2
-3dprinter.menu.pnum.PRNTR_V2.build.series=STM32F4xx
-3dprinter.menu.pnum.PRNTR_V2.build.product_line=STM32F407xx
-3dprinter.menu.pnum.PRNTR_V2.build.variant=STM32F4xx/F407V(E-G)T_F417V(E-G)T
-3dprinter.menu.pnum.PRNTR_V2.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-3dprinter.menu.pnum.PRNTR_V2.build.flash_offset=0x8000
-3dprinter.menu.pnum.PRNTR_V2.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
-3dprinter.menu.pnum.PRNTR_V2.openocd.target=stm32f4x
-3dprinter.menu.pnum.PRNTR_V2.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F407.svd
-
-# REMRAM_V1 board
-3dprinter.menu.pnum.REMRAM_V1=RemRam v1
-3dprinter.menu.pnum.REMRAM_V1.upload.maximum_size=2097152
-3dprinter.menu.pnum.REMRAM_V1.upload.maximum_data_size=524288
-3dprinter.menu.pnum.REMRAM_V1.build.mcu=cortex-m7
-3dprinter.menu.pnum.REMRAM_V1.build.fpu=-mfpu=fpv4-sp-d16
-3dprinter.menu.pnum.REMRAM_V1.build.float-abi=-mfloat-abi=hard
-3dprinter.menu.pnum.REMRAM_V1.build.board=REMRAM_V1
-3dprinter.menu.pnum.REMRAM_V1.build.series=STM32F7xx
-3dprinter.menu.pnum.REMRAM_V1.build.product_line=STM32F765xx
-3dprinter.menu.pnum.REMRAM_V1.build.variant=STM32F7xx/F765V(G-I)(H-T)_F767V(G-I)(H-T)_F777VI(H-T)
-3dprinter.menu.pnum.REMRAM_V1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-3dprinter.menu.pnum.REMRAM_V1.openocd.target=stm32f7x
-3dprinter.menu.pnum.REMRAM_V1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F7xx/STM32F765.svd
-
-# RUMBA32 board
-3dprinter.menu.pnum.RUMBA32=RUMBA32
-3dprinter.menu.pnum.RUMBA32.upload.maximum_size=524288
-3dprinter.menu.pnum.RUMBA32.upload.maximum_data_size=131072
-3dprinter.menu.pnum.RUMBA32.build.mcu=cortex-m4
-3dprinter.menu.pnum.RUMBA32.build.fpu=-mfpu=fpv4-sp-d16
-3dprinter.menu.pnum.RUMBA32.build.float-abi=-mfloat-abi=hard
-3dprinter.menu.pnum.RUMBA32.build.board=RUMBA32
-3dprinter.menu.pnum.RUMBA32.build.series=STM32F4xx
-3dprinter.menu.pnum.RUMBA32.build.product_line=STM32F446xx
-3dprinter.menu.pnum.RUMBA32.build.variant=STM32F4xx/F446V(C-E)T
-3dprinter.menu.pnum.RUMBA32.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-3dprinter.menu.pnum.RUMBA32.openocd.target=stm32f4x
-3dprinter.menu.pnum.RUMBA32.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F446.svd
-
-# STEVAL-3DP001V1 board
-3dprinter.menu.pnum.ST3DP001_EVAL=STEVAL-3DP001V1
-3dprinter.menu.pnum.ST3DP001_EVAL.upload.maximum_size=524288
-3dprinter.menu.pnum.ST3DP001_EVAL.upload.maximum_data_size=98304
-3dprinter.menu.pnum.ST3DP001_EVAL.build.mcu=cortex-m4
-3dprinter.menu.pnum.ST3DP001_EVAL.build.fpu=-mfpu=fpv4-sp-d16
-3dprinter.menu.pnum.ST3DP001_EVAL.build.float-abi=-mfloat-abi=hard
-3dprinter.menu.pnum.ST3DP001_EVAL.build.board=ST3DP001_EVAL
-3dprinter.menu.pnum.ST3DP001_EVAL.build.series=STM32F4xx
-3dprinter.menu.pnum.ST3DP001_EVAL.build.product_line=STM32F401xE
-3dprinter.menu.pnum.ST3DP001_EVAL.build.variant=STM32F4xx/F401V(B-C-D-E)T
-3dprinter.menu.pnum.ST3DP001_EVAL.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-3dprinter.menu.pnum.ST3DP001_EVAL.openocd.target=stm32f4x
-3dprinter.menu.pnum.ST3DP001_EVAL.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
-
 # VAkE v1.0
 3dprinter.menu.pnum.VAKE_V1=VAkE v1.0
 3dprinter.menu.pnum.VAKE_V1.upload.maximum_size=524288
@@ -14179,6 +14170,23 @@ GenWL.menu.upload_method.OpenOCDDapLink.debug.server.openocd.scripts.1={runtime.
 3dprinter.menu.pnum.VAKE_V1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 3dprinter.menu.pnum.VAKE_V1.openocd.target=stm32f4x
 3dprinter.menu.pnum.VAKE_V1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F446.svd
+
+# FYSETC_S6 board
+3dprinter.menu.pnum.FYSETC_S6=FYSETC_S6
+3dprinter.menu.pnum.FYSETC_S6.upload.maximum_size=458752
+3dprinter.menu.pnum.FYSETC_S6.upload.maximum_data_size=131072
+3dprinter.menu.pnum.FYSETC_S6.build.mcu=cortex-m4
+3dprinter.menu.pnum.FYSETC_S6.build.fpu=-mfpu=fpv4-sp-d16
+3dprinter.menu.pnum.FYSETC_S6.build.float-abi=-mfloat-abi=hard
+3dprinter.menu.pnum.FYSETC_S6.build.board=FYSETC_S6
+3dprinter.menu.pnum.FYSETC_S6.build.series=STM32F4xx
+3dprinter.menu.pnum.FYSETC_S6.build.product_line=STM32F446xx
+3dprinter.menu.pnum.FYSETC_S6.build.variant=STM32F4xx/F446V(C-E)T
+3dprinter.menu.pnum.FYSETC_S6.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+3dprinter.menu.pnum.FYSETC_S6.build.flash_offset=0x10000
+3dprinter.menu.pnum.FYSETC_S6.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial}
+3dprinter.menu.pnum.FYSETC_S6.openocd.target=stm32f4x
+3dprinter.menu.pnum.FYSETC_S6.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F446.svd
 
 # Upload menu
 3dprinter.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
@@ -14228,23 +14236,6 @@ Blues.build.flash_offset=0x0
 Blues.upload.maximum_size=0
 Blues.upload.maximum_data_size=0
 
-# Cygnet board
-Blues.menu.pnum.CYGNET=Cygnet
-Blues.menu.pnum.CYGNET.upload.maximum_size=262144
-Blues.menu.pnum.CYGNET.upload.maximum_data_size=65536
-Blues.menu.pnum.CYGNET.build.mcu=cortex-m4
-Blues.menu.pnum.CYGNET.build.fpu=-mfpu=fpv4-sp-d16
-Blues.menu.pnum.CYGNET.build.float-abi=-mfloat-abi=hard
-Blues.menu.pnum.CYGNET.build.board=CYGNET
-Blues.menu.pnum.CYGNET.build.series=STM32L4xx
-Blues.menu.pnum.CYGNET.build.product_line=STM32L433xx
-Blues.menu.pnum.CYGNET.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
-Blues.menu.pnum.CYGNET.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-Blues.menu.pnum.CYGNET.vid.0=0x30A4
-Blues.menu.pnum.CYGNET.pid.0=0x0003
-Blues.menu.pnum.CYGNET.openocd.target=stm32l4x
-Blues.menu.pnum.CYGNET.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
-
 # Swan R5 board
 Blues.menu.pnum.SWAN_R5=Swan R5
 Blues.menu.pnum.SWAN_R5.upload.maximum_size=2097152
@@ -14261,6 +14252,23 @@ Blues.menu.pnum.SWAN_R5.vid.0=0x30A4
 Blues.menu.pnum.SWAN_R5.pid.0=0x0002
 Blues.menu.pnum.SWAN_R5.openocd.target=stm32l4x
 Blues.menu.pnum.SWAN_R5.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L4R5.svd
+
+# Cygnet board
+Blues.menu.pnum.CYGNET=Cygnet
+Blues.menu.pnum.CYGNET.upload.maximum_size=262144
+Blues.menu.pnum.CYGNET.upload.maximum_data_size=65536
+Blues.menu.pnum.CYGNET.build.mcu=cortex-m4
+Blues.menu.pnum.CYGNET.build.fpu=-mfpu=fpv4-sp-d16
+Blues.menu.pnum.CYGNET.build.float-abi=-mfloat-abi=hard
+Blues.menu.pnum.CYGNET.build.board=CYGNET
+Blues.menu.pnum.CYGNET.build.series=STM32L4xx
+Blues.menu.pnum.CYGNET.build.product_line=STM32L433xx
+Blues.menu.pnum.CYGNET.build.variant=STM32L4xx/L433C(B-C)(T-U)_L443CC(T-U)
+Blues.menu.pnum.CYGNET.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+Blues.menu.pnum.CYGNET.vid.0=0x30A4
+Blues.menu.pnum.CYGNET.pid.0=0x0003
+Blues.menu.pnum.CYGNET.openocd.target=stm32l4x
+Blues.menu.pnum.CYGNET.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L4xx/STM32L433.svd
 
 # Upload menu
 Blues.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
@@ -14372,19 +14380,6 @@ ESC_board.upload.maximum_data_size=0
 ESC_board.vid.0=0x0483
 ESC_board.pid.0=0x5740
 
-# STORM32_V1_RC board
-ESC_board.menu.pnum.STORM32_V1_31_RC=STorM32 BGC v1.31 RC
-ESC_board.menu.pnum.STORM32_V1_31_RC.upload.maximum_size=262144
-ESC_board.menu.pnum.STORM32_V1_31_RC.upload.maximum_data_size=49152
-ESC_board.menu.pnum.STORM32_V1_31_RC.build.mcu=cortex-m3
-ESC_board.menu.pnum.STORM32_V1_31_RC.build.board=STORM32_V1_31_RC
-ESC_board.menu.pnum.STORM32_V1_31_RC.build.series=STM32F1xx
-ESC_board.menu.pnum.STORM32_V1_31_RC.build.product_line=STM32F103xE
-ESC_board.menu.pnum.STORM32_V1_31_RC.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-ESC_board.menu.pnum.STORM32_V1_31_RC.build.variant=STM32F1xx/F103R(C-D-E)T
-ESC_board.menu.pnum.STORM32_V1_31_RC.openocd.target=stm32f1x
-ESC_board.menu.pnum.STORM32_V1_31_RC.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
-
 # WRAITH32_V1 board
 ESC_board.menu.pnum.WRAITH32_V1=Wraith V1 ESC
 ESC_board.menu.pnum.WRAITH32_V1.upload.maximum_size=32768
@@ -14397,6 +14392,19 @@ ESC_board.menu.pnum.WRAITH32_V1.build.variant=STM32F0xx/F051K(6-8)U
 ESC_board.menu.pnum.WRAITH32_V1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 ESC_board.menu.pnum.WRAITH32_V1.openocd.target=stm32f0x
 ESC_board.menu.pnum.WRAITH32_V1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x1.svd
+
+# STORM32_V1_RC board
+ESC_board.menu.pnum.STORM32_V1_31_RC=STorM32 BGC v1.31 RC
+ESC_board.menu.pnum.STORM32_V1_31_RC.upload.maximum_size=262144
+ESC_board.menu.pnum.STORM32_V1_31_RC.upload.maximum_data_size=49152
+ESC_board.menu.pnum.STORM32_V1_31_RC.build.mcu=cortex-m3
+ESC_board.menu.pnum.STORM32_V1_31_RC.build.board=STORM32_V1_31_RC
+ESC_board.menu.pnum.STORM32_V1_31_RC.build.series=STM32F1xx
+ESC_board.menu.pnum.STORM32_V1_31_RC.build.product_line=STM32F103xE
+ESC_board.menu.pnum.STORM32_V1_31_RC.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+ESC_board.menu.pnum.STORM32_V1_31_RC.build.variant=STM32F1xx/F103R(C-D-E)T
+ESC_board.menu.pnum.STORM32_V1_31_RC.openocd.target=stm32f1x
+ESC_board.menu.pnum.STORM32_V1_31_RC.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F1xx/STM32F103.svd
 
 # Upload menu
 ESC_board.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
@@ -14476,21 +14484,6 @@ Garatronic.menu.pnum.PYBSTICK26_LITE.build.float-abi=-mfloat-abi=hard
 Garatronic.menu.pnum.PYBSTICK26_LITE.openocd.target=stm32f4x
 Garatronic.menu.pnum.PYBSTICK26_LITE.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F401.svd
 
-# PYBSTICK26(PRO) board with F412RE
-Garatronic.menu.pnum.PYBSTICK26_PRO=PYBSTICK26 Pro
-Garatronic.menu.pnum.PYBSTICK26_PRO.upload.maximum_size=524288
-Garatronic.menu.pnum.PYBSTICK26_PRO.upload.maximum_data_size=262144
-Garatronic.menu.pnum.PYBSTICK26_PRO.build.mcu=cortex-m4
-Garatronic.menu.pnum.PYBSTICK26_PRO.build.board=PYBSTICK26_PRO
-Garatronic.menu.pnum.PYBSTICK26_PRO.build.series=STM32F4xx
-Garatronic.menu.pnum.PYBSTICK26_PRO.build.product_line=STM32F412Rx
-Garatronic.menu.pnum.PYBSTICK26_PRO.build.variant=STM32F4xx/F412R(E-G)(T-Y)x(P)
-Garatronic.menu.pnum.PYBSTICK26_PRO.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-Garatronic.menu.pnum.PYBSTICK26_PRO.build.fpu=-mfpu=fpv4-sp-d16
-Garatronic.menu.pnum.PYBSTICK26_PRO.build.float-abi=-mfloat-abi=hard
-Garatronic.menu.pnum.PYBSTICK26_PRO.openocd.target=stm32f4x
-Garatronic.menu.pnum.PYBSTICK26_PRO.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
-
 # PYBSTICK26(STD/Programmez!) board with F411RE
 Garatronic.menu.pnum.PYBSTICK26_STD=PYBSTICK26 STD-Programmez
 Garatronic.menu.pnum.PYBSTICK26_STD.upload.maximum_size=524288
@@ -14505,6 +14498,21 @@ Garatronic.menu.pnum.PYBSTICK26_STD.build.fpu=-mfpu=fpv4-sp-d16
 Garatronic.menu.pnum.PYBSTICK26_STD.build.float-abi=-mfloat-abi=hard
 Garatronic.menu.pnum.PYBSTICK26_STD.openocd.target=stm32f4x
 Garatronic.menu.pnum.PYBSTICK26_STD.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F411.svd
+
+# PYBSTICK26(PRO) board with F412RE
+Garatronic.menu.pnum.PYBSTICK26_PRO=PYBSTICK26 Pro
+Garatronic.menu.pnum.PYBSTICK26_PRO.upload.maximum_size=524288
+Garatronic.menu.pnum.PYBSTICK26_PRO.upload.maximum_data_size=262144
+Garatronic.menu.pnum.PYBSTICK26_PRO.build.mcu=cortex-m4
+Garatronic.menu.pnum.PYBSTICK26_PRO.build.board=PYBSTICK26_PRO
+Garatronic.menu.pnum.PYBSTICK26_PRO.build.series=STM32F4xx
+Garatronic.menu.pnum.PYBSTICK26_PRO.build.product_line=STM32F412Rx
+Garatronic.menu.pnum.PYBSTICK26_PRO.build.variant=STM32F4xx/F412R(E-G)(T-Y)x(P)
+Garatronic.menu.pnum.PYBSTICK26_PRO.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+Garatronic.menu.pnum.PYBSTICK26_PRO.build.fpu=-mfpu=fpv4-sp-d16
+Garatronic.menu.pnum.PYBSTICK26_PRO.build.float-abi=-mfloat-abi=hard
+Garatronic.menu.pnum.PYBSTICK26_PRO.openocd.target=stm32f4x
+Garatronic.menu.pnum.PYBSTICK26_PRO.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F412.svd
 
 # PYBSTICK26 boards upload method
 Garatronic.menu.upload_method.dfuMethod=STM32CubeProgrammer (DFU)
@@ -14717,36 +14725,6 @@ LoRa.menu.pnum.ACSIP_S76S.build.st_extra_flags=-D{build.product_line} {build.ena
 LoRa.menu.pnum.ACSIP_S76S.openocd.target=stm32l0
 LoRa.menu.pnum.ACSIP_S76S.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x3.svd
 
-# ELEKTOR_F072C8
-LoRa.menu.pnum.ELEKTOR_F072C8=Elektor LoRa Node Core F072C8 (64kB)
-LoRa.menu.pnum.ELEKTOR_F072C8.upload.maximum_data_size=16384
-LoRa.menu.pnum.ELEKTOR_F072C8.upload.maximum_size=65536
-LoRa.menu.pnum.ELEKTOR_F072C8.build.mcu=cortex-m0
-LoRa.menu.pnum.ELEKTOR_F072C8.build.board=ELEKTOR_F072C8
-LoRa.menu.pnum.ELEKTOR_F072C8.build.series=STM32F0xx
-LoRa.menu.pnum.ELEKTOR_F072C8.build.product_line=STM32F072xB
-LoRa.menu.pnum.ELEKTOR_F072C8.build.variant=STM32F0xx/F072C8(T-U)_F072CB(T-U-Y)
-LoRa.menu.pnum.ELEKTOR_F072C8.build.variant_h=variant_ELEKTOR_F072Cx.h
-LoRa.menu.pnum.ELEKTOR_F072C8.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-LoRa.menu.pnum.ELEKTOR_F072C8.build.st_extra_flags=-D{build.product_line} {build.xSerial}
-LoRa.menu.pnum.ELEKTOR_F072C8.openocd.target=stm32f0x
-LoRa.menu.pnum.ELEKTOR_F072C8.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
-
-# ELEKTOR_F072CB
-LoRa.menu.pnum.ELEKTOR_F072CB=Elektor LoRa Node Core F072CB (128kB)
-LoRa.menu.pnum.ELEKTOR_F072CB.upload.maximum_data_size=16384
-LoRa.menu.pnum.ELEKTOR_F072CB.upload.maximum_size=131072
-LoRa.menu.pnum.ELEKTOR_F072CB.build.mcu=cortex-m0
-LoRa.menu.pnum.ELEKTOR_F072CB.build.board=ELEKTOR_F072CB
-LoRa.menu.pnum.ELEKTOR_F072CB.build.series=STM32F0xx
-LoRa.menu.pnum.ELEKTOR_F072CB.build.product_line=STM32F072xB
-LoRa.menu.pnum.ELEKTOR_F072CB.build.variant=STM32F0xx/F072C8(T-U)_F072CB(T-U-Y)
-LoRa.menu.pnum.ELEKTOR_F072CB.build.variant_h=variant_ELEKTOR_F072Cx.h
-LoRa.menu.pnum.ELEKTOR_F072CB.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-LoRa.menu.pnum.ELEKTOR_F072CB.build.st_extra_flags=-D{build.product_line} {build.xSerial}
-LoRa.menu.pnum.ELEKTOR_F072CB.openocd.target=stm32f0x
-LoRa.menu.pnum.ELEKTOR_F072CB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
-
 # Generic node SE by The Things Industries
 LoRa.menu.pnum.GENERIC_NODE_SE_TTI=Generic Node SE (TTI)
 LoRa.menu.pnum.GENERIC_NODE_SE_TTI.upload.maximum_size=262144
@@ -14774,34 +14752,6 @@ LoRa.menu.pnum.LORA_E5_MINI.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 LoRa.menu.pnum.LORA_E5_MINI.build.variant_h=variant_LORA_E5_MINI.h
 LoRa.menu.pnum.LORA_E5_MINI.openocd.target=stm32wlx
 LoRa.menu.pnum.LORA_E5_MINI.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WLxx/STM32WLE5_CM4.svd
-
-# Oceanus-I EV
-LoRa.menu.pnum.WE_OCEANUS1_EV=Oceanus-I EV
-LoRa.menu.pnum.WE_OCEANUS1_EV.upload.maximum_size=262144
-LoRa.menu.pnum.WE_OCEANUS1_EV.upload.maximum_data_size=65536
-LoRa.menu.pnum.WE_OCEANUS1_EV.build.mcu=cortex-m4
-LoRa.menu.pnum.WE_OCEANUS1_EV.build.board=WE_OCEANUS1_EV
-LoRa.menu.pnum.WE_OCEANUS1_EV.build.series=STM32WLxx
-LoRa.menu.pnum.WE_OCEANUS1_EV.build.product_line=STM32WLE5xx
-LoRa.menu.pnum.WE_OCEANUS1_EV.build.variant=STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U
-LoRa.menu.pnum.WE_OCEANUS1_EV.build.variant_h=variant_WE_OCEANUS1_EV.h
-LoRa.menu.pnum.WE_OCEANUS1_EV.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-LoRa.menu.pnum.WE_OCEANUS1_EV.openocd.target=stm32wlx
-LoRa.menu.pnum.WE_OCEANUS1_EV.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WLxx/STM32WLE5_CM4.svd
-
-# Oceanus-I Module
-LoRa.menu.pnum.WE_OCEANUS1=Oceanus-I Module
-LoRa.menu.pnum.WE_OCEANUS1.upload.maximum_size=262144
-LoRa.menu.pnum.WE_OCEANUS1.upload.maximum_data_size=65536
-LoRa.menu.pnum.WE_OCEANUS1.build.mcu=cortex-m4
-LoRa.menu.pnum.WE_OCEANUS1.build.board=WE_OCEANUS1
-LoRa.menu.pnum.WE_OCEANUS1.build.series=STM32WLxx
-LoRa.menu.pnum.WE_OCEANUS1.build.product_line=STM32WLE5xx
-LoRa.menu.pnum.WE_OCEANUS1.build.variant=STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U
-LoRa.menu.pnum.WE_OCEANUS1.build.variant_h=variant_WE_OCEANUS1.h
-LoRa.menu.pnum.WE_OCEANUS1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-LoRa.menu.pnum.WE_OCEANUS1.openocd.target=stm32wlx
-LoRa.menu.pnum.WE_OCEANUS1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WLxx/STM32WLE5_CM4.svd
 
 # RAK3172 module
 LoRa.menu.pnum.RAK3172_MODULE=RAK3172 Module
@@ -14867,6 +14817,64 @@ LoRa.menu.pnum.RHF76_052.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
 LoRa.menu.pnum.RHF76_052.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -D__CORTEX_SC=0
 LoRa.menu.pnum.RHF76_052.openocd.target=stm32l0
 LoRa.menu.pnum.RHF76_052.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32L0xx/STM32L0x1.svd
+
+# ELEKTOR_F072C8
+LoRa.menu.pnum.ELEKTOR_F072C8=Elektor LoRa Node Core F072C8 (64kB)
+LoRa.menu.pnum.ELEKTOR_F072C8.upload.maximum_data_size=16384
+LoRa.menu.pnum.ELEKTOR_F072C8.upload.maximum_size=65536
+LoRa.menu.pnum.ELEKTOR_F072C8.build.mcu=cortex-m0
+LoRa.menu.pnum.ELEKTOR_F072C8.build.board=ELEKTOR_F072C8
+LoRa.menu.pnum.ELEKTOR_F072C8.build.series=STM32F0xx
+LoRa.menu.pnum.ELEKTOR_F072C8.build.product_line=STM32F072xB
+LoRa.menu.pnum.ELEKTOR_F072C8.build.variant=STM32F0xx/F072C8(T-U)_F072CB(T-U-Y)
+LoRa.menu.pnum.ELEKTOR_F072C8.build.variant_h=variant_ELEKTOR_F072Cx.h
+LoRa.menu.pnum.ELEKTOR_F072C8.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+LoRa.menu.pnum.ELEKTOR_F072C8.build.st_extra_flags=-D{build.product_line} {build.xSerial}
+LoRa.menu.pnum.ELEKTOR_F072C8.openocd.target=stm32f0x
+LoRa.menu.pnum.ELEKTOR_F072C8.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
+
+# ELEKTOR_F072CB
+LoRa.menu.pnum.ELEKTOR_F072CB=Elektor LoRa Node Core F072CB (128kB)
+LoRa.menu.pnum.ELEKTOR_F072CB.upload.maximum_data_size=16384
+LoRa.menu.pnum.ELEKTOR_F072CB.upload.maximum_size=131072
+LoRa.menu.pnum.ELEKTOR_F072CB.build.mcu=cortex-m0
+LoRa.menu.pnum.ELEKTOR_F072CB.build.board=ELEKTOR_F072CB
+LoRa.menu.pnum.ELEKTOR_F072CB.build.series=STM32F0xx
+LoRa.menu.pnum.ELEKTOR_F072CB.build.product_line=STM32F072xB
+LoRa.menu.pnum.ELEKTOR_F072CB.build.variant=STM32F0xx/F072C8(T-U)_F072CB(T-U-Y)
+LoRa.menu.pnum.ELEKTOR_F072CB.build.variant_h=variant_ELEKTOR_F072Cx.h
+LoRa.menu.pnum.ELEKTOR_F072CB.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+LoRa.menu.pnum.ELEKTOR_F072CB.build.st_extra_flags=-D{build.product_line} {build.xSerial}
+LoRa.menu.pnum.ELEKTOR_F072CB.openocd.target=stm32f0x
+LoRa.menu.pnum.ELEKTOR_F072CB.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F0xx/STM32F0x2.svd
+
+# Oceanus-I Module
+LoRa.menu.pnum.WE_OCEANUS1=Oceanus-I Module
+LoRa.menu.pnum.WE_OCEANUS1.upload.maximum_size=262144
+LoRa.menu.pnum.WE_OCEANUS1.upload.maximum_data_size=65536
+LoRa.menu.pnum.WE_OCEANUS1.build.mcu=cortex-m4
+LoRa.menu.pnum.WE_OCEANUS1.build.board=WE_OCEANUS1
+LoRa.menu.pnum.WE_OCEANUS1.build.series=STM32WLxx
+LoRa.menu.pnum.WE_OCEANUS1.build.product_line=STM32WLE5xx
+LoRa.menu.pnum.WE_OCEANUS1.build.variant=STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U
+LoRa.menu.pnum.WE_OCEANUS1.build.variant_h=variant_WE_OCEANUS1.h
+LoRa.menu.pnum.WE_OCEANUS1.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+LoRa.menu.pnum.WE_OCEANUS1.openocd.target=stm32wlx
+LoRa.menu.pnum.WE_OCEANUS1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WLxx/STM32WLE5_CM4.svd
+
+# Oceanus-I EV
+LoRa.menu.pnum.WE_OCEANUS1_EV=Oceanus-I EV
+LoRa.menu.pnum.WE_OCEANUS1_EV.upload.maximum_size=262144
+LoRa.menu.pnum.WE_OCEANUS1_EV.upload.maximum_data_size=65536
+LoRa.menu.pnum.WE_OCEANUS1_EV.build.mcu=cortex-m4
+LoRa.menu.pnum.WE_OCEANUS1_EV.build.board=WE_OCEANUS1_EV
+LoRa.menu.pnum.WE_OCEANUS1_EV.build.series=STM32WLxx
+LoRa.menu.pnum.WE_OCEANUS1_EV.build.product_line=STM32WLE5xx
+LoRa.menu.pnum.WE_OCEANUS1_EV.build.variant=STM32WLxx/WL54CCU_WL55CCU_WLE4C(8-B-C)U_WLE5C(8-B-C)U
+LoRa.menu.pnum.WE_OCEANUS1_EV.build.variant_h=variant_WE_OCEANUS1_EV.h
+LoRa.menu.pnum.WE_OCEANUS1_EV.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+LoRa.menu.pnum.WE_OCEANUS1_EV.openocd.target=stm32wlx
+LoRa.menu.pnum.WE_OCEANUS1_EV.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WLxx/STM32WLE5_CM4.svd
 
 # Upload menu
 LoRa.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
@@ -14987,6 +14995,23 @@ SparkFun.upload.maximum_data_size=0
 SparkFun.vid.0=0x0483
 SparkFun.pid.0=0x5740
 
+# SFE_MMPB_STM32WB5MMG board
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG=SparkFun MicroMod STM32WB5MMG
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.upload.maximum_size=827392
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.upload.maximum_data_size=196608
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.mcu=cortex-m4
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.fpu=-mfpu=fpv4-sp-d16
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.float-abi=-mfloat-abi=hard
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.board=SFE_MMPB_STM32WB5MMG
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.series=STM32WBxx
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.product_line=STM32WB5Mxx
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.variant=STM32WBxx/WB5MMGH
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.vid.0=0x1B4F
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.pid.0=0x0034
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.openocd.target=stm32wbx
+SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
+
 # SparkFun MicroMod STM32F405 Board
 SparkFun.menu.pnum.MICROMOD_F405=SparkFun MicroMod STM32F405
 SparkFun.menu.pnum.MICROMOD_F405.upload.maximum_size=1048576
@@ -15004,23 +15029,6 @@ SparkFun.menu.pnum.MICROMOD_F405.vid.0=0x1B4F
 SparkFun.menu.pnum.MICROMOD_F405.pid.0=0x0029
 SparkFun.menu.pnum.MICROMOD_F405.openocd.target=stm32f4x
 SparkFun.menu.pnum.MICROMOD_F405.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32F4xx/STM32F405.svd
-
-# SFE_MMPB_STM32WB5MMG board
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG=SparkFun MicroMod STM32WB5MMG
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.upload.maximum_size=827392
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.upload.maximum_data_size=196608
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.mcu=cortex-m4
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.fpu=-mfpu=fpv4-sp-d16
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.float-abi=-mfloat-abi=hard
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.board=SFE_MMPB_STM32WB5MMG
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.series=STM32WBxx
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.product_line=STM32WB5Mxx
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.variant=STM32WBxx/WB5MMGH
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.build.peripheral_pins=-DCUSTOM_PERIPHERAL_PINS
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.vid.0=0x1B4F
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.pid.0=0x0034
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.openocd.target=stm32wbx
-SparkFun.menu.pnum.SFE_MMPB_STM32WB5MMG.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
 
 # Upload menu
 SparkFun.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
@@ -15412,6 +15420,10 @@ Nucleo_144.menu.xusb.HSFS=High Speed in Full Speed mode
 Nucleo_144.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 
 Nucleo_64.menu.usb.none=None
+Nucleo_64.menu.usb.TinyUSB=Adafruit TinyUSB
+Nucleo_64.menu.usb.TinyUSB.build.usb_flags={build.extra_flags} -DARDUINO_ARCH_TINYUSB
+Nucleo_64.menu.usb.TinyUSB.upload.use_1200bps_touch=true
+Nucleo_64.menu.usb.TinyUSB.upload.wait_for_upload_port=false
 Nucleo_64.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 Nucleo_64.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 Nucleo_64.menu.usb.CDC=CDC (no generic 'Serial')
@@ -15482,6 +15494,8 @@ GenF0.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
 GenF1.menu.usb.none=None
 GenF1.menu.usb.TinyUSB=Adafruit TinyUSB
 GenF1.menu.usb.TinyUSB.build.usb_flags={build.extra_flags} -DARDUINO_ARCH_TINYUSB
+GenF1.menu.usb.TinyUSB.upload.use_1200bps_touch=true
+GenF1.menu.usb.TinyUSB.upload.wait_for_upload_port=false
 GenF1.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenF1.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 GenF1.menu.usb.CDC=CDC (no generic 'Serial')
@@ -15523,6 +15537,8 @@ GenF3.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 GenF4.menu.usb.none=None
 GenF4.menu.usb.TinyUSB=Adafruit TinyUSB
 GenF4.menu.usb.TinyUSB.build.usb_flags={build.extra_flags} -DARDUINO_ARCH_TINYUSB
+GenF4.menu.usb.TinyUSB.upload.use_1200bps_touch=true
+GenF4.menu.usb.TinyUSB.upload.wait_for_upload_port=false
 GenF4.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenF4.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 GenF4.menu.usb.CDC=CDC (no generic 'Serial')
@@ -15559,6 +15575,8 @@ GenG0.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
 GenG4.menu.usb.none=None
 GenG4.menu.usb.TinyUSB=Adafruit TinyUSB
 GenG4.menu.usb.TinyUSB.build.usb_flags={build.extra_flags} -DARDUINO_ARCH_TINYUSB
+GenG4.menu.usb.TinyUSB.upload.use_1200bps_touch=true
+GenG4.menu.usb.TinyUSB.upload.wait_for_upload_port=false
 GenG4.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenG4.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 GenG4.menu.usb.CDC=CDC (no generic 'Serial')
@@ -15669,6 +15687,10 @@ GenU5.menu.xusb.HSFS=High Speed in Full Speed mode
 GenU5.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 
 GenWB.menu.usb.none=None
+GenWB.menu.usb.TinyUSB=Adafruit TinyUSB
+GenWB.menu.usb.TinyUSB.build.usb_flags={build.extra_flags} -DARDUINO_ARCH_TINYUSB
+GenWB.menu.usb.TinyUSB.upload.use_1200bps_touch=true
+GenWB.menu.usb.TinyUSB.upload.wait_for_upload_port=false
 GenWB.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
 GenWB.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
 GenWB.menu.usb.CDC=CDC (no generic 'Serial')


### PR DESCRIPTION
## Summary

Add a TinyUSB USB menu option for Generic STM32F4 boards to improve compatibility with the Adafruit TinyUSB Arduino library.

## This PR fixes/implements the following bugs/features

**Feature**
- Adds a `TinyUSB` USB menu option for `GenF4` boards in `boards.txt`
- Enables `ARDUINO_ARCH_TINYUSB` via `build.usb_flags` when selected

**Non-breaking**
- Existing USB options and behavior are unchanged unless `TinyUSB` is explicitly selected

## Motivation

I have completed the STM32 port files for the Adafruit TinyUSB Arduino library and a pull request has been submitted upstream to include them after testing.

Without a dedicated USB menu option in the STM32 core, using TinyUSB currently requires sketch-level workarounds or manual defines. Adding a `TinyUSB` option in `boards.txt` allows the core to expose the required build flag cleanly and consistently.

This change enables TinyUSB to work across all STM32F4 boards using the Generic core configuration, simplifying usage and improving compatibility.

While this approach could be extended to other STM32 families in the future, testing for this change has currently been limited to an STM32F411 BlackPill board.

## Validation

- CI build passes
- Tested on STM32F411 BlackPill
- Verified TinyUSB CDC works without requiring sketch-level `#define` workarounds

## Code formatting

- No source formatting changes required (boards.txt only)
- CI AStyle unaffected

## Closing issues

- N/A
