### PR TITLE
support for ARDUINO_WEACT_WB55CGU6

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,6 +819,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | :----: | :-------: | ---- | :-----: | :---- |
 | :green_heart: | STM32WB15CCU | Generic Board | *2.5.0* |  |
 | :green_heart: | STM32WB55CC<br>STM32WB55CE<br>STM32WB55CG | Generic Board | *2.0.0* |  |
+| :yellow_heart: | STM32WB55CGU | [WeAct STM32WB55CGU6](https://github.com/WeActStudio/WeActStudio.STM32WB55CoreBoard) | **3.0.0** |  |
 | :green_heart: | STM32WB5MMG | Generic Board | *2.1.0* |  |
 | :green_heart: | STM32WB55RC<br>STM32WB55RE<br>STM32WB55RG | Generic Board | *2.0.0* |  |
 | :green_heart: | STM32WB55VC<br>STM32WB55VE<br>STM32WB55VG | Generic Board | *2.10.0* |  |

--- a/boards.txt
+++ b/boards.txt
@@ -13539,6 +13539,16 @@ GenWB.openocd.target=stm32wbx
 GenWB.vid.0=0x0483
 GenWB.pid.0=0x5740
 
+# WeAct STM32WB55CGU6
+GenWB.menu.pnum.WEACT_WB55CGU6=WeAct STM32WB55CGU6
+GenWB.menu.pnum.WEACT_WB55CGU6.upload.maximum_size=524288
+GenWB.menu.pnum.WEACT_WB55CGU6.upload.maximum_data_size=196608
+GenWB.menu.pnum.WEACT_WB55CGU6.build.board=WEACT_WB55CGU6
+GenWB.menu.pnum.WEACT_WB55CGU6.build.product_line=STM32WB55xx
+GenWB.menu.pnum.WEACT_WB55CGU6.build.variant=STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U
+GenWB.menu.pnum.WEACT_WB55CGU6.build.variant_h=variant_WEACT_WB55CGU6.h
+GenWB.menu.pnum.WEACT_WB55CGU6.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
+
 # Generic WB15CCUx
 GenWB.menu.pnum.GENERIC_WB15CCUX=Generic WB15CCUx
 GenWB.menu.pnum.GENERIC_WB15CCUX.upload.maximum_size=131072
@@ -13673,16 +13683,6 @@ GenWB.menu.pnum.GENERIC_WB5MMGHX.build.board=GENERIC_WB5MMGHX
 GenWB.menu.pnum.GENERIC_WB5MMGHX.build.product_line=STM32WB5Mxx
 GenWB.menu.pnum.GENERIC_WB5MMGHX.build.variant=STM32WBxx/WB5MMGH
 GenWB.menu.pnum.GENERIC_WB5MMGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
-
-# WeAct STM32WB55CGU6
-GenWB.menu.pnum.WEACT_WB55CGU6=WeAct STM32WB55CGU6
-GenWB.menu.pnum.WEACT_WB55CGU6.upload.maximum_size=524288
-GenWB.menu.pnum.WEACT_WB55CGU6.upload.maximum_data_size=196608
-GenWB.menu.pnum.WEACT_WB55CGU6.build.board=WEACT_WB55CGU6
-GenWB.menu.pnum.WEACT_WB55CGU6.build.product_line=STM32WB55xx
-GenWB.menu.pnum.WEACT_WB55CGU6.build.variant=STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U
-GenWB.menu.pnum.WEACT_WB55CGU6.build.variant_h=variant_WEACT_WB55CGU6.h
-GenWB.menu.pnum.WEACT_WB55CGU6.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
 
 
 # Upload menu

--- a/boards.txt
+++ b/boards.txt
@@ -13674,6 +13674,16 @@ GenWB.menu.pnum.GENERIC_WB5MMGHX.build.product_line=STM32WB5Mxx
 GenWB.menu.pnum.GENERIC_WB5MMGHX.build.variant=STM32WBxx/WB5MMGH
 GenWB.menu.pnum.GENERIC_WB5MMGHX.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
 
+# WeAct STM32WB55CGU6
+GenWB.menu.pnum.WEACT_WB55CGU6=WeAct STM32WB55CGU6
+GenWB.menu.pnum.WEACT_WB55CGU6.upload.maximum_size=524288
+GenWB.menu.pnum.WEACT_WB55CGU6.upload.maximum_data_size=196608
+GenWB.menu.pnum.WEACT_WB55CGU6.build.board=WEACT_WB55CGU6
+GenWB.menu.pnum.WEACT_WB55CGU6.build.product_line=STM32WB55xx
+GenWB.menu.pnum.WEACT_WB55CGU6.build.variant=STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U
+GenWB.menu.pnum.WEACT_WB55CGU6.build.variant_h=variant_WEACT_WB55CGU6.h
+GenWB.menu.pnum.WEACT_WB55CGU6.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32WBxx/STM32WB55_CM4.svd
+
 
 # Upload menu
 GenWB.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)

--- a/variants/STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U/CMakeLists.txt
+++ b/variants/STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(variant_bin STATIC EXCLUDE_FROM_ALL
   variant_generic.cpp
   variant_MKR_SHARKY.cpp
   variant_P_NUCLEO_WB55_USB_DONGLE.cpp
+  variant_WEACT_WB55CGU6.cpp
 )
 target_link_libraries(variant_bin PUBLIC variant_usage)
 

--- a/variants/STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U/variant_WEACT_WB55CGU6.cpp
+++ b/variants/STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U/variant_WEACT_WB55CGU6.cpp
@@ -1,0 +1,150 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2026, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#if defined(ARDUINO_WEACT_WB55CGU6)
+#include "pins_arduino.h"
+#include "lock_resource.h"
+
+// Digital PinName array
+const PinName digitalPin[] = {
+  PB_2,   // D0
+  PA_9,   // D1
+  PA_8,   // D2
+  PA_7,   // D3
+  PA_6,   // D4
+  PA_5,   // D5
+  PA_4,   // D6
+  PA_3,   // D7
+  PA_2,   // D8
+  PA_1,   // D9
+  PA_0,   // D10
+  PB_8,   // D11
+  PB_9,   // D12
+  PH_3,   // D13 - BOOT0 / SW2 button
+  PB_0,   // D14
+  PB_1,   // D15
+  PE_4,   // D16 - onboard blue LED
+  PA_10,  // D17
+  PA_15,  // D18
+  PB_3,   // D19
+  PB_4,   // D20
+  PB_5,   // D21
+  PB_6,   // D22
+  PB_7    // D23
+};
+
+// Analog (Ax) pin number array
+const pin_size_t analogInputPin[] = {
+  10, // A0,  PA0
+  9,  // A1,  PA1
+  8,  // A2,  PA2
+  7,  // A3,  PA3
+  6,  // A4,  PA4
+  5,  // A5,  PA5
+  4,  // A6,  PA6
+  3,  // A7,  PA7
+  2,  // A8,  PA8
+  1   // A9,  PA9
+};
+
+// ----------------------------------------------------------------------------
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief  System Clock Configuration
+  * @param  None
+  * @retval None
+  *
+  * Board is fitted with a 32MHz HSE crystal (X2) and a 32.768kHz LSE
+  * crystal (X1). SYSCLK is driven directly by HSE (no PLL needed) and
+  * USB/RNG are clocked from the dedicated HSI48 oscillator, otherwise
+  * the USB peripheral is left unclocked and never enumerates.
+  */
+WEAK void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {};
+  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {};
+
+  /* This prevents concurrent access to RCC registers by CPU2 (M0+) */
+  hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
+
+  /* Macro to configure the PLL multiplication factor */
+  __HAL_RCC_PLL_PLLM_CONFIG(RCC_PLLM_DIV2);
+
+  /* Macro to configure the PLL clock source */
+  __HAL_RCC_PLL_PLLSOURCE_CONFIG(RCC_PLLSOURCE_HSE);
+
+  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_MEDIUMHIGH);
+  /* Configure the main internal regulator output voltage */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /* This prevents the CPU2 (M0+) to disable the HSI48 oscillator */
+  hsem_lock(CFG_HW_CLK48_CONFIG_SEMID, HSEM_LOCK_DEFAULT_RETRY);
+
+  /* Initializes the CPU, AHB and APB busses clocks */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI48 | RCC_OSCILLATORTYPE_HSI
+                                     | RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_LSE;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+
+  /* Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK4 | RCC_CLOCKTYPE_HCLK2
+                                | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK
+                                | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_HSE;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.AHBCLK2Divider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.AHBCLK4Divider = RCC_SYSCLK_DIV1;
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK) {
+    Error_Handler();
+  }
+
+  /* Initializes the peripherals clocks */
+  /* RNG needs to be configured like in M0 core, i.e. with HSI48 */
+  PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SMPS | RCC_PERIPHCLK_RFWAKEUP
+                                             | RCC_PERIPHCLK_RNG | RCC_PERIPHCLK_USB;
+  PeriphClkInitStruct.RFWakeUpClockSelection = RCC_RFWKPCLKSOURCE_LSE;
+  PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_HSI48;
+  PeriphClkInitStruct.SmpsClockSelection = RCC_SMPSCLKSOURCE_HSE;
+  PeriphClkInitStruct.SmpsDivSelection = RCC_SMPSCLKDIV_RANGE0;
+  PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
+
+  if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+
+  LL_PWR_SMPS_SetStartupCurrent(LL_PWR_SMPS_STARTUP_CURRENT_80MA);
+  LL_PWR_SMPS_SetOutputVoltageLevel(LL_PWR_SMPS_OUTPUT_VOLTAGE_1V40);
+  LL_PWR_SMPS_Enable();
+
+  /* Select HSI as system clock source after Wake Up from Stop mode */
+  LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+
+  hsem_unlock(CFG_HW_RCC_SEMID);
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ARDUINO_WEACT_WB55CGU6 */

--- a/variants/STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U/variant_WEACT_WB55CGU6.h
+++ b/variants/STM32WBxx/WB35C(C-E)UxA_WB55C(C-E-G)U/variant_WEACT_WB55CGU6.h
@@ -1,0 +1,150 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2026, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#pragma once
+
+/*----------------------------------------------------------------------------
+ *        STM32 pins number
+ *----------------------------------------------------------------------------*/
+#define PB2                     0
+#define PA9                     PIN_A9
+#define PA8                     PIN_A8
+#define PA7                     PIN_A7
+#define PA6                     PIN_A6
+#define PA5                     PIN_A5
+#define PA4                     PIN_A4
+#define PA3                     PIN_A3
+#define PA2                     PIN_A2
+#define PA1                     PIN_A1
+#define PA0                     PIN_A0
+#define PB8                     11
+#define PB9                     12
+#define PH3                     13 // BOOT0 / SW2 button
+#define PB0                     14
+#define PB1                     15
+#define PE4                     16 // Onboard blue LED
+#define PA10                    17
+#define PA15                    18
+#define PB3                     19
+#define PB4                     20
+#define PB5                     21
+#define PB6                     22
+#define PB7                     23
+
+// Alternate pins number
+#define PA7_ALT1                (PA7 | ALT1)
+#define PB8_ALT1                (PB8 | ALT1)
+#define PB9_ALT1                (PB9 | ALT1)
+
+#define NUM_DIGITAL_PINS        24
+#define NUM_ANALOG_INPUTS       10
+
+// On-board LED pin number
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN           PE4
+#endif
+
+// On-board user button (shared with BOOT0 hardware bootloader select)
+#ifndef USER_BTN
+  #define USER_BTN              PH3
+#endif
+
+// SPI definitions
+#ifndef PIN_SPI_SS
+  #define PIN_SPI_SS            PA4
+#endif
+#ifndef PIN_SPI_SS1
+  #define PIN_SPI_SS1           PA15
+#endif
+#ifndef PIN_SPI_SS2
+  #define PIN_SPI_SS2           PB2
+#endif
+#ifndef PIN_SPI_SS3
+  #define PIN_SPI_SS3           PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_MOSI
+  #define PIN_SPI_MOSI          PA7
+#endif
+#ifndef PIN_SPI_MISO
+  #define PIN_SPI_MISO          PA6
+#endif
+#ifndef PIN_SPI_SCK
+  #define PIN_SPI_SCK           PA5
+#endif
+
+// I2C definitions
+#ifndef PIN_WIRE_SDA
+  #define PIN_WIRE_SDA          PB9
+#endif
+#ifndef PIN_WIRE_SCL
+  #define PIN_WIRE_SCL          PB8
+#endif
+
+// Timer Definitions
+// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
+#ifndef TIMER_TONE
+  #define TIMER_TONE            TIM16
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO           TIM17
+#endif
+
+// UART Definitions
+#ifndef SERIAL_UART_INSTANCE
+  #define SERIAL_UART_INSTANCE  101
+#endif
+
+// Default pin used for generic 'Serial' instance
+// Mandatory for Firmata
+#ifndef PIN_SERIAL_RX
+  #define PIN_SERIAL_RX         PA3
+#endif
+#ifndef PIN_SERIAL_TX
+  #define PIN_SERIAL_TX         PA2
+#endif
+
+// Extra HAL modules
+#if !defined(HAL_QSPI_MODULE_DISABLED)
+  #define HAL_QSPI_MODULE_ENABLED
+#endif
+
+#ifndef HSE_VALUE
+  #define HSE_VALUE 32000000U
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+  // These serial port names are intended to allow libraries and architecture-neutral
+  // sketches to automatically default to the correct port name for a particular type
+  // of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+  // the first hardware serial port whose RX/TX pins are not dedicated to another use.
+  //
+  // SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+  //
+  // SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+  //
+  // SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+  //
+  // SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+  //
+  // SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+  //                            pins are NOT connected to anything by default.
+  #ifndef SERIAL_PORT_MONITOR
+    #define SERIAL_PORT_MONITOR   Serial
+  #endif
+  #ifndef SERIAL_PORT_HARDWARE
+    #define SERIAL_PORT_HARDWARE  Serial
+  #endif
+#endif


### PR DESCRIPTION
## Pull Request 

**Summary**

As a final test, I wanted to confirm the USB Audio functionality on the WeAct Studio STM32WB55CGU6 board. Unfortunately USB did not work at all, not even CDC!

This was because no clock has been defined in the generic STM32WB55CGU profile. 

I created this new board definition to be able to contiune with my tests.

**Validation**

- Tested that Serial is working (passed)
- Tested USB Audio with CDC (passed)
