### PR TITLE
Fixed timer disabling for SoftareSerial in half duplex mode.

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -360,6 +360,7 @@ void SoftwareSerial::begin(long speed)
 void SoftwareSerial::end()
 {
   stopListening();
+  setSpeed(0);
 }
 
 // Read data from buffer


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **bugs/features**

* [x] SoftwareSerial.end() doesn't stop the hardware timer in half duplex mode. See issue #2910 

**Motivation**
I work mostly with battery powered devices, and the hardware timer was waking up the controller.

**Validation**
Tests made on a custom board based on STM32L443VC.
