### PR TITLE
fix(i3c): minor changes

### DIFF
--- a/CI/update/stm32variant.py
+++ b/CI/update/stm32variant.py
@@ -1478,6 +1478,25 @@ def i2c_pins_variant():
     return dict(sda=sda_pin, scl=scl_pin)
 
 
+def i3c_pins_variant():
+    sda_pin = scl_pin = "PNUM_NOT_DEFINED"
+    # Iterate to find match instance if any
+    for sda in i3csda_list:
+        sda_inst = sda[2].split("_", 1)[0]
+        for scl in i3cscl_list:
+            scl_inst = scl[2].split("_", 1)[0]
+            if sda_inst == scl_inst:
+                sda_pin = sda[0].replace("_", "", 1)
+                scl_pin = scl[0].replace("_", "", 1)
+                break
+        else:
+            continue
+        break
+    else:
+        print("No I3C found!")
+    return dict(sda=sda_pin, scl=scl_pin)
+
+
 def serial_pins_variant():
     # Manage (LP)U(S)ART pins
     if uarttx_list:
@@ -1591,6 +1610,12 @@ def print_variant(generic_list, alt_syswkup_list):
     # I2C definition
     i2c_pins = i2c_pins_variant()
 
+    # I3C definition if any
+    if i3csda_list and i3cscl_list:
+        i3c_pins = i3c_pins_variant()
+    else:
+        i3c_pins = None
+
     # Serial definition
     serial = serial_pins_variant()
 
@@ -1660,6 +1685,8 @@ def print_variant(generic_list, alt_syswkup_list):
         hal_modules_list.append("DAC")
     if eth_list:
         hal_modules_list.append("ETH")
+    if i3csda_list and i3cscl_list:
+        hal_modules_list.append("I3C")
     if xspidata0_list:
         if "OCTOSPI" in xspidata0_list[0][2]:
             hal_modules_list.append("OSPI")
@@ -1681,6 +1708,7 @@ def print_variant(generic_list, alt_syswkup_list):
             num_analog_inputs=len(analog_pins_list),
             spi_pins=spi_pins,
             i2c_pins=i2c_pins,
+            i3c_pins=i3c_pins,
             timer=timer,
             serial=serial,
             hal_modules_list=hal_modules_list,

--- a/CI/update/templates/variant_generic.h
+++ b/CI/update/templates/variant_generic.h
@@ -75,6 +75,16 @@
 #ifndef PIN_WIRE_SCL
   #define PIN_WIRE_SCL          {{i2c_pins.scl}}
 #endif
+{% if i3c_pins %}
+
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           {{i3c_pins.sda}}
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           {{i3c_pins.scl}}
+#endif
+{% endif %}
 
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin

--- a/cores/arduino/stm32/stm32yyxx_hal_conf.h
+++ b/cores/arduino/stm32/stm32yyxx_hal_conf.h
@@ -46,12 +46,6 @@
   #undef HAL_I2S_MODULE_ENABLED
 #endif
 
-#if !defined(HAL_I3C_MODULE_DISABLED)
-  #define HAL_I3C_MODULE_ENABLED
-#else
-  #undef HAL_I3C_MODULE_ENABLED
-#endif
-
 #if !defined(HAL_RTC_MODULE_DISABLED)
   #define HAL_RTC_MODULE_ENABLED
 #else
@@ -115,6 +109,12 @@
   /*#define HAL_EXTI_MODULE_ENABLED*/
 #else
   #undef HAL_EXTI_MODULE_ENABLED
+#endif
+
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  /*#define HAL_I3C_MODULE_ENABLED*/
+#else
+  #undef HAL_I3C_MODULE_ENABLED
 #endif
 
 #if !defined(HAL_ETH_MODULE_DISABLED)

--- a/libraries/I3C/examples/BasicBegin/BasicBegin.ino
+++ b/libraries/I3C/examples/BasicBegin/BasicBegin.ino
@@ -2,7 +2,7 @@
 
 // Choose the bus instance available on your board.
 
-#define I3C_BUS = I3C1Bus;
+#define I3C_BUS  I3C1Bus
 
 void setup() {
   Serial.begin(115200);

--- a/libraries/I3C/examples/DeviceReady/DeviceReady.ino
+++ b/libraries/I3C/examples/DeviceReady/DeviceReady.ino
@@ -1,6 +1,6 @@
 #include <I3C.h>
 
-#define I3C_BUS = I3C1Bus;
+#define I3C_BUS I3C1Bus
 
 
 void setup() {

--- a/libraries/I3C/src/I3C.cpp
+++ b/libraries/I3C/src/I3C.cpp
@@ -676,13 +676,13 @@ bool I3CBus::isI3CDeviceReady(uint8_t dynAddr, uint32_t trials, uint32_t timeout
 // Low-level CCC helpers
 // ============================================================================
 
-int I3CBus::cccBroadcastWrite(uint8_t cccId,
+bool I3CBus::cccBroadcastWrite(uint8_t cccId,
                               const uint8_t *data,
                               uint16_t length,
                               bool withDefByte,
                               uint32_t timeout)
 {
-  int result = -1;
+  bool result = false;
 
   if (_initialized) {
     uint32_t        controlBuffer[0xFF];
@@ -712,11 +712,11 @@ int I3CBus::cccBroadcastWrite(uint8_t cccId,
     if (st == HAL_OK) {
       st = HAL_I3C_Ctrl_TransmitCCC(&_hi3c, &context, timeout);
       if (st == HAL_OK) {
-        result = 0;
+        result = true;
       } else {
         uint32_t err = HAL_I3C_GetError(&_hi3c);
         if ((err & HAL_I3C_ERROR_CE2) != 0U) {
-          result = 0;
+          result = true;
         }
       }
     }
@@ -725,14 +725,14 @@ int I3CBus::cccBroadcastWrite(uint8_t cccId,
   return result;
 }
 
-int I3CBus::cccDirectWrite(uint8_t targetAddr,
+bool I3CBus::cccDirectWrite(uint8_t targetAddr,
                            uint8_t cccId,
                            const uint8_t *data,
                            uint16_t length,
                            bool withDefByte,
                            uint32_t timeout)
 {
-  int result = -1;
+  bool result = false;
 
   if (_initialized) {
     uint32_t        controlBuffer[0xFF];
@@ -767,7 +767,7 @@ int I3CBus::cccDirectWrite(uint8_t targetAddr,
     if (st == HAL_OK) {
       st = HAL_I3C_Ctrl_TransmitCCC(&_hi3c, &context, timeout);
       if (st == HAL_OK) {
-        result = 0;
+        result = true;
       }
     }
   }
@@ -775,13 +775,13 @@ int I3CBus::cccDirectWrite(uint8_t targetAddr,
   return result;
 }
 
-int I3CBus::cccDirectRead(uint8_t targetAddr,
+bool I3CBus::cccDirectRead(uint8_t targetAddr,
                           uint8_t cccId,
                           uint8_t *rxData,
                           uint16_t rxLength,
                           uint32_t timeout)
 {
-  int result = -1;
+  bool result = false;
 
   if (_initialized && (rxData != nullptr) && (rxLength != 0U)) {
     uint32_t        controlBuffer[0xFF];
@@ -812,7 +812,7 @@ int I3CBus::cccDirectRead(uint8_t targetAddr,
     if (st == HAL_OK) {
       st = HAL_I3C_Ctrl_ReceiveCCC(&_hi3c, &context, timeout);
       if (st == HAL_OK) {
-        result = 0;
+        result = true;
       }
     }
   }
@@ -824,45 +824,38 @@ int I3CBus::cccDirectRead(uint8_t targetAddr,
 // CCC direct-read helpers
 // ============================================================================
 
-int I3CBus::getbcr(uint8_t dynAddr, uint8_t &bcr, uint32_t timeout)
+bool I3CBus::getbcr(uint8_t dynAddr, uint8_t &bcr, uint32_t timeout)
 {
-  int result = 0;
+  bool result = false;
   uint8_t rxData[1] = {0};
 
-  int rc = cccDirectRead(dynAddr, I3C_CCC_GETBCR_DIR, rxData, 1U, timeout);
-  if (rc != 0) {
-    result = rc;
-  } else {
+  result = cccDirectRead(dynAddr, I3C_CCC_GETBCR_DIR, rxData, 1U, timeout);
+  if (result) {
     bcr = rxData[0];
   }
-
   return result;
 }
 
-int I3CBus::getdcr(uint8_t dynAddr, uint8_t &dcr, uint32_t timeout)
+bool I3CBus::getdcr(uint8_t dynAddr, uint8_t &dcr, uint32_t timeout)
 {
-  int result = 0;
+  bool result = false;
   uint8_t rxData[1] = {0};
 
-  int rc = cccDirectRead(dynAddr, I3C_CCC_GETDCR_DIR, rxData, 1U, timeout);
-  if (rc != 0) {
-    result = rc;
-  } else {
+  result = cccDirectRead(dynAddr, I3C_CCC_GETDCR_DIR, rxData, 1U, timeout);
+  if (result) {
     dcr = rxData[0];
   }
 
   return result;
 }
 
-int I3CBus::getpid(uint8_t dynAddr, uint64_t &pid, uint32_t timeout)
+bool I3CBus::getpid(uint8_t dynAddr, uint64_t &pid, uint32_t timeout)
 {
-  int result = 0;
+  bool result = false;
   uint8_t rxData[6] = {0};
 
-  int rc = cccDirectRead(dynAddr, I3C_CCC_GETPID_DIR, rxData, 6U, timeout);
-  if (rc != 0) {
-    result = rc;
-  } else {
+  result = cccDirectRead(dynAddr, I3C_CCC_GETPID_DIR, rxData, 6U, timeout);
+  if (result) {
     pid = 0ULL;
     pid |= (uint64_t)rxData[0] << 40;
     pid |= (uint64_t)rxData[1] << 32;
@@ -879,24 +872,24 @@ int I3CBus::getpid(uint8_t dynAddr, uint64_t &pid, uint32_t timeout)
 // 9. High-level CCC commands
 // ============================================================================
 
-int I3CBus::resetDynamicAddresses()
+bool I3CBus::resetDynamicAddresses()
 {
   return cccBroadcastWrite(I3C_CCC_RSTDAA_BCAST, nullptr, 0U, false, 1000U);
 }
 
-int I3CBus::disableEvents(const uint8_t *pCCCData, uint16_t length)
+bool I3CBus::disableEvents(const uint8_t *pCCCData, uint16_t length)
 {
   return cccBroadcastWrite(I3C_CCC_DISEC_BCAST, pCCCData, length, length > 0U, 1000U);
 }
 
-int I3CBus::assignAllStaticAsDynamic()
+bool I3CBus::assignAllStaticAsDynamic()
 {
   return cccBroadcastWrite(I3C_CCC_SETAASA_BCAST, nullptr, 0U, false, 1000U);
 }
 
-int I3CBus::assignDynamicAddress(uint8_t staticAddr7, uint8_t dynAddr7)
+bool I3CBus::assignDynamicAddress(uint8_t staticAddr7, uint8_t dynAddr7)
 {
-  int result = -1;
+  bool result = false;
 
   if (_initialized) {
     uint8_t daByte = static_cast<uint8_t>((dynAddr7 & 0x7FU) << 1);
@@ -906,15 +899,15 @@ int I3CBus::assignDynamicAddress(uint8_t staticAddr7, uint8_t dynAddr7)
   return result;
 }
 
-int I3CBus::disecAll()
+bool I3CBus::disecAll()
 {
   const uint8_t evAll = I3C_CCC_EVT_ALL;
   return disableEvents(&evAll, 1U);
 }
 
-int I3CBus::rstactWholeTarget()
+bool I3CBus::rstactWholeTarget()
 {
-  int result = -1;
+  bool result = false;
 
   if (_initialized) {
     uint8_t defByte = I3C_CCC_RSTACT_RESET_WHOLE_TARGET;
@@ -928,9 +921,9 @@ int I3CBus::rstactWholeTarget()
   return result;
 }
 
-int I3CBus::rstactPeripheralOnly()
+bool I3CBus::rstactPeripheralOnly()
 {
-  int result = -1;
+  bool result = false;
 
   if (_initialized) {
     uint8_t defByte = I3C_CCC_RSTACT_PERIPHERAL_ONLY;
@@ -944,12 +937,12 @@ int I3CBus::rstactPeripheralOnly()
   return result;
 }
 
-int I3CBus::setEvents(uint8_t dynAddr,
+bool I3CBus::setEvents(uint8_t dynAddr,
                       bool enable,
                       uint8_t events,
                       uint32_t timeout)
 {
-  int result = -1;
+  bool result = false;
 
   if (_initialized && (_hi3c.Mode == HAL_I3C_MODE_CONTROLLER)) {
     uint8_t ev    = events;
@@ -960,7 +953,7 @@ int I3CBus::setEvents(uint8_t dynAddr,
   return result;
 }
 
-int I3CBus::enecHotJoin()
+bool I3CBus::enecHotJoin()
 {
   uint8_t evHj = I3C_CCC_EVT_HJ;
   return cccBroadcastWrite(I3C_CCC_ENEC_BCAST, &evHj, 1U, true, 1000U);
@@ -1136,7 +1129,7 @@ int I3CBus::assignKnownDevices(const I3CKnownDevice *knownDevices,
         continue;
       }
 
-      if (assignDynamicAddress(kd.staticAddr, dyn) == 0) {
+      if (assignDynamicAddress(kd.staticAddr, dyn)) {
         markAddrUsed(dyn);
 
         if (count < maxDiscovered) {
@@ -1153,15 +1146,15 @@ int I3CBus::assignKnownDevices(const I3CKnownDevice *knownDevices,
           uint8_t  dcr = 0U;
           uint64_t pid = 0ULL;
 
-          if (getbcr(dyn, bcr) == 0) {
+          if (getbcr(dyn, bcr)) {
             d.bcr = bcr;
           }
 
-          if (getdcr(dyn, dcr) == 0) {
+          if (getdcr(dyn, dcr)) {
             d.dcr = dcr;
           }
 
-          if ((d.pid == 0U) && (getpid(dyn, pid) == 0)) {
+          if ((d.pid == 0U) && (getpid(dyn, pid))) {
             d.pid = pid;
           }
         }
@@ -1308,7 +1301,7 @@ int I3CBus::discover(const I3CBusBeginConfig &cfg,
     initAddressMap();
 
     if (cfg.doRstact) {
-      if (rstactWholeTarget() != 0) {
+      if (!rstactWholeTarget()) {
         (void)rstactPeripheralOnly();
       }
     }

--- a/libraries/I3C/src/I3C.h
+++ b/libraries/I3C/src/I3C.h
@@ -296,14 +296,14 @@ class I3CBus {
     // ------------------------------------------------------------------------
     // CCC broadcast & direct commands
     // ------------------------------------------------------------------------
-    int resetDynamicAddresses();
-    int disableEvents(const uint8_t *pCCCData, uint16_t length);
-    int assignAllStaticAsDynamic();
-    int assignDynamicAddress(uint8_t staticAddr, uint8_t dynAddr);
+    bool resetDynamicAddresses();
+    bool disableEvents(const uint8_t *pCCCData, uint16_t length);
+    bool assignAllStaticAsDynamic();
+    bool assignDynamicAddress(uint8_t staticAddr, uint8_t dynAddr);
 
-    int getbcr(uint8_t dynAddr, uint8_t &bcr, uint32_t timeout = 1000U);
-    int getdcr(uint8_t dynAddr, uint8_t &dcr, uint32_t timeout = 1000U);
-    int getpid(uint8_t dynAddr, uint64_t &pid, uint32_t timeout = 1000U);
+    bool getbcr(uint8_t dynAddr, uint8_t &bcr, uint32_t timeout = 1000U);
+    bool getdcr(uint8_t dynAddr, uint8_t &dcr, uint32_t timeout = 1000U);
+    bool getpid(uint8_t dynAddr, uint64_t &pid, uint32_t timeout = 1000U);
 
     // ------------------------------------------------------------------------
     // Discovery and dynamic address assignment
@@ -396,7 +396,7 @@ class I3CBus {
 
     int disableTargetEvents(uint32_t interruptMask);
 
-    int setEvents(uint8_t dynAddr,
+    bool setEvents(uint8_t dynAddr,
                   bool enable,
                   uint8_t events,
                   uint32_t timeout = 1000U);
@@ -470,10 +470,10 @@ class I3CBus {
     // ------------------------------------------------------------------------
     // Bus sequencing helpers
     // ------------------------------------------------------------------------
-    int disecAll();
-    int enecHotJoin();
-    int rstactPeripheralOnly();
-    int rstactWholeTarget();
+    bool disecAll();
+    bool enecHotJoin();
+    bool rstactPeripheralOnly();
+    bool rstactWholeTarget();
 
     int assignKnownDevices(const I3CKnownDevice *knownDevices,
                            size_t numKnownDevices,
@@ -495,20 +495,20 @@ class I3CBus {
     // ------------------------------------------------------------------------
     // Low-level CCC helpers
     // ------------------------------------------------------------------------
-    int cccBroadcastWrite(uint8_t cccId,
+    bool cccBroadcastWrite(uint8_t cccId,
                           const uint8_t *data,
                           uint16_t length,
                           bool withDefByte,
                           uint32_t timeout = 1000U);
 
-    int cccDirectWrite(uint8_t targetAddr,
+    bool cccDirectWrite(uint8_t targetAddr,
                        uint8_t cccId,
                        const uint8_t *data,
                        uint16_t length,
                        bool withDefByte,
                        uint32_t timeout = 1000U);
 
-    int cccDirectRead(uint8_t targetAddr,
+    bool cccDirectRead(uint8_t targetAddr,
                       uint8_t cccId,
                       uint8_t *rxData,
                       uint16_t rxLength,

--- a/variants/STM32H5xx/H503CB(T-U)/variant_generic.h
+++ b/variants/STM32H5xx/H503CB(T-U)/variant_generic.h
@@ -131,6 +131,14 @@
   #define PIN_WIRE_SCL          PB3
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB4
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB3
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -157,6 +165,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 
 /*----------------------------------------------------------------------------

--- a/variants/STM32H5xx/H503EBY/variant_generic.h
+++ b/variants/STM32H5xx/H503EBY/variant_generic.h
@@ -104,6 +104,14 @@
   #define PIN_WIRE_SCL          PB3
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB4
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB3
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -130,6 +138,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 
 /*----------------------------------------------------------------------------

--- a/variants/STM32H5xx/H503KBU/variant_generic.h
+++ b/variants/STM32H5xx/H503KBU/variant_generic.h
@@ -118,6 +118,14 @@
   #define PIN_WIRE_SCL          PB3
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB4
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB3
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -144,6 +152,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 
 /*----------------------------------------------------------------------------

--- a/variants/STM32H5xx/H503RBT/variant_NUCLEO_H503RB.h
+++ b/variants/STM32H5xx/H503RBT/variant_NUCLEO_H503RB.h
@@ -161,6 +161,9 @@
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
 #endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
+#endif
 
 // Value of the External oscillator in Hz
 #define HSE_VALUE               24000000UL

--- a/variants/STM32H5xx/H503RBT/variant_generic.h
+++ b/variants/STM32H5xx/H503RBT/variant_generic.h
@@ -153,6 +153,14 @@
   #define PIN_WIRE_SCL          PB3
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB4
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB3
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -179,6 +187,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 
 /*----------------------------------------------------------------------------

--- a/variants/STM32H5xx/H523C(C-E)(T-U)_H533CE(T-U)/variant_generic.h
+++ b/variants/STM32H5xx/H523C(C-E)(T-U)_H533CE(T-U)/variant_generic.h
@@ -130,6 +130,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB4
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA8
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -156,6 +164,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H523HEY_H533HEY/variant_generic.h
+++ b/variants/STM32H5xx/H523HEY_H533HEY/variant_generic.h
@@ -112,6 +112,14 @@
   #define PIN_WIRE_SCL          PB8
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB4
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA8
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -138,6 +146,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H523R(C-E)T_H533RET/variant_generic.h
+++ b/variants/STM32H5xx/H523R(C-E)T_H533RET/variant_generic.h
@@ -156,6 +156,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB4
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA8
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -185,6 +193,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H523V(C-E)(I-T)_H533VE(I-T)/variant_generic.h
+++ b/variants/STM32H5xx/H523V(C-E)(I-T)_H533VE(I-T)/variant_generic.h
@@ -187,6 +187,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB4
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA8
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -213,6 +221,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H523Z(C-E)(J-T)_H533ZE(J-T)/variant_generic.h
+++ b/variants/STM32H5xx/H523Z(C-E)(J-T)_H533ZE(J-T)/variant_generic.h
@@ -219,6 +219,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB4
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA8
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -245,6 +253,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H562A(G-I)I/variant_generic.h
+++ b/variants/STM32H5xx/H562A(G-I)I/variant_generic.h
@@ -262,6 +262,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -288,6 +296,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H562I(G-I)(K-T)/variant_generic.h
+++ b/variants/STM32H5xx/H562I(G-I)(K-T)/variant_generic.h
@@ -268,6 +268,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -294,6 +302,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H562R(G-I)T/variant_WEACT_H562RG.h
+++ b/variants/STM32H5xx/H562R(G-I)T/variant_WEACT_H562RG.h
@@ -188,6 +188,14 @@ P1                P2
   #define PIN_WIRE_SCL          PB6
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -214,6 +222,9 @@ P1                P2
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H562R(G-I)T/variant_generic.h
+++ b/variants/STM32H5xx/H562R(G-I)T/variant_generic.h
@@ -161,6 +161,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -190,6 +198,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H562R(G-I)V/variant_generic.h
+++ b/variants/STM32H5xx/H562R(G-I)V/variant_generic.h
@@ -166,6 +166,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -192,6 +200,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H562V(G-I)T/variant_generic.h
+++ b/variants/STM32H5xx/H562V(G-I)T/variant_generic.h
@@ -193,6 +193,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -219,6 +227,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H562Z(G-I)T/variant_generic.h
+++ b/variants/STM32H5xx/H562Z(G-I)T/variant_generic.h
@@ -228,6 +228,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -254,6 +262,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563A(G-I)I_H573AII/variant_generic.h
+++ b/variants/STM32H5xx/H563A(G-I)I_H573AII/variant_generic.h
@@ -262,6 +262,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -291,6 +299,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563AIIxQ_H573AIIxQ/variant_generic.h
+++ b/variants/STM32H5xx/H563AIIxQ_H573AIIxQ/variant_generic.h
@@ -261,6 +261,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -290,6 +298,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563I(G-I)(K-T)_H563LIHxQ_H573II(K-T)_H573LIHxQ/variant_generic.h
+++ b/variants/STM32H5xx/H563I(G-I)(K-T)_H563LIHxQ_H573II(K-T)_H573LIHxQ/variant_generic.h
@@ -268,6 +268,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -297,6 +305,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563IIKxQ_H573IIKxQ/variant_STM32H573I_DK.h
+++ b/variants/STM32H5xx/H563IIKxQ_H573IIKxQ/variant_STM32H573I_DK.h
@@ -302,6 +302,9 @@
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
 #endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
+#endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
 #endif

--- a/variants/STM32H5xx/H563IIKxQ_H573IIKxQ/variant_generic.h
+++ b/variants/STM32H5xx/H563IIKxQ_H573IIKxQ/variant_generic.h
@@ -267,6 +267,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -296,6 +304,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563IITxQ_H573IITxQ/variant_generic.h
+++ b/variants/STM32H5xx/H563IITxQ_H573IITxQ/variant_generic.h
@@ -263,6 +263,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -292,6 +300,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563MIYxQ_H573MIYxQ/variant_generic.h
+++ b/variants/STM32H5xx/H563MIYxQ_H573MIYxQ/variant_generic.h
@@ -169,6 +169,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -201,6 +209,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563R(G-I)T_H573RIT/variant_generic.h
+++ b/variants/STM32H5xx/H563R(G-I)T_H573RIT/variant_generic.h
@@ -161,6 +161,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -193,6 +201,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563R(G-I)V_H573RIV/variant_generic.h
+++ b/variants/STM32H5xx/H563R(G-I)V_H573RIV/variant_generic.h
@@ -166,6 +166,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -195,6 +203,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563V(G-I)T_H573VIT/variant_generic.h
+++ b/variants/STM32H5xx/H563V(G-I)T_H573VIT/variant_generic.h
@@ -193,6 +193,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -222,6 +230,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563VITxQ_H573VITxQ/variant_generic.h
+++ b/variants/STM32H5xx/H563VITxQ_H573VITxQ/variant_generic.h
@@ -189,6 +189,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -215,6 +223,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563Z(G-I)T_H573ZIT/variant_NUCLEO_H563ZI.h
+++ b/variants/STM32H5xx/H563Z(G-I)T_H573ZIT/variant_NUCLEO_H563ZI.h
@@ -247,6 +247,9 @@
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
 #endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
+#endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED
 #endif

--- a/variants/STM32H5xx/H563Z(G-I)T_H573ZIT/variant_generic.h
+++ b/variants/STM32H5xx/H563Z(G-I)T_H573ZIT/variant_generic.h
@@ -228,6 +228,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -257,6 +265,9 @@
 #endif
 #if !defined(HAL_ETH_MODULE_DISABLED)
   #define HAL_ETH_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32H5xx/H563ZITxQ_H573ZITxQ/variant_generic.h
+++ b/variants/STM32H5xx/H563ZITxQ_H573ZITxQ/variant_generic.h
@@ -224,6 +224,14 @@
   #define PIN_WIRE_SCL          PB10
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PB7
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB6
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -250,6 +258,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375C(E-G)(T-U)_U385CG(T-U)/variant_generic.h
+++ b/variants/STM32U3xx/U375C(E-G)(T-U)_U385CG(T-U)/variant_generic.h
@@ -125,6 +125,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -151,6 +159,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375C(E-G)(T-U)xQ_U385CG(T-U)xQ/variant_generic.h
+++ b/variants/STM32U3xx/U375C(E-G)(T-U)xQ_U385CG(T-U)xQ/variant_generic.h
@@ -118,6 +118,14 @@
   #define PIN_WIRE_SCL          PB13
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -144,6 +152,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375C(E-G)YxQ_U385CGYxQ/variant_generic.h
+++ b/variants/STM32U3xx/U375C(E-G)YxQ_U385CGYxQ/variant_generic.h
@@ -121,6 +121,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -147,6 +155,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375K(E-G)U_U385KGU/variant_generic.h
+++ b/variants/STM32U3xx/U375K(E-G)U_U385KGU/variant_generic.h
@@ -105,6 +105,14 @@
   #define PIN_WIRE_SCL          PB6
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -131,6 +139,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375R(E-G)I_U385RGI/variant_generic.h
+++ b/variants/STM32U3xx/U375R(E-G)I_U385RGI/variant_generic.h
@@ -144,6 +144,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -170,6 +178,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375R(E-G)IxQ_U385RGIxQ/variant_generic.h
+++ b/variants/STM32U3xx/U375R(E-G)IxQ_U385RGIxQ/variant_generic.h
@@ -136,6 +136,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -165,6 +173,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375R(E-G)T_U385RGT/variant_generic.h
+++ b/variants/STM32U3xx/U375R(E-G)T_U385RGT/variant_generic.h
@@ -144,6 +144,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -170,6 +178,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375R(E-G)TxQ_U385RGTxQ/variant_NUCLEO_U385RG_Q.h
+++ b/variants/STM32U3xx/U375R(E-G)TxQ_U385RGTxQ/variant_NUCLEO_U385RG_Q.h
@@ -147,6 +147,9 @@
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
 #endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
+#endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED
 #endif

--- a/variants/STM32U3xx/U375R(E-G)TxQ_U385RGTxQ/variant_NUCLEO_U385RG_Q.h
+++ b/variants/STM32U3xx/U375R(E-G)TxQ_U385RGTxQ/variant_NUCLEO_U385RG_Q.h
@@ -136,6 +136,10 @@
   #define PIN_SERIAL_TX         PA9
 #endif
 
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB13_ALT1
+#endif
+
 // SDMMC signals not available
 #define SDMMC_CDIR_NA
 

--- a/variants/STM32U3xx/U375R(E-G)TxQ_U385RGTxQ/variant_generic.h
+++ b/variants/STM32U3xx/U375R(E-G)TxQ_U385RGTxQ/variant_generic.h
@@ -136,6 +136,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -165,6 +173,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375R(E-G)YxG_U385RGYxG/variant_generic.h
+++ b/variants/STM32U3xx/U375R(E-G)YxG_U385RGYxG/variant_generic.h
@@ -131,6 +131,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -157,6 +165,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375R(E-G)YxQ_U385RGYxQ/variant_generic.h
+++ b/variants/STM32U3xx/U375R(E-G)YxQ_U385RGYxQ/variant_generic.h
@@ -143,6 +143,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -169,6 +177,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375V(E-G)I_U385VGI/variant_generic.h
+++ b/variants/STM32U3xx/U375V(E-G)I_U385VGI/variant_generic.h
@@ -175,6 +175,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -201,6 +209,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375V(E-G)IxQ_U385VGIxQ/variant_STDES_MB2095.h
+++ b/variants/STM32U3xx/U375V(E-G)IxQ_U385VGIxQ/variant_STDES_MB2095.h
@@ -194,6 +194,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA6
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PB2
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -220,6 +228,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375V(E-G)IxQ_U385VGIxQ/variant_generic.h
+++ b/variants/STM32U3xx/U375V(E-G)IxQ_U385VGIxQ/variant_generic.h
@@ -169,6 +169,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -195,6 +203,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375V(E-G)T_U385VGT/variant_generic.h
+++ b/variants/STM32U3xx/U375V(E-G)T_U385VGT/variant_generic.h
@@ -175,6 +175,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -201,6 +209,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U375V(E-G)TxQ_U385VGTxQ/variant_generic.h
+++ b/variants/STM32U3xx/U375V(E-G)TxQ_U385VGTxQ/variant_generic.h
@@ -169,6 +169,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -195,6 +203,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5C(G-I)(T-U)_U3C5CI(T-U)/variant_generic.h
+++ b/variants/STM32U3xx/U3B5C(G-I)(T-U)_U3C5CI(T-U)/variant_generic.h
@@ -134,6 +134,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -160,6 +168,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5C(G-I)(T-U)xQ_U3C5CI(T-U)xQ/variant_generic.h
+++ b/variants/STM32U3xx/U3B5C(G-I)(T-U)xQ_U3C5CI(T-U)xQ/variant_generic.h
@@ -127,6 +127,14 @@
   #define PIN_WIRE_SCL          PB13
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -153,6 +161,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5J(G-I)YxQ_U3C5JIYxQ/variant_generic.h
+++ b/variants/STM32U3xx/U3B5J(G-I)YxQ_U3C5JIYxQ/variant_generic.h
@@ -160,6 +160,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -186,6 +194,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5Q(G-I)I_U3C5QII/variant_generic.h
+++ b/variants/STM32U3xx/U3B5Q(G-I)I_U3C5QII/variant_generic.h
@@ -217,6 +217,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -243,6 +251,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5Q(G-I)IxQ_U3C5QIIxQ/variant_generic.h
+++ b/variants/STM32U3xx/U3B5Q(G-I)IxQ_U3C5QIIxQ/variant_generic.h
@@ -213,6 +213,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -239,6 +247,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5R(G-I)T_U3C5RIT/variant_generic.h
+++ b/variants/STM32U3xx/U3B5R(G-I)T_U3C5RIT/variant_generic.h
@@ -157,6 +157,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -183,6 +191,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5R(G-I)TxQ_U3C5RITxQ/variant_generic.h
+++ b/variants/STM32U3xx/U3B5R(G-I)TxQ_U3C5RITxQ/variant_generic.h
@@ -149,6 +149,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -178,6 +186,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5V(G-I)T_U3C5VIT/variant_generic.h
+++ b/variants/STM32U3xx/U3B5V(G-I)T_U3C5VIT/variant_generic.h
@@ -188,6 +188,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -214,6 +222,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5V(G-I)TxQ_U3C5VITxQ/variant_generic.h
+++ b/variants/STM32U3xx/U3B5V(G-I)TxQ_U3C5VITxQ/variant_generic.h
@@ -183,6 +183,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -209,6 +217,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5V(G-I)YxQ_U3C5VIYxQ/variant_generic.h
+++ b/variants/STM32U3xx/U3B5V(G-I)YxQ_U3C5VIYxQ/variant_generic.h
@@ -182,6 +182,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -208,6 +216,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5W(G-I)YxQ_U3C5WIYxQ/variant_generic.h
+++ b/variants/STM32U3xx/U3B5W(G-I)YxQ_U3C5WIYxQ/variant_generic.h
@@ -208,6 +208,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -234,6 +242,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5Z(G-I)T_U3C5ZIT/variant_generic.h
+++ b/variants/STM32U3xx/U3B5Z(G-I)T_U3C5ZIT/variant_generic.h
@@ -220,6 +220,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -246,6 +254,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED

--- a/variants/STM32U3xx/U3B5Z(G-I)TxQ_U3C5ZITxQ/variant_generic.h
+++ b/variants/STM32U3xx/U3B5Z(G-I)TxQ_U3C5ZITxQ/variant_generic.h
@@ -215,6 +215,14 @@
   #define PIN_WIRE_SCL          PB2
 #endif
 
+// I3C definitions
+#ifndef PIN_I3C_SDA
+  #define PIN_I3C_SDA           PA1
+#endif
+#ifndef PIN_I3C_SCL
+  #define PIN_I3C_SCL           PA7
+#endif
+
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #ifndef TIMER_TONE
@@ -241,6 +249,9 @@
 // Extra HAL modules
 #if !defined(HAL_DAC_MODULE_DISABLED)
   #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_I3C_MODULE_DISABLED)
+  #define HAL_I3C_MODULE_ENABLED
 #endif
 #if !defined(HAL_OSPI_MODULE_DISABLED)
   #define HAL_OSPI_MODULE_ENABLED


### PR DESCRIPTION

- Fix I3C Bus definition in examples
- Wrong I3C_SCL definiton for Nucleo U385RG_Q
- Use boolean for binary result functions
- Properly generate I3C pins definitions and enable HAL I3C module 

> [!Note]
> I3C usage on STM32U3xx is not fully functional. Some differences have to be managed.