### PR TITLE
ARDUINO_DISCO_F411VE fix broken usb

### DIFF
--- a/variants/STM32F4xx/F411V(C-E)T/variant_DISCO_F411VE.cpp
+++ b/variants/STM32F4xx/F411V(C-E)T/variant_DISCO_F411VE.cpp
@@ -155,7 +155,7 @@ WEAK void SystemClock_Config(void)
   RCC_OscInitStruct.PLL.PLLM = 4;
   RCC_OscInitStruct.PLL.PLLN = 192;
   RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV4;
-  RCC_OscInitStruct.PLL.PLLQ = 4;
+  RCC_OscInitStruct.PLL.PLLQ = 8;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
     Error_Handler();
   }


### PR DESCRIPTION
## Pull Request

**Summary**

This pull requests fixes the broken USB output for the ARDUINO_DISCO_F411VE

I just changed the   
    
    RCC_OscInitStruct.PLL.PLLQ = 4;

to 

    RCC_OscInitStruct.PLL.PLLQ = 8;

For more details see [this discussion](https://github.com/orgs/stm32duino/discussions/3011#discussioncomment-17544450).


**Validation**

I tested with the following sketch to confirm that the USB CDC / Serial Output is working on an STM32F411 Discovery Kit using the STM32F411VE MCU:

```C++

// the setup function runs once when you press reset or power the board
void setup() {
  // initialize digital pin LED_BUILTIN as an output.
  pinMode(LED_BUILTIN, OUTPUT);
  Serial.begin(115200);
}

// the loop function runs over and over again forever
void loop() {
  digitalWrite(LED_BUILTIN, HIGH);  // change state of the LED by setting the pin to the HIGH voltage level
  delay(1000);                      // wait for a second
  digitalWrite(LED_BUILTIN, LOW);   // change state of the LED by setting the pin to the LOW voltage level
  delay(1000);                      // wait for a second
  Serial.println("test");
}
```

In addition I tested with my audio library which is based on TinyUSB using [this sketch](https://github.com/pschatzmann/arduino-audio-tools/blob/main/examples/examples-communication/usb/usb-tx/usb-tx.ino).

**Code formatting**

I did not change the formatting

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #xxx
