### PR TITLE
fix(lora e5 mini): changeLORAWAN_RFSWITCH_RFO_LP_VALUES to LOW,HIGH

### DIFF
--- a/variants/STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I/variant_LORA_E5_MINI.h
+++ b/variants/STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I/variant_LORA_E5_MINI.h
@@ -174,7 +174,7 @@
 #define LORAWAN_RFSWITCH_PIN_COUNT      2
 #define LORAWAN_RFSWITCH_OFF_VALUES     LOW,LOW
 #define LORAWAN_RFSWITCH_RX_VALUES      HIGH,LOW
-#define LORAWAN_RFSWITCH_RFO_LP_VALUES  HIGH,HIGH
+#define LORAWAN_RFSWITCH_RFO_LP_VALUES  LOW,HIGH
 #define LORAWAN_RFSWITCH_RFO_HP_VALUES  LOW,HIGH
 
 /*----------------------------------------------------------------------------


### PR DESCRIPTION
I am working on a LoRaWAN project using a Seeed LoRA-E5 module. So, I used the LORA_E5_MINI variant. I noticed that the module stopped transmitting after about 24 messages. I read the Seeed Wio E5 HF documentation, and [it says that this module transmits at high power only](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module/#:~:text=3.%20RF%20Switch,0%2C%20PA5%3D1).  

The suspect line of code was in the file 
`variants/STM32WLxx/WL54JCI_WL55JCI_WLE4J(8-B-C)I_WLE5J(8-B-C)I/variant_LORA_E5_MINI.h`

It has

`#define LORAWAN_RFSWITCH_RFO_LP_VALUES  HIGH,HIGH`

I modified the line as follows

`#define LORAWAN_RFSWITCH_RFO_LP_VALUES  LOW,HIGH`

This is to prevent the LoRaWAN stack from configuring the node to use low transmission power, as the module does not support this capability.

It now works for me with this modification.
Fixes #3001.
