### PR TITLE
fix(api): case insensitive issue

### DIFF
--- a/cmake/set_base_arduino_config.cmake
+++ b/cmake/set_base_arduino_config.cmake
@@ -56,7 +56,7 @@ target_include_directories(base_config INTERFACE
 	"${BUILD_CORE_PATH}"
 	"${BUILD_CORE_PATH}/avr"
 	"${BUILD_CORE_PATH}/stm32"
-	"${BUILD_CORE_PATH}/api"
+	"${BUILD_CORE_PATH}/api/deprecated"
 	"${BUILD_LIB_PATH}/SrcWrapper/inc"
 	"${BUILD_LIB_PATH}/SrcWrapper/inc/LL"
 	"${BUILD_LIB_PATH}/USBDevice/inc"

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -33,9 +33,8 @@
   #include "SrcWrapper.h"
 #endif
 
-#include "ArduinoAPI.h"
+#include "api/ArduinoAPI.h"
 #include "wiring.h"
-#include "deprecated-avr-comp/avr/dtostrf.h"
 
 /* sketch */
 

--- a/cores/arduino/Serial.h
+++ b/cores/arduino/Serial.h
@@ -26,7 +26,7 @@
 
 #include <inttypes.h>
 
-#include "Common.h"
+#include "api/Common.h"
 #include "HardwareSerial.h"
 #include "Stream.h"
 #include "uart.h"

--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -19,7 +19,7 @@
 #define _PINS_ARDUINO_H_
 #include <stdbool.h>
 #include <stdlib.h> /* Required for static_assert */
-#include "Common.h"
+#include "api/Common.h"
 #include "variant.h"
 #include "PinNames.h"
 

--- a/cores/arduino/wiring.h
+++ b/cores/arduino/wiring.h
@@ -26,8 +26,8 @@
 #include <math.h>
 #include <sys/time.h> // for struct timeval
 
-#include "Common.h"
-#include "deprecated-avr-comp/avr/dtostrf.h"
+#include "api/Common.h"
+#include "api/deprecated-avr-comp/avr/dtostrf.h"
 #include "clock.h"
 #include "dwt.h"
 #include "interrupt.h"

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -13,7 +13,7 @@
 #define _SPI_H_INCLUDED
 
 #include "Arduino.h"
-#include "HardwareSPI.h"
+#include "api/HardwareSPI.h"
 #include <stdio.h>
 extern "C" {
 #include "utility/spi_com.h"

--- a/libraries/Servo/src/Servo.h
+++ b/libraries/Servo/src/Servo.h
@@ -48,7 +48,7 @@
 #ifndef Servo_h
 #define Servo_h
 
-#include <Common.h>
+#include "api/Common.h"
 #include <inttypes.h>
 
 /*

--- a/libraries/SrcWrapper/inc/HardwareTimer.h
+++ b/libraries/SrcWrapper/inc/HardwareTimer.h
@@ -28,7 +28,7 @@
 #define HARDWARETIMER_H_
 
 /* Includes ------------------------------------------------------------------*/
-#include "Common.h"
+#include "api/Common.h"
 #include "timer.h"
 #include "stm32yyxx_ll_tim.h"
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -25,7 +25,7 @@
 #include <functional>
 
 #include "Arduino.h"
-#include "HardwareI2C.h"
+#include "api/HardwareI2C.h"
 extern "C" {
 #include "utility/twi.h"
 }

--- a/platform.txt
+++ b/platform.txt
@@ -39,7 +39,7 @@ USBDevice_include_dir={builtin_library_dir}/USBDevice/inc
 
 # STM compile variables
 # ----------------------
-compiler.stm.extra_include="-I{build.source.path}" "-I{build.core.path}/avr" "-I{core_stm32_dir}" "-I{api_dir}" "-I{SrcWrapper_include_dir}" "-I{SrcWrapper_include_dir}/LL" "-I{hal_dir}/Inc" "-I{hal_dir}/Src" "-I{build.system.path}/{build.series}" "-I{USBDevice_include_dir}" "-I{usbd_core_dir}/Inc" "-I{usbd_core_dir}/Src" "-I{VirtIO_include_dir}" {build.virtio_extra_include}
+compiler.stm.extra_include="-I{build.source.path}" "-I{build.core.path}/avr" "-I{core_stm32_dir}" "-I{api_dir}/deprecated" "-I{SrcWrapper_include_dir}" "-I{SrcWrapper_include_dir}/LL" "-I{hal_dir}/Inc" "-I{hal_dir}/Src" "-I{build.system.path}/{build.series}" "-I{USBDevice_include_dir}" "-I{usbd_core_dir}/Inc" "-I{usbd_core_dir}/Src" "-I{VirtIO_include_dir}" {build.virtio_extra_include}
 compiler.arm.cmsis.c.flags="-I{cmsis_dir}/Core/Include/" "-I{cmsis_dev_dir}/Include/" "-I{cmsis_dev_dir}/Source/Templates/gcc/" "-I{cmsis_dsp}/Include" "-I{cmsis_dsp}/PrivateInclude"
 
 compiler.warning_flags=-w


### PR DESCRIPTION
Having the `api/` folder in the include path cause issue between` string.h` provided by gcc and `String.h` provided by the ArduinoCore-API.

See https://github.com/arduino/ArduinoCore-API/issues/37

