### PR TITLE
fix(h7): wrong data size

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -9618,7 +9618,7 @@ GenH7.menu.pnum.WeActMiniH750VBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/
 # Generic H723VEHx
 GenH7.menu.pnum.GENERIC_H723VEHX=Generic H723VEHx
 GenH7.menu.pnum.GENERIC_H723VEHX.upload.maximum_size=524288
-GenH7.menu.pnum.GENERIC_H723VEHX.upload.maximum_data_size=528384
+GenH7.menu.pnum.GENERIC_H723VEHX.upload.maximum_data_size=327680
 GenH7.menu.pnum.GENERIC_H723VEHX.build.board=GENERIC_H723VEHX
 GenH7.menu.pnum.GENERIC_H723VEHX.build.product_line=STM32H723xx
 GenH7.menu.pnum.GENERIC_H723VEHX.build.variant=STM32H7xx/H723V(E-G)(H-T)_H730VB(H-T)_H733VG(H-T)
@@ -9627,7 +9627,7 @@ GenH7.menu.pnum.GENERIC_H723VEHX.debug.svd_file={runtime.tools.STM32_SVD.path}/s
 # Generic H723VETx
 GenH7.menu.pnum.GENERIC_H723VETX=Generic H723VETx
 GenH7.menu.pnum.GENERIC_H723VETX.upload.maximum_size=524288
-GenH7.menu.pnum.GENERIC_H723VETX.upload.maximum_data_size=528384
+GenH7.menu.pnum.GENERIC_H723VETX.upload.maximum_data_size=327680
 GenH7.menu.pnum.GENERIC_H723VETX.build.board=GENERIC_H723VETX
 GenH7.menu.pnum.GENERIC_H723VETX.build.product_line=STM32H723xx
 GenH7.menu.pnum.GENERIC_H723VETX.build.variant=STM32H7xx/H723V(E-G)(H-T)_H730VB(H-T)_H733VG(H-T)
@@ -9636,7 +9636,7 @@ GenH7.menu.pnum.GENERIC_H723VETX.debug.svd_file={runtime.tools.STM32_SVD.path}/s
 # Generic H723VGHx
 GenH7.menu.pnum.GENERIC_H723VGHX=Generic H723VGHx
 GenH7.menu.pnum.GENERIC_H723VGHX.upload.maximum_size=1048576
-GenH7.menu.pnum.GENERIC_H723VGHX.upload.maximum_data_size=528384
+GenH7.menu.pnum.GENERIC_H723VGHX.upload.maximum_data_size=327680
 GenH7.menu.pnum.GENERIC_H723VGHX.build.board=GENERIC_H723VGHX
 GenH7.menu.pnum.GENERIC_H723VGHX.build.product_line=STM32H723xx
 GenH7.menu.pnum.GENERIC_H723VGHX.build.variant=STM32H7xx/H723V(E-G)(H-T)_H730VB(H-T)_H733VG(H-T)
@@ -9645,7 +9645,7 @@ GenH7.menu.pnum.GENERIC_H723VGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/s
 # Generic H723VGTx
 GenH7.menu.pnum.GENERIC_H723VGTX=Generic H723VGTx
 GenH7.menu.pnum.GENERIC_H723VGTX.upload.maximum_size=1048576
-GenH7.menu.pnum.GENERIC_H723VGTX.upload.maximum_data_size=528384
+GenH7.menu.pnum.GENERIC_H723VGTX.upload.maximum_data_size=327680
 GenH7.menu.pnum.GENERIC_H723VGTX.build.board=GENERIC_H723VGTX
 GenH7.menu.pnum.GENERIC_H723VGTX.build.product_line=STM32H723xx
 GenH7.menu.pnum.GENERIC_H723VGTX.build.variant=STM32H7xx/H723V(E-G)(H-T)_H730VB(H-T)_H733VG(H-T)
@@ -9672,7 +9672,7 @@ GenH7.menu.pnum.GENERIC_H723ZGTX.debug.svd_file={runtime.tools.STM32_SVD.path}/s
 # Generic H730VBHx
 GenH7.menu.pnum.GENERIC_H730VBHX=Generic H730VBHx
 GenH7.menu.pnum.GENERIC_H730VBHX.upload.maximum_size=131072
-GenH7.menu.pnum.GENERIC_H730VBHX.upload.maximum_data_size=528384
+GenH7.menu.pnum.GENERIC_H730VBHX.upload.maximum_data_size=327680
 GenH7.menu.pnum.GENERIC_H730VBHX.build.board=GENERIC_H730VBHX
 GenH7.menu.pnum.GENERIC_H730VBHX.build.product_line=STM32H730xx
 GenH7.menu.pnum.GENERIC_H730VBHX.build.variant=STM32H7xx/H723V(E-G)(H-T)_H730VB(H-T)_H733VG(H-T)
@@ -9681,7 +9681,7 @@ GenH7.menu.pnum.GENERIC_H730VBHX.debug.svd_file={runtime.tools.STM32_SVD.path}/s
 # Generic H730VBTx
 GenH7.menu.pnum.GENERIC_H730VBTX=Generic H730VBTx
 GenH7.menu.pnum.GENERIC_H730VBTX.upload.maximum_size=131072
-GenH7.menu.pnum.GENERIC_H730VBTX.upload.maximum_data_size=528384
+GenH7.menu.pnum.GENERIC_H730VBTX.upload.maximum_data_size=327680
 GenH7.menu.pnum.GENERIC_H730VBTX.build.board=GENERIC_H730VBTX
 GenH7.menu.pnum.GENERIC_H730VBTX.build.product_line=STM32H730xx
 GenH7.menu.pnum.GENERIC_H730VBTX.build.variant=STM32H7xx/H723V(E-G)(H-T)_H730VB(H-T)_H733VG(H-T)
@@ -9699,7 +9699,7 @@ GenH7.menu.pnum.GENERIC_H730ZBTX.debug.svd_file={runtime.tools.STM32_SVD.path}/s
 # Generic H733VGHx
 GenH7.menu.pnum.GENERIC_H733VGHX=Generic H733VGHx
 GenH7.menu.pnum.GENERIC_H733VGHX.upload.maximum_size=1048576
-GenH7.menu.pnum.GENERIC_H733VGHX.upload.maximum_data_size=528384
+GenH7.menu.pnum.GENERIC_H733VGHX.upload.maximum_data_size=327680
 GenH7.menu.pnum.GENERIC_H733VGHX.build.board=GENERIC_H733VGHX
 GenH7.menu.pnum.GENERIC_H733VGHX.build.product_line=STM32H733xx
 GenH7.menu.pnum.GENERIC_H733VGHX.build.variant=STM32H7xx/H723V(E-G)(H-T)_H730VB(H-T)_H733VG(H-T)
@@ -9708,7 +9708,7 @@ GenH7.menu.pnum.GENERIC_H733VGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/s
 # Generic H733VGTx
 GenH7.menu.pnum.GENERIC_H733VGTX=Generic H733VGTx
 GenH7.menu.pnum.GENERIC_H733VGTX.upload.maximum_size=1048576
-GenH7.menu.pnum.GENERIC_H733VGTX.upload.maximum_data_size=528384
+GenH7.menu.pnum.GENERIC_H733VGTX.upload.maximum_data_size=327680
 GenH7.menu.pnum.GENERIC_H733VGTX.build.board=GENERIC_H733VGTX
 GenH7.menu.pnum.GENERIC_H733VGTX.build.product_line=STM32H733xx
 GenH7.menu.pnum.GENERIC_H733VGTX.build.variant=STM32H7xx/H723V(E-G)(H-T)_H730VB(H-T)_H733VG(H-T)


### PR DESCRIPTION
Only the AXI SRAM and RAM shared between ITCM and AXI are contiguous.

Fixes #2936.

