### PR TITLE
fix(variant): define Nucleo-L432KC USER_BTN to PNUM_NOT_DEFINED

### DIFF
--- a/variants/STM32L4xx/L432K(B-C)U_L442KCU/variant_NUCLEO_L432KC.h
+++ b/variants/STM32L4xx/L432K(B-C)U_L442KCU/variant_NUCLEO_L432KC.h
@@ -57,11 +57,11 @@
 #ifndef LED_BUILTIN
   #define LED_BUILTIN             PB3
 #endif
-#define LED_GREEN               LED_BUILTIN
+#define LED_GREEN                 LED_BUILTIN
 
 // On-board user button
 #ifndef USER_BTN
-  #define USER_BTN                PA8
+  #define USER_BTN                PNUM_NOT_DEFINED
 #endif
 
 // I2C Definitions


### PR DESCRIPTION
Fixes #2971.
