### PR TITLE
Add Phoque1 and Phoque2 brushless driver variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
  - [IoT continuum boards](#iot-continuum-boards)
  - [LoRa boards](#lora-boards)
  - [Midatronics boards](#midatronics-boards)
+ - [Phoque brushless motor driver boards](#phoque-brushless-motor-driver-boards)
  - [SparkFun boards](#sparkfun-boards)
  - [ELV Boards](#elv-boards)
  - [STeaMi board](#steami-board)
@@ -946,6 +947,12 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 | Status | Device(s) | Name | Release | Notes |
 | :----: | :-------: | ---- | :-----: | :---- |
 | :green_heart:  | STM32WB55CE | SharkyMKR | *1.7.0* |  |
+
+### Phoque brushless motor driver boards
+| Status | Device(s) | Name | Release | Notes |
+| :----: | :-------: | ---- | :-----: | :---- |
+| :yellow_heart:  | STM32G431VBT | Phoque 1 Brushless Motor Driver | **3.0.1* | STSPIN32G4-based |
+| :yellow_heart:  | STM32G431CBU | Phoque 2 Brushless Motor Driver | **3.0.1* |  |
 
 ### [SparkFun](https://www.sparkfun.com/) boards
 

--- a/README.md
+++ b/README.md
@@ -951,8 +951,8 @@ User can add a STM32 based board following this [wiki](https://github.com/stm32d
 ### Phoque brushless motor driver boards
 | Status | Device(s) | Name | Release | Notes |
 | :----: | :-------: | ---- | :-----: | :---- |
-| :yellow_heart:  | STM32G431VBT | Phoque 1 Brushless Motor Driver | **3.0.1* | STSPIN32G4-based |
-| :yellow_heart:  | STM32G431CBU | Phoque 2 Brushless Motor Driver | **3.0.1* |  |
+| :yellow_heart:  | STM32G431VBT | Phoque 1 Brushless Motor Driver | **3.0.1** | STSPIN32G4-based |
+| :yellow_heart:  | STM32G431CBU | Phoque 2 Brushless Motor Driver | **3.0.1** |  |
 
 ### [SparkFun](https://www.sparkfun.com/) boards
 

--- a/boards.txt
+++ b/boards.txt
@@ -15396,6 +15396,74 @@ STeaMi.menu.upload_method.OpenOCDSTLink=OpenOCD STLink (SWD)
 STeaMi.menu.upload_method.OpenOCDSTLink.upload.protocol=stlink
 STeaMi.menu.upload_method.OpenOCDSTLink.upload.tool=openocd_upload
 
+###############################
+# Phoque-series brushless motor drivers
+Phoque.name=Phoque Brushless Motor Drivers
+
+Phoque.build.core=arduino
+Phoque.build.board=Phoque
+Phoque.build.st_extra_flags=-D{build.product_line} {build.enable_usb} {build.xSerial} -DARDUINO_PHOQUE
+Phoque.build.mcu=cortex-m4
+Phoque.build.fpu=-mfpu=fpv4-sp-d16
+Phoque.build.float-abi=-mfloat-abi=hard
+Phoque.build.series=STM32G4xx
+Phoque.build.flash_offset=0x0
+Phoque.upload.maximum_size=0
+Phoque.upload.maximum_data_size=0
+Phoque.openocd.target=stm32g4x
+Phoque.vid.0=0x0483
+Phoque.pid.0=0x5740
+
+# Phoque 1 Brushless Motor Driver
+Phoque.menu.pnum.PHOQUE1=Phoque 1
+Phoque.menu.pnum.PHOQUE1.upload.maximum_size=131072
+Phoque.menu.pnum.PHOQUE1.upload.maximum_data_size=32768
+Phoque.menu.pnum.PHOQUE1.build.board=PHOQUE1
+Phoque.menu.pnum.PHOQUE1.build.product_line=STM32G431xx
+Phoque.menu.pnum.PHOQUE1.build.variant=STM32G4xx/G431V(6-8-B)T_G441VBT
+Phoque.menu.pnum.PHOQUE1.build.variant_h=variant_{build.board}.h
+Phoque.menu.pnum.PHOQUE1.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
+
+# Phoque 2 Brushless Motor Driver
+Phoque.menu.pnum.PHOQUE2=Phoque 2
+Phoque.menu.pnum.PHOQUE2.upload.maximum_size=131072
+Phoque.menu.pnum.PHOQUE2.upload.maximum_data_size=32768
+Phoque.menu.pnum.PHOQUE2.build.board=PHOQUE2
+Phoque.menu.pnum.PHOQUE2.build.product_line=STM32G431xx
+Phoque.menu.pnum.PHOQUE2.build.variant=STM32G4xx/G431C(6-8-B)U_G441CBU
+Phoque.menu.pnum.PHOQUE2.build.variant_h=variant_{build.board}.h
+Phoque.menu.pnum.PHOQUE2.debug.svd_file={runtime.tools.STM32_SVD.path}/svd/STM32G4xx/STM32G431.svd
+
+# Upload menu
+Phoque.menu.upload_method.swdMethod=STM32CubeProgrammer (SWD)
+Phoque.menu.upload_method.swdMethod.upload.protocol=swd
+Phoque.menu.upload_method.swdMethod.upload.options=-a {upload.address} -m {upload.mode} -s {upload.start} -f {upload.freq} -n {upload.stlink_sn}
+Phoque.menu.upload_method.swdMethod.upload.tool=stm32CubeProg
+
+Phoque.menu.upload_method.serialMethod=STM32CubeProgrammer (Serial)
+Phoque.menu.upload_method.serialMethod.upload.protocol=serial
+Phoque.menu.upload_method.serialMethod.upload.options=-c {serial.port.file} -a {upload.address} -s {upload.start} -p {upload.parity}
+Phoque.menu.upload_method.serialMethod.upload.tool=stm32CubeProg
+
+Phoque.menu.upload_method.dfuMethod=STM32CubeProgrammer (DFU)
+Phoque.menu.upload_method.dfuMethod.upload.protocol=dfu
+Phoque.menu.upload_method.dfuMethod.upload.options=-v {upload.vid} -p {upload.pid} -a {upload.address} -s {upload.start}
+Phoque.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
+
+Phoque.menu.upload_method.bmpMethod=BMP (Black Magic Probe)
+Phoque.menu.upload_method.bmpMethod.upload.protocol=gdb_bmp
+Phoque.menu.upload_method.bmpMethod.upload.tool=bmp_upload
+
+Phoque.menu.upload_method.OpenOCDSTLink=OpenOCD STLink (SWD)
+Phoque.menu.upload_method.OpenOCDSTLink.upload.protocol=stlink
+Phoque.menu.upload_method.OpenOCDSTLink.upload.tool=openocd_upload
+
+Phoque.menu.upload_method.OpenOCDDapLink=OpenOCD DapLink (SWD)
+Phoque.menu.upload_method.OpenOCDDapLink.upload.protocol=cmsis-dap
+Phoque.menu.upload_method.OpenOCDDapLink.upload.tool=openocd_upload
+Phoque.menu.upload_method.OpenOCDDapLink.debug.server.openocd.scripts.0=interface/cmsis-dap.cfg
+Phoque.menu.upload_method.OpenOCDDapLink.debug.server.openocd.scripts.1={runtime.platform.path}/debugger/select_swd.cfg
+
 ################################################################################
 # Serialx activation
 Nucleo_144.menu.xserial.generic=Enabled (generic 'Serial')
@@ -15656,6 +15724,12 @@ STeaMi.menu.xserial.none=Enabled (no generic 'Serial')
 STeaMi.menu.xserial.none.build.xSerial=-DHAL_UART_MODULE_ENABLED -DHWSERIAL_NONE
 STeaMi.menu.xserial.disabled=Disabled (no Serial support)
 STeaMi.menu.xserial.disabled.build.xSerial=
+
+Phoque.menu.xserial.generic=Enabled (generic 'Serial')
+Phoque.menu.xserial.none=Enabled (no generic 'Serial')
+Phoque.menu.xserial.none.build.xSerial=-DHAL_UART_MODULE_ENABLED -DHWSERIAL_NONE
+Phoque.menu.xserial.disabled=Disabled (no Serial support)
+Phoque.menu.xserial.disabled.build.xSerial=
 
 # USB connectivity
 Nucleo_144.menu.usb.none=None
@@ -16037,6 +16111,19 @@ SparkFun.menu.xusb.HS=High Speed
 SparkFun.menu.xusb.HS.build.usb_speed=-DUSE_USB_HS
 SparkFun.menu.xusb.HSFS=High Speed in Full Speed mode
 SparkFun.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
+
+Phoque.menu.usb.none=None
+Phoque.menu.usb.CDCgen=CDC (generic 'Serial' supersede U(S)ART)
+Phoque.menu.usb.CDCgen.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC
+Phoque.menu.usb.CDC=CDC (no generic 'Serial')
+Phoque.menu.usb.CDC.build.enable_usb={build.usb_flags} -DUSBD_USE_CDC -DDISABLE_GENERIC_SERIALUSB
+Phoque.menu.usb.HID=HID (keyboard and mouse)
+Phoque.menu.usb.HID.build.enable_usb={build.usb_flags} -DUSBD_USE_HID_COMPOSITE
+Phoque.menu.xusb.FS=Low/Full Speed
+Phoque.menu.xusb.HS=High Speed
+Phoque.menu.xusb.HS.build.usb_speed=-DUSE_USB_HS
+Phoque.menu.xusb.HSFS=High Speed in Full Speed mode
+Phoque.menu.xusb.HSFS.build.usb_speed=-DUSE_USB_HS -DUSE_USB_HS_IN_FS
 
 # Optimizations
 Nucleo_144.menu.opt.osstd=Smallest (-Os default)
@@ -16879,6 +16966,26 @@ STeaMi.menu.opt.ogstd.build.flags.optimize=-Og
 STeaMi.menu.opt.o0std=No Optimization (-O0)
 STeaMi.menu.opt.o0std.build.flags.optimize=-O0
 
+Phoque.menu.opt.osstd=Smallest (-Os default)
+Phoque.menu.opt.oslto=Smallest (-Os) with LTO
+Phoque.menu.opt.oslto.build.flags.optimize=-Os -flto
+Phoque.menu.opt.o1std=Fast (-O1)
+Phoque.menu.opt.o1std.build.flags.optimize=-O1
+Phoque.menu.opt.o1lto=Fast (-O1) with LTO
+Phoque.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+Phoque.menu.opt.o2std=Faster (-O2)
+Phoque.menu.opt.o2std.build.flags.optimize=-O2
+Phoque.menu.opt.o2lto=Faster (-O2) with LTO
+Phoque.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+Phoque.menu.opt.o3std=Fastest (-O3)
+Phoque.menu.opt.o3std.build.flags.optimize=-O3
+Phoque.menu.opt.o3lto=Fastest (-O3) with LTO
+Phoque.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+Phoque.menu.opt.ogstd=Debug (-Og)
+Phoque.menu.opt.ogstd.build.flags.optimize=-Og
+Phoque.menu.opt.o0std=No Optimization (-O0)
+Phoque.menu.opt.o0std.build.flags.optimize=-O0
+
 # Debug information
 Nucleo_144.menu.dbg.none=None
 Nucleo_144.menu.dbg.enable_sym=Symbols Enabled (-g)
@@ -17207,6 +17314,14 @@ STeaMi.menu.dbg.enable_log=Core logs Enabled
 STeaMi.menu.dbg.enable_log.build.flags.debug=
 STeaMi.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
 STeaMi.menu.dbg.enable_all.build.flags.debug=-g
+
+Phoque.menu.dbg.none=None
+Phoque.menu.dbg.enable_sym=Symbols Enabled (-g)
+Phoque.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
+Phoque.menu.dbg.enable_log=Core logs Enabled
+Phoque.menu.dbg.enable_log.build.flags.debug=
+Phoque.menu.dbg.enable_all=Core Logs and Symbols Enabled (-g)
+Phoque.menu.dbg.enable_all.build.flags.debug=-g
 
 # C Runtime Library
 Nucleo_144.menu.rtlib.nano=Newlib Nano (default)
@@ -17628,3 +17743,13 @@ STeaMi.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 STeaMi.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 STeaMi.menu.rtlib.full=Newlib Standard
 STeaMi.menu.rtlib.full.build.flags.ldspecs=
+
+Phoque.menu.rtlib.nano=Newlib Nano (default)
+Phoque.menu.rtlib.nanofp=Newlib Nano + Float Printf
+Phoque.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+Phoque.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+Phoque.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+Phoque.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+Phoque.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+Phoque.menu.rtlib.full=Newlib Standard
+Phoque.menu.rtlib.full.build.flags.ldspecs=

--- a/cmake/boards_db.cmake
+++ b/cmake/boards_db.cmake
@@ -2260,7 +2260,8 @@ target_link_options(BLACKPILL_F401CE_hid INTERFACE
   -mcpu=${BLACKPILL_F401CE_hid_MCU}
 )
 
-# BLACKPILL_F411CE_25M
+
+# BLACKPILL_F411CE
 # -----------------------------------------------------------------------------
 
 set(BLACKPILL_F411CE_VARIANT_PATH "${CMAKE_CURRENT_LIST_DIR}/../variants/STM32F4xx/F411C(C-E)(U-Y)")
@@ -2338,48 +2339,6 @@ target_compile_options(BLACKPILL_F411CE_xusb_HS INTERFACE
 add_library(BLACKPILL_F411CE_xusb_HSFS INTERFACE)
 target_compile_options(BLACKPILL_F411CE_xusb_HSFS INTERFACE
   "SHELL:-DUSE_USB_HS -DUSE_USB_HS_IN_FS"
-)
-
-# BLACKPILL_F411CE_25M_hid
-# -----------------------------------------------------------------------------
-
-set(BLACKPILL_F411CE_hid_VARIANT_PATH "${CMAKE_CURRENT_LIST_DIR}/../variants/STM32F4xx/F411C(C-E)(U-Y)")
-set(BLACKPILL_F411CE_hid_MAXSIZE 524288)
-set(BLACKPILL_F411CE_hid_MAXDATASIZE 131072)
-set(BLACKPILL_F411CE_hid_MCU cortex-m4)
-set(BLACKPILL_F411CE_hid_FPCONF "-")
-add_library(BLACKPILL_F411CE_hid INTERFACE)
-target_compile_options(BLACKPILL_F411CE_hid INTERFACE
-  "SHELL:-DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER"
-  "SHELL:-DSTM32F411xE -DHAL_UART_MODULE_ENABLED -DBL_HID"
-  "SHELL:-DCUSTOM_PERIPHERAL_PINS"
-  "SHELL:-mfpu=fpv4-sp-d16 -mfloat-abi=hard"
-  -mcpu=${BLACKPILL_F411CE_hid_MCU}
-)
-target_compile_definitions(BLACKPILL_F411CE_hid INTERFACE
-  "STM32F4xx"
-	"ARDUINO_BLACKPILL_F411CE"
-	"BOARD_NAME=\"BLACKPILL_F411CE\""
-	"BOARD_ID=BLACKPILL_F411CE"
-	"VARIANT_H=\"variant_BLACKPILL_F411CE.h\""
-)
-target_include_directories(BLACKPILL_F411CE_hid INTERFACE
-  ${CMAKE_CURRENT_LIST_DIR}/../system/STM32F4xx
-  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/STM32F4xx_HAL_Driver/Inc
-  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/STM32F4xx_HAL_Driver/Src
-  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32F4xx/Include/
-  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32F4xx/Source/
-  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc/
-  ${BLACKPILL_F411CE_hid_VARIANT_PATH}
-)
-
-target_link_options(BLACKPILL_F411CE_hid INTERFACE
-  "LINKER:--default-script=${BLACKPILL_F411CE_hid_VARIANT_PATH}/ldscript.ld"
-  "LINKER:--defsym=LD_FLASH_OFFSET=0x4000"
-  "LINKER:--defsym=LD_MAX_SIZE=524288"
-  "LINKER:--defsym=LD_MAX_DATA_SIZE=131072"
-  "SHELL:-mfpu=fpv4-sp-d16 -mfloat-abi=hard"
-  -mcpu=${BLACKPILL_F411CE_hid_MCU}
 )
 
 # BLACKPILL_F411CE_8M
@@ -2503,6 +2462,50 @@ target_link_options(BLACKPILL_F411CE_8M_hid INTERFACE
   "SHELL:-mfpu=fpv4-sp-d16 -mfloat-abi=hard"
   -mcpu=${BLACKPILL_F411CE_8M_hid_MCU}
 )
+
+
+# BLACKPILL_F411CE_hid
+# -----------------------------------------------------------------------------
+
+set(BLACKPILL_F411CE_hid_VARIANT_PATH "${CMAKE_CURRENT_LIST_DIR}/../variants/STM32F4xx/F411C(C-E)(U-Y)")
+set(BLACKPILL_F411CE_hid_MAXSIZE 524288)
+set(BLACKPILL_F411CE_hid_MAXDATASIZE 131072)
+set(BLACKPILL_F411CE_hid_MCU cortex-m4)
+set(BLACKPILL_F411CE_hid_FPCONF "-")
+add_library(BLACKPILL_F411CE_hid INTERFACE)
+target_compile_options(BLACKPILL_F411CE_hid INTERFACE
+  "SHELL:-DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER"
+  "SHELL:-DSTM32F411xE -DHAL_UART_MODULE_ENABLED -DBL_HID"
+  "SHELL:-DCUSTOM_PERIPHERAL_PINS"
+  "SHELL:-mfpu=fpv4-sp-d16 -mfloat-abi=hard"
+  -mcpu=${BLACKPILL_F411CE_hid_MCU}
+)
+target_compile_definitions(BLACKPILL_F411CE_hid INTERFACE
+  "STM32F4xx"
+	"ARDUINO_BLACKPILL_F411CE"
+	"BOARD_NAME=\"BLACKPILL_F411CE\""
+	"BOARD_ID=BLACKPILL_F411CE"
+	"VARIANT_H=\"variant_BLACKPILL_F411CE.h\""
+)
+target_include_directories(BLACKPILL_F411CE_hid INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/../system/STM32F4xx
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/STM32F4xx_HAL_Driver/Inc
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/STM32F4xx_HAL_Driver/Src
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32F4xx/Include/
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32F4xx/Source/
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc/
+  ${BLACKPILL_F411CE_hid_VARIANT_PATH}
+)
+
+target_link_options(BLACKPILL_F411CE_hid INTERFACE
+  "LINKER:--default-script=${BLACKPILL_F411CE_hid_VARIANT_PATH}/ldscript.ld"
+  "LINKER:--defsym=LD_FLASH_OFFSET=0x4000"
+  "LINKER:--defsym=LD_MAX_SIZE=524288"
+  "LINKER:--defsym=LD_MAX_DATA_SIZE=131072"
+  "SHELL:-mfpu=fpv4-sp-d16 -mfloat-abi=hard"
+  -mcpu=${BLACKPILL_F411CE_hid_MCU}
+)
+
 
 # BLUE_F407VE_MINI
 # -----------------------------------------------------------------------------
@@ -4644,6 +4647,7 @@ target_link_options(DATABOARD_hid INTERFACE
   "LINKER:--defsym=LD_MAX_DATA_SIZE=20480"
   -mcpu=${DATABOARD_hid_MCU}
 )
+
 
 # DEMO_F030F4
 # -----------------------------------------------------------------------------
@@ -112103,6 +112107,164 @@ target_compile_options(P_NUCLEO_WB55RG_xusb_HS INTERFACE
 )
 add_library(P_NUCLEO_WB55RG_xusb_HSFS INTERFACE)
 target_compile_options(P_NUCLEO_WB55RG_xusb_HSFS INTERFACE
+  "SHELL:-DUSE_USB_HS -DUSE_USB_HS_IN_FS"
+)
+
+# PHOQUE1
+# -----------------------------------------------------------------------------
+
+set(PHOQUE1_VARIANT_PATH "${CMAKE_CURRENT_LIST_DIR}/../variants/STM32G4xx/G431V(6-8-B)T_G441VBT")
+set(PHOQUE1_MAXSIZE 131072)
+set(PHOQUE1_MAXDATASIZE 32768)
+set(PHOQUE1_MCU cortex-m4)
+set(PHOQUE1_FPCONF "-")
+add_library(PHOQUE1 INTERFACE)
+target_compile_options(PHOQUE1 INTERFACE
+  "SHELL:-DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER"
+  "SHELL:-DSTM32G431xx -DARDUINO_PHOQUE"
+  "SHELL:-mfpu=fpv4-sp-d16 -mfloat-abi=hard"
+  -mcpu=${PHOQUE1_MCU}
+)
+target_compile_definitions(PHOQUE1 INTERFACE
+  "STM32G4xx"
+	"ARDUINO_PHOQUE1"
+	"BOARD_NAME=\"PHOQUE1\""
+	"BOARD_ID=PHOQUE1"
+	"VARIANT_H=\"variant_PHOQUE1.h\""
+)
+target_include_directories(PHOQUE1 INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/../system/STM32G4xx
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/STM32G4xx_HAL_Driver/Inc
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/STM32G4xx_HAL_Driver/Src
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32G4xx/Include/
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32G4xx/Source/
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32G4xx/Source/Templates/gcc/
+  ${PHOQUE1_VARIANT_PATH}
+)
+
+target_link_options(PHOQUE1 INTERFACE
+  "LINKER:--default-script=${PHOQUE1_VARIANT_PATH}/ldscript.ld"
+  "LINKER:--defsym=LD_FLASH_OFFSET=0x0"
+  "LINKER:--defsym=LD_MAX_SIZE=131072"
+  "LINKER:--defsym=LD_MAX_DATA_SIZE=32768"
+  "SHELL:-mfpu=fpv4-sp-d16 -mfloat-abi=hard"
+  -mcpu=${PHOQUE1_MCU}
+)
+
+add_library(PHOQUE1_serial_disabled INTERFACE)
+target_compile_options(PHOQUE1_serial_disabled INTERFACE
+)
+add_library(PHOQUE1_serial_generic INTERFACE)
+target_compile_options(PHOQUE1_serial_generic INTERFACE
+  "SHELL:-DHAL_UART_MODULE_ENABLED"
+)
+add_library(PHOQUE1_serial_none INTERFACE)
+target_compile_options(PHOQUE1_serial_none INTERFACE
+  "SHELL:-DHAL_UART_MODULE_ENABLED -DHWSERIAL_NONE"
+)
+add_library(PHOQUE1_usb_CDC INTERFACE)
+target_compile_options(PHOQUE1_usb_CDC INTERFACE
+  "SHELL:-DUSBCON -DUSBD_VID=0x0483 -DUSBD_PID=0x5740 -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DDISABLE_GENERIC_SERIALUSB"
+)
+add_library(PHOQUE1_usb_CDCgen INTERFACE)
+target_compile_options(PHOQUE1_usb_CDCgen INTERFACE
+  "SHELL:-DUSBCON -DUSBD_VID=0x0483 -DUSBD_PID=0x5740 -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC"
+)
+add_library(PHOQUE1_usb_HID INTERFACE)
+target_compile_options(PHOQUE1_usb_HID INTERFACE
+  "SHELL:-DUSBCON -DUSBD_VID=0x0483 -DUSBD_PID=0x5740 -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_HID_COMPOSITE"
+)
+add_library(PHOQUE1_usb_none INTERFACE)
+target_compile_options(PHOQUE1_usb_none INTERFACE
+)
+add_library(PHOQUE1_xusb_FS INTERFACE)
+target_compile_options(PHOQUE1_xusb_FS INTERFACE
+)
+add_library(PHOQUE1_xusb_HS INTERFACE)
+target_compile_options(PHOQUE1_xusb_HS INTERFACE
+  "SHELL:-DUSE_USB_HS"
+)
+add_library(PHOQUE1_xusb_HSFS INTERFACE)
+target_compile_options(PHOQUE1_xusb_HSFS INTERFACE
+  "SHELL:-DUSE_USB_HS -DUSE_USB_HS_IN_FS"
+)
+
+# PHOQUE2
+# -----------------------------------------------------------------------------
+
+set(PHOQUE2_VARIANT_PATH "${CMAKE_CURRENT_LIST_DIR}/../variants/STM32G4xx/G431C(6-8-B)U_G441CBU")
+set(PHOQUE2_MAXSIZE 131072)
+set(PHOQUE2_MAXDATASIZE 32768)
+set(PHOQUE2_MCU cortex-m4)
+set(PHOQUE2_FPCONF "-")
+add_library(PHOQUE2 INTERFACE)
+target_compile_options(PHOQUE2 INTERFACE
+  "SHELL:-DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER"
+  "SHELL:-DSTM32G431xx -DARDUINO_PHOQUE"
+  "SHELL:-mfpu=fpv4-sp-d16 -mfloat-abi=hard"
+  -mcpu=${PHOQUE2_MCU}
+)
+target_compile_definitions(PHOQUE2 INTERFACE
+  "STM32G4xx"
+	"ARDUINO_PHOQUE2"
+	"BOARD_NAME=\"PHOQUE2\""
+	"BOARD_ID=PHOQUE2"
+	"VARIANT_H=\"variant_PHOQUE2.h\""
+)
+target_include_directories(PHOQUE2 INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/../system/STM32G4xx
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/STM32G4xx_HAL_Driver/Inc
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/STM32G4xx_HAL_Driver/Src
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32G4xx/Include/
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32G4xx/Source/
+  ${CMAKE_CURRENT_LIST_DIR}/../system/Drivers/CMSIS/Device/ST/STM32G4xx/Source/Templates/gcc/
+  ${PHOQUE2_VARIANT_PATH}
+)
+
+target_link_options(PHOQUE2 INTERFACE
+  "LINKER:--default-script=${PHOQUE2_VARIANT_PATH}/ldscript.ld"
+  "LINKER:--defsym=LD_FLASH_OFFSET=0x0"
+  "LINKER:--defsym=LD_MAX_SIZE=131072"
+  "LINKER:--defsym=LD_MAX_DATA_SIZE=32768"
+  "SHELL:-mfpu=fpv4-sp-d16 -mfloat-abi=hard"
+  -mcpu=${PHOQUE2_MCU}
+)
+
+add_library(PHOQUE2_serial_disabled INTERFACE)
+target_compile_options(PHOQUE2_serial_disabled INTERFACE
+)
+add_library(PHOQUE2_serial_generic INTERFACE)
+target_compile_options(PHOQUE2_serial_generic INTERFACE
+  "SHELL:-DHAL_UART_MODULE_ENABLED"
+)
+add_library(PHOQUE2_serial_none INTERFACE)
+target_compile_options(PHOQUE2_serial_none INTERFACE
+  "SHELL:-DHAL_UART_MODULE_ENABLED -DHWSERIAL_NONE"
+)
+add_library(PHOQUE2_usb_CDC INTERFACE)
+target_compile_options(PHOQUE2_usb_CDC INTERFACE
+  "SHELL:-DUSBCON -DUSBD_VID=0x0483 -DUSBD_PID=0x5740 -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DDISABLE_GENERIC_SERIALUSB"
+)
+add_library(PHOQUE2_usb_CDCgen INTERFACE)
+target_compile_options(PHOQUE2_usb_CDCgen INTERFACE
+  "SHELL:-DUSBCON -DUSBD_VID=0x0483 -DUSBD_PID=0x5740 -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC"
+)
+add_library(PHOQUE2_usb_HID INTERFACE)
+target_compile_options(PHOQUE2_usb_HID INTERFACE
+  "SHELL:-DUSBCON -DUSBD_VID=0x0483 -DUSBD_PID=0x5740 -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_HID_COMPOSITE"
+)
+add_library(PHOQUE2_usb_none INTERFACE)
+target_compile_options(PHOQUE2_usb_none INTERFACE
+)
+add_library(PHOQUE2_xusb_FS INTERFACE)
+target_compile_options(PHOQUE2_xusb_FS INTERFACE
+)
+add_library(PHOQUE2_xusb_HS INTERFACE)
+target_compile_options(PHOQUE2_xusb_HS INTERFACE
+  "SHELL:-DUSE_USB_HS"
+)
+add_library(PHOQUE2_xusb_HSFS INTERFACE)
+target_compile_options(PHOQUE2_xusb_HSFS INTERFACE
   "SHELL:-DUSE_USB_HS -DUSE_USB_HS_IN_FS"
 )
 

--- a/variants/STM32G4xx/G431C(6-8-B)U_G441CBU/CMakeLists.txt
+++ b/variants/STM32G4xx/G431C(6-8-B)U_G441CBU/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(variant_bin STATIC EXCLUDE_FROM_ALL
   PeripheralPins_B_G431B_ESC1.c
   variant_B_G431B_ESC1.cpp
   variant_generic.cpp
+  variant_PHOQUE2.cpp
 )
 target_link_libraries(variant_bin PUBLIC variant_usage)
 

--- a/variants/STM32G4xx/G431C(6-8-B)U_G441CBU/variant_PHOQUE2.cpp
+++ b/variants/STM32G4xx/G431C(6-8-B)U_G441CBU/variant_PHOQUE2.cpp
@@ -1,0 +1,144 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#if defined(ARDUINO_PHOQUE2)
+#include "pins_arduino.h"
+#include "pinmap.h"
+
+// Digital PinName array
+extern "C" const PinName digitalPin[] = {
+  PA_0,   // D0/A0
+  PA_1,   // D1/A1
+  PA_2,   // D2/A2
+  PA_3,   // D3/A3
+  PA_4,   // D4/A4
+  PA_5,   // D5/A5
+  PA_6,   // D6/A6
+  PA_7,   // D7/A7
+  PA_8,   // D8
+  PA_9,   // D9
+  PA_10,  // D10
+  PA_11,  // D11
+  PA_12,  // D12
+  PA_13,  // D13
+  PA_14,  // D14
+  PA_15,  // D15
+  PB_0,   // D16/A8
+  PB_1,   // D17/A9
+  PB_2,   // D18/A10
+  PB_3,   // D19
+  PB_4,   // D20
+  PB_5,   // D21
+  PB_6,   // D22
+  PB_7,   // D23
+  PB_8,   // D24
+  PB_9,   // D25
+  PB_10,  // D26
+  PB_11,  // D27/A11
+  PB_12,  // D28/A12
+  PB_13,  // D29
+  PB_14,  // D30/A13
+  PB_15,  // D31/A14
+  PC_4,   // D32/A15
+  PC_6,   // D33
+  PC_10,  // D34
+  PC_11,  // D35
+  PC_13,  // D36
+  PC_14,  // D37
+  PC_15,  // D38
+  PF_0,   // D39/A16
+  PF_1,   // D40/A17
+  PG_10   // D41
+};
+
+// Analog (Ax) pin number array
+extern "C" const uint32_t analogInputPin[] = {
+  0,  // A0,  PA0
+  1,  // A1,  PA1
+  2,  // A2,  PA2
+  3,  // A3,  PA3
+  4,  // A4,  PA4
+  5,  // A5,  PA5
+  6,  // A6,  PA6
+  7,  // A7,  PA7
+  16, // A8,  PB0
+  17, // A9,  PB1
+  18, // A10, PB2
+  27, // A11, PB11
+  28, // A12, PB12
+  30, // A13, PB14
+  31, // A14, PB15
+  32, // A15, PC4
+  39, // A16, PF0
+  40  // A17, PF1
+};
+
+__weak void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {};
+
+  /** Configure the main internal regulator output voltage
+  */
+  HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1_BOOST);
+
+  /** Initializes the RCC Oscillators according to the specified parameters
+  * in the RCC_OscInitTypeDef structure.
+  */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSI48 | RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+#if PHOQUE_PLL_HSI
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+  RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
+#else
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV2;
+#endif
+  RCC_OscInitStruct.PLL.PLLN = 85;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+  RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
+  RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+
+  /** Initializes the CPU, AHB and APB buses clocks
+  */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK
+                                | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK) {
+    Error_Handler();
+  }
+
+  RCC_PeriphCLKInitTypeDef PeriphClkInit;
+  PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_FDCAN | RCC_PERIPHCLK_USB | RCC_PERIPHCLK_RNG | RCC_PERIPHCLK_LPUART1 | RCC_PERIPHCLK_I2C1;
+  PeriphClkInit.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_PCLK1;
+  PeriphClkInit.FdcanClockSelection = RCC_FDCANCLKSOURCE_PLL; //CAN will run at 170MHz (PLLQ)
+  PeriphClkInit.I2c1ClockSelection = RCC_I2C1CLKSOURCE_PCLK1; //I2C1 at 170MHz
+  PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
+  PeriphClkInit.RngClockSelection = RCC_RNGCLKSOURCE_HSI48;
+  if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
+    Error_Handler();
+  }
+
+}
+
+#endif /* ARDUINO_PHOQUE2* */

--- a/variants/STM32G4xx/G431C(6-8-B)U_G441CBU/variant_PHOQUE2.h
+++ b/variants/STM32G4xx/G431C(6-8-B)U_G441CBU/variant_PHOQUE2.h
@@ -1,0 +1,233 @@
+#pragma once
+
+/*----------------------------------------------------------------------------
+ *        STM32 pins number
+ *----------------------------------------------------------------------------*/
+#define PA0                     PIN_A0
+#define PA1                     PIN_A1
+#define PA2                     PIN_A2
+#define PA3                     PIN_A3
+#define PA4                     PIN_A4
+#define PA5                     PIN_A5
+#define PA6                     PIN_A6
+#define PA7                     PIN_A7
+#define PA8                     8
+#define PA9                     9
+#define PA10                    10
+#define PA11                    11
+#define PA12                    12
+#define PA13                    13
+#define PA14                    14
+#define PA15                    15
+#define PB0                     PIN_A8
+#define PB1                     PIN_A9
+#define PB2                     PIN_A10
+#define PB3                     19
+#define PB4                     20
+#define PB5                     21
+#define PB6                     22
+#define PB7                     23
+#define PB8                     24
+#define PB9                     25
+#define PB10                    26
+#define PB11                    PIN_A11
+#define PB12                    PIN_A12
+#define PB13                    29
+#define PB14                    PIN_A13
+#define PB15                    PIN_A14
+#define PC4                     PIN_A15
+#define PC6                     33
+#define PC10                    34
+#define PC11                    35
+#define PC13                    36
+#define PC14                    37
+#define PC15                    38
+#define PF0                     PIN_A16
+#define PF1                     PIN_A17
+#define PG10                    41
+
+// Alternate pins number
+#define PA0_ALT1                (PA0  | ALT1)
+#define PA1_ALT1                (PA1  | ALT1)
+#define PA2_ALT1                (PA2  | ALT1)
+#define PA3_ALT1                (PA3  | ALT1)
+#define PA4_ALT1                (PA4  | ALT1)
+#define PA6_ALT1                (PA6  | ALT1)
+#define PA7_ALT1                (PA7  | ALT1)
+#define PA7_ALT2                (PA7  | ALT2)
+#define PA7_ALT3                (PA7  | ALT3)
+#define PA9_ALT1                (PA9  | ALT1)
+#define PA10_ALT1               (PA10 | ALT1)
+#define PA11_ALT1               (PA11 | ALT1)
+#define PA11_ALT2               (PA11 | ALT2)
+#define PA12_ALT1               (PA12 | ALT1)
+#define PA12_ALT2               (PA12 | ALT2)
+#define PA13_ALT1               (PA13 | ALT1)
+#define PA15_ALT1               (PA15 | ALT1)
+#define PB0_ALT1                (PB0  | ALT1)
+#define PB0_ALT2                (PB0  | ALT2)
+#define PB1_ALT1                (PB1  | ALT1)
+#define PB1_ALT2                (PB1  | ALT2)
+#define PB3_ALT1                (PB3  | ALT1)
+#define PB4_ALT1                (PB4  | ALT1)
+#define PB4_ALT2                (PB4  | ALT2)
+#define PB5_ALT1                (PB5  | ALT1)
+#define PB5_ALT2                (PB5  | ALT2)
+#define PB6_ALT1                (PB6  | ALT1)
+#define PB6_ALT2                (PB6  | ALT2)
+#define PB7_ALT1                (PB7  | ALT1)
+#define PB7_ALT2                (PB7  | ALT2)
+#define PB8_ALT1                (PB8  | ALT1)
+#define PB8_ALT2                (PB8  | ALT2)
+#define PB9_ALT1                (PB9  | ALT1)
+#define PB9_ALT2                (PB9  | ALT2)
+#define PB9_ALT3                (PB9  | ALT3)
+#define PB11_ALT1               (PB11 | ALT1)
+#define PB13_ALT1               (PB13 | ALT1)
+#define PB14_ALT1               (PB14 | ALT1)
+#define PB15_ALT1               (PB15 | ALT1)
+#define PB15_ALT2               (PB15 | ALT2)
+#define PC6_ALT1                (PC6  | ALT1)
+#define PC10_ALT1               (PC10 | ALT1)
+#define PC11_ALT1               (PC11 | ALT1)
+#define PC13_ALT1               (PC13 | ALT1)
+
+#define NUM_DIGITAL_PINS        42
+#define NUM_ANALOG_INPUTS       18
+
+
+
+/* Alias */
+#define A_PHASE_UL        PB15
+#define A_PHASE_UH        PA10
+#define A_PHASE_VL        PB14
+#define A_PHASE_VH        PA9
+#define A_PHASE_WL        PB13
+#define A_PHASE_WH        PA8
+
+#define PIN_SS_DRIVER     PC14  //Gate driver chip select
+#define PIN_NFAULT        PC15  //Gate driver fault pin
+
+#define A_VBUS          PB0   //Pin to sense supply voltage, connected to COMP4
+#define BRAKE_RESISTOR      PB1   //Brake resistor control, also connected to output of COMP4
+#define BRAKE_AF        3   //Alternate function 8
+#define BRAKE_DAC       DAC3  //DAC3
+#define BRAKE_DAC_CHAN      DAC_CHANNEL_2 //Channel 2
+#define BRAKE_COMP        COMP4 //Comparator 4
+#define BRAKE_COMP_PLUS     COMP_INPUT_PLUS_IO1
+#define BRAKE_COMP_MINUS    COMP_INPUT_MINUS_DAC1_CH2
+
+#define VBUS_MUL_FACTOR     23    //Multiply the adc voltage read by this value to get the supply voltage
+
+//BEMF inputs are connected to comparators with a 10k resistor to phase, 1k to 3.3v and 1k to gnd, so it's offset slightly above ground
+
+#define A_CURRU         PA2   //Current sense connected to phase U
+#define A_BEMFU         PA0   //BEMF connected to comparator 3 for phase U
+
+#define A_CURRV         PA7   //Current sense connected to phase V
+#define A_BEMFV         PA1   //BEMF connected to comparator 4 for phase V
+
+#define A_CURRW         PC4   //Current sense connected to phase W
+#define A_BEMFW         PA3   //BEMF connected to comparator 1 for phase W
+
+#define A_POTENTIOMETER     PB2
+#define A_TEMPERATURE     PB12
+
+//Voltage divider based on CMFA104J4250HANT and 100k resistor
+#define NTC_B_CONSTANT      4250  //B = ln(R/R0)/(1/T-1/T0)
+#define NTC_T0          (273.15f+25)//Kelvin
+#ifndef NTC_DIVIDER_BALANCE
+  #define NTC_DIVIDER_BALANCE   (22.f/100.f) //R1 (value of the other resistance in the voltage divider) over R0 (resistance of NTC at T0)
+#endif
+
+#define CAN_RX          PB8
+#define CAN_TX          PB9
+#define CAN_PWR         PC13 //Pin must be high to turn on CAN transceiver
+
+#define SWDIO         PA13
+#define SWCLK         PA14
+
+#define ENCODER_A       PA6   //TIM3_CH1 @ J5
+#define ENCODER_B       PA4   //TIM3_CH2 @ J5
+#define ENCODER_Z       PB3   //TIM3_ETR @ J5
+
+// On-board LED pin number
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN     PB6   //Drive low to turn on
+#endif
+
+//Magnetic angle sensor gets dedicated SPI
+#define PIN_MISO_MAG_ANGLE    PC11  //SPI3_MISO
+#define PIN_CLK_MAG_ANGLE   PC10  //SPI3_CLK
+#define PIN_SS_MAG_ANGLE    PC6   //GPIO
+/**
+ * Not actually connected to MOSI, but Arduino needs this since it doesn't expect RX-only SPI
+ * Call pinmap_pinout(digitalPinToPinName(PIN_SPI_MOSI), PinMap_SPI_MOSI); to reset the pin to the other SPI if needed
+ */
+
+#define PIN_MOSI_MAG_ANGLE    PB5_ALT1
+
+// SPI definitions
+#ifndef PIN_SPI_SS
+  #define PIN_SPI_SS        PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_SS1
+  #define PIN_SPI_SS1       PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_SS2
+  #define PIN_SPI_SS2       PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_SS3
+  #define PIN_SPI_SS3       PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_MOSI
+  #define PIN_SPI_MOSI      PB5   //SPI1_MOSI @ J6
+#endif
+#ifndef PIN_SPI_MISO
+  #define PIN_SPI_MISO      PB4   //SPI1_MISO @ J6
+#endif
+#ifndef PIN_SPI_SCK
+  #define PIN_SPI_SCK       PA5   //SPI1_SCK @ J6
+#endif
+
+//Qwiic-standard I2C on J1
+// I2C definitions
+#ifndef PIN_WIRE_SDA
+  #define PIN_WIRE_SDA      PB7
+#endif
+#ifndef PIN_WIRE_SCL
+  #define PIN_WIRE_SCL      PA15
+#endif
+
+// Timer Definitions
+// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
+#ifndef TIMER_TONE
+  #define TIMER_TONE      TIM6
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO     TIM7
+#endif
+
+// UART Definitions
+#define SERIAL_UART_INSTANCE  0
+
+//LPUART1 on J7
+// Default pin used for 'Serial' instance (ex: ST-Link)
+// Mandatory for Firmata
+#ifndef PIN_SERIAL_RX
+  #define PIN_SERIAL_RX     PB10
+#endif
+#ifndef PIN_SERIAL_TX
+  #define PIN_SERIAL_TX     PB11
+#endif
+
+/* HAL configuration */
+#define HSE_VALUE       (8000000UL)
+
+/* Extra HAL modules */
+#if !defined(HAL_DAC_MODULE_DISABLED)
+  #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_FDCAN_MODULE_DISABLED)
+  #define HAL_FDCAN_MODULE_ENABLED
+#endif

--- a/variants/STM32G4xx/G431V(6-8-B)T_G441VBT/CMakeLists.txt
+++ b/variants/STM32G4xx/G431V(6-8-B)T_G441VBT/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(variant_bin STATIC EXCLUDE_FROM_ALL
   generic_clock.c
   PeripheralPins.c
   variant_generic.cpp
+  variant_PHOQUE1.cpp
 )
 target_link_libraries(variant_bin PUBLIC variant_usage)
 

--- a/variants/STM32G4xx/G431V(6-8-B)T_G441VBT/variant_PHOQUE1.cpp
+++ b/variants/STM32G4xx/G431V(6-8-B)T_G441VBT/variant_PHOQUE1.cpp
@@ -1,0 +1,192 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020, STMicroelectronics
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#if defined(ARDUINO_PHOQUE1)
+#include "variant_PHOQUE1.h"
+#include "pinmap.h"
+
+// Digital PinName array
+extern "C" const PinName digitalPin[] = {
+  PA_0,   // D0/A0
+  PA_1,   // D1/A1
+  PA_2,   // D2/A2
+  PA_3,   // D3/A3
+  PA_4,   // D4/A4
+  PA_5,   // D5/A5
+  PA_6,   // D6/A6
+  PA_7,   // D7/A7
+  PA_8,   // D8
+  PA_9,   // D9
+  PA_10,  // D10
+  PA_11,  // D11
+  PA_12,  // D12
+  PA_13,  // D13
+  PA_14,  // D14
+  PA_15,  // D15
+  PB_0,   // D16/A8
+  PB_1,   // D17/A9
+  PB_2,   // D18/A10
+  PB_3,   // D19
+  PB_4,   // D20
+  PB_5,   // D21
+  PB_6,   // D22
+  PB_7,   // D23
+  PB_8,   // D24
+  PB_9,   // D25
+  PB_10,  // D26
+  PB_11,  // D27/A11
+  PB_12,  // D28/A12
+  PB_13,  // D29
+  PB_14,  // D30/A13
+  PB_15,  // D31/A14
+  PC_0,   // D32/A15
+  PC_1,   // D33/A16
+  PC_2,   // D34/A17
+  PC_3,   // D35/A18
+  PC_4,   // D36/A19
+  PC_5,   // D37/A20
+  PC_6,   // D38
+  PC_7,   // D39
+  PC_8,   // D40
+  PC_9,   // D41
+  PC_10,  // D42
+  PC_11,  // D43
+  PC_12,  // D44
+  PC_13,  // D45
+  PC_14,  // D46
+  PC_15,  // D47
+  PD_0,   // D48
+  PD_1,   // D49
+  PD_2,   // D50
+  PD_3,   // D51
+  PD_4,   // D52
+  PD_5,   // D53
+  PD_6,   // D54
+  PD_7,   // D55
+  PD_8,   // D56
+  PD_9,   // D57
+  PD_10,  // D58
+  PD_11,  // D59
+  PD_12,  // D60
+  PD_13,  // D61
+  PD_14,  // D62
+  PD_15,  // D63
+  PE_0,   // D64
+  PE_1,   // D65
+  PE_2,   // D66
+  PE_3,   // D67
+  PE_4,   // D68
+  PE_5,   // D69
+  PE_6,   // D70
+  PE_7,   // D71
+  PE_8,   // D72
+  PE_9,   // D73
+  PE_10,  // D74
+  PE_11,  // D75
+  PE_12,  // D76
+  PE_13,  // D77
+  PE_14,  // D78
+  PE_15,  // D79
+  PF_0,   // D80/A21
+  PF_1,   // D81/A22
+  PF_2,   // D82
+  PF_9,   // D83
+  PF_10,  // D84
+  PG_10   // D85
+};
+
+// Analog (Ax) pin number array
+extern "C" const uint32_t analogInputPin[] = {
+  0,  // A0,  PA0
+  1,  // A1,  PA1
+  2,  // A2,  PA2
+  3,  // A3,  PA3
+  4,  // A4,  PA4
+  5,  // A5,  PA5
+  6,  // A6,  PA6
+  7,  // A7,  PA7
+  16, // A8,  PB0
+  17, // A9,  PB1
+  18, // A10, PB2
+  27, // A11, PB11
+  28, // A12, PB12
+  30, // A13, PB14
+  31, // A14, PB15
+  32, // A15, PC0
+  33, // A16, PC1
+  34, // A17, PC2
+  35, // A18, PC3
+  36, // A19, PC4
+  37, // A20, PC5
+  80, // A21, PF0
+  81  // A22, PF1
+};
+
+__weak void SystemClock_Config(void)
+{
+  RCC_OscInitTypeDef RCC_OscInitStruct = {};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {};
+
+  /** Configure the main internal regulator output voltage
+  */
+  HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1_BOOST);
+
+  /** Initializes the RCC Oscillators according to the specified parameters
+  * in the RCC_OscInitTypeDef structure.
+  */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSI48 | RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+#if PHOQUE_PLL_HSI
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+  RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
+#else
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV2;
+#endif
+  RCC_OscInitStruct.PLL.PLLN = 85;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+  RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
+  RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+    Error_Handler();
+  }
+
+  /** Initializes the CPU, AHB and APB buses clocks
+  */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK
+                                | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK) {
+    Error_Handler();
+  }
+
+  RCC_PeriphCLKInitTypeDef PeriphClkInit;
+  PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_FDCAN | RCC_PERIPHCLK_USB | RCC_PERIPHCLK_RNG | RCC_PERIPHCLK_I2C2 | RCC_PERIPHCLK_I2C3;
+  PeriphClkInit.Usart1ClockSelection = RCC_USART1CLKSOURCE_PCLK2; //USART1 at 170MHz
+  PeriphClkInit.FdcanClockSelection = RCC_FDCANCLKSOURCE_PLL; //CAN will run at 170MHz
+  PeriphClkInit.I2c2ClockSelection = RCC_I2C2CLKSOURCE_PCLK1; //I2C2 at 170MHz
+  PeriphClkInit.I2c3ClockSelection = RCC_I2C3CLKSOURCE_PCLK1; //I2C3 at 170MHz
+  PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
+  if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
+    Error_Handler();
+  }
+
+}
+#endif

--- a/variants/STM32G4xx/G431V(6-8-B)T_G441VBT/variant_PHOQUE1.h
+++ b/variants/STM32G4xx/G431V(6-8-B)T_G441VBT/variant_PHOQUE1.h
@@ -1,0 +1,294 @@
+#pragma once
+
+/*----------------------------------------------------------------------------
+ *        STM32 pins number
+ *----------------------------------------------------------------------------*/
+#define PA0                     PIN_A0
+#define PA1                     PIN_A1
+#define PA2                     PIN_A2
+#define PA3                     PIN_A3
+#define PA4                     PIN_A4
+#define PA5                     PIN_A5
+#define PA6                     PIN_A6
+#define PA7                     PIN_A7
+#define PA8                     8
+#define PA9                     9
+#define PA10                    10
+#define PA11                    11
+#define PA12                    12
+#define PA13                    13
+#define PA14                    14
+#define PA15                    15
+#define PB0                     PIN_A8
+#define PB1                     PIN_A9
+#define PB2                     PIN_A10
+#define PB3                     19
+#define PB4                     20
+#define PB5                     21
+#define PB6                     22
+#define PB7                     23
+#define PB8                     24
+#define PB9                     25
+#define PB10                    26
+#define PB11                    PIN_A11
+#define PB12                    PIN_A12
+#define PB13                    29
+#define PB14                    PIN_A13
+#define PB15                    PIN_A14
+#define PC0                     PIN_A15
+#define PC1                     PIN_A16
+#define PC2                     PIN_A17
+#define PC3                     PIN_A18
+#define PC4                     PIN_A19
+#define PC5                     PIN_A20
+#define PC6                     38
+#define PC7                     39
+#define PC8                     40
+#define PC9                     41
+#define PC10                    42
+#define PC11                    43
+#define PC12                    44
+#define PC13                    45
+#define PC14                    46
+#define PC15                    47
+#define PD0                     48
+#define PD1                     49
+#define PD2                     50
+#define PD3                     51
+#define PD4                     52
+#define PD5                     53
+#define PD6                     54
+#define PD7                     55
+#define PD8                     56
+#define PD9                     57
+#define PD10                    58
+#define PD11                    59
+#define PD12                    60
+#define PD13                    61
+#define PD14                    62
+#define PD15                    63
+#define PE0                     64
+#define PE1                     65
+#define PE2                     66
+#define PE3                     67
+#define PE4                     68
+#define PE5                     69
+#define PE6                     70
+#define PE7                     71
+#define PE8                     72
+#define PE9                     73
+#define PE10                    74
+#define PE11                    75
+#define PE12                    76
+#define PE13                    77
+#define PE14                    78
+#define PE15                    79
+#define PF0                     PIN_A21
+#define PF1                     PIN_A22
+#define PF2                     82
+#define PF9                     83
+#define PF10                    84
+#define PG10                    85
+
+// Alternate pins number
+#define PA0_ALT1                (PA0  | ALT1)
+#define PA1_ALT1                (PA1  | ALT1)
+#define PA2_ALT1                (PA2  | ALT1)
+#define PA3_ALT1                (PA3  | ALT1)
+#define PA4_ALT1                (PA4  | ALT1)
+#define PA6_ALT1                (PA6  | ALT1)
+#define PA7_ALT1                (PA7  | ALT1)
+#define PA7_ALT2                (PA7  | ALT2)
+#define PA7_ALT3                (PA7  | ALT3)
+#define PA9_ALT1                (PA9  | ALT1)
+#define PA10_ALT1               (PA10 | ALT1)
+#define PA11_ALT1               (PA11 | ALT1)
+#define PA11_ALT2               (PA11 | ALT2)
+#define PA12_ALT1               (PA12 | ALT1)
+#define PA12_ALT2               (PA12 | ALT2)
+#define PA13_ALT1               (PA13 | ALT1)
+#define PA15_ALT1               (PA15 | ALT1)
+#define PB0_ALT1                (PB0  | ALT1)
+#define PB0_ALT2                (PB0  | ALT2)
+#define PB1_ALT1                (PB1  | ALT1)
+#define PB1_ALT2                (PB1  | ALT2)
+#define PB3_ALT1                (PB3  | ALT1)
+#define PB4_ALT1                (PB4  | ALT1)
+#define PB4_ALT2                (PB4  | ALT2)
+#define PB5_ALT1                (PB5  | ALT1)
+#define PB5_ALT2                (PB5  | ALT2)
+#define PB6_ALT1                (PB6  | ALT1)
+#define PB6_ALT2                (PB6  | ALT2)
+#define PB7_ALT1                (PB7  | ALT1)
+#define PB7_ALT2                (PB7  | ALT2)
+#define PB8_ALT1                (PB8  | ALT1)
+#define PB8_ALT2                (PB8  | ALT2)
+#define PB9_ALT1                (PB9  | ALT1)
+#define PB9_ALT2                (PB9  | ALT2)
+#define PB9_ALT3                (PB9  | ALT3)
+#define PB11_ALT1               (PB11 | ALT1)
+#define PB13_ALT1               (PB13 | ALT1)
+#define PB14_ALT1               (PB14 | ALT1)
+#define PB15_ALT1               (PB15 | ALT1)
+#define PB15_ALT2               (PB15 | ALT2)
+#define PC0_ALT1                (PC0  | ALT1)
+#define PC1_ALT1                (PC1  | ALT1)
+#define PC2_ALT1                (PC2  | ALT1)
+#define PC3_ALT1                (PC3  | ALT1)
+#define PC6_ALT1                (PC6  | ALT1)
+#define PC7_ALT1                (PC7  | ALT1)
+#define PC8_ALT1                (PC8  | ALT1)
+#define PC9_ALT1                (PC9  | ALT1)
+#define PC10_ALT1               (PC10 | ALT1)
+#define PC11_ALT1               (PC11 | ALT1)
+#define PC13_ALT1               (PC13 | ALT1)
+
+#define NUM_DIGITAL_PINS        86
+#define NUM_ANALOG_INPUTS       23
+
+
+
+/* Alias */
+#define A_PHASE_UL        PE8
+#define A_PHASE_UH        PE9
+#define A_PHASE_VL        PE10
+#define A_PHASE_VH        PE11
+#define A_PHASE_WL        PE12
+#define A_PHASE_WH        PE13
+
+#define PIN_READY       PE14  //Gate driver ready pin
+#define PIN_NFAULT        PE15  //Gate driver fault pin
+#define PIN_I2C_GD_SCL      PC8   //I2C3 connected to Gate driver
+#define PIN_I2C_GD_SDA      PC9   //I2C3 connected to Gate driver
+
+#define A_VBUS          PC1   //Pin to sense supply voltage. Also input of COMP3
+#define BRAKE_RESISTOR      PC2   //Brake resistor. Also output of COMP3
+#define BRAKE_AF        3   //Alternate function 3
+#define BRAKE_DAC       DAC1  //DAC 1 or 3
+#define BRAKE_DAC_CHAN      DAC_CHANNEL_1   //DAC Channel 1
+#define BRAKE_COMP        COMP3   //Use comparator 3
+#define BRAKE_COMP_PLUS     COMP_INPUT_PLUS_IO2
+#define BRAKE_COMP_MINUS    COMP_INPUT_MINUS_DAC1_CH1
+
+#define VBUS_MUL_FACTOR     23    //Multiply the adc voltage read by this value to get the supply voltage
+
+#define A_GPIO_BEMF       PA10  //Pin to pull Back-emf high or low
+
+#define A_CURRW_H       PA1   //phase W and opamp 1
+#define A_CURRW_L       PA3
+#define A_BEMFW         PA2
+
+#define A_CURRU_H       PA7   //phase U and opamp 2
+#define A_CURRU_L       PA5
+#define A_BEMFU         PA0
+
+#define A_CURRV_H       PB0   //phase V and opamp 3
+#define A_CURRV_L       PB2
+#define A_BEMFV         PC4
+
+#define A_POTENTIOMETER     PC0
+#define A_TEMPERATURE     PC5
+
+#ifndef NTC_B_CONSTANT
+  #define NTC_B_CONSTANT      4250  //B = ln(R/R0)/(1/T-1/T0)
+#endif
+#ifndef NTC_T0
+  #define NTC_T0          (273.15f+25)//Kelvin
+#endif
+#ifndef NTC_DIVIDER_BALANCE
+  #define NTC_DIVIDER_BALANCE   (22.f/100.f) //R1 (value of the other resistance in the voltage divider) over R0 (resistance of NTC at T0)
+#endif
+
+#define CAN_RX          PB8
+#define CAN_TX          PB9
+#define CAN_PWR         PC13 //Take pin high to power on CAN transceiver
+
+#define SWDIO         PA13 //Serial wire debug I/O
+#define SWCLK         PA14 //Serial wire debug clock
+
+#define I2C2_SCL        PA9 //I2C clock on the QWIIC connector
+#define I2C2_SDA        PA8 //I2C data on the QWIIC connector
+
+#define USART_TX        PB6
+#define USART_RX        PB7
+
+#define ENCODER_A       PA6
+#define ENCODER_B       PA4
+#define ENCODER_Z       PC3
+
+#define HALL1         ENCODER_A
+#define HALL2         ENCODER_B
+#define HALL3         ENCODER_Z
+
+
+// On-board LED pin number
+#define LED_RED         PA15
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN       LED_RED
+#endif
+
+#define PIN_PWM_MAG_ANGLE
+#define PIN_SS_MAG_ANGLE    PD2
+
+// SPI definitions
+#ifndef PIN_SPI_SS
+  #define PIN_SPI_SS        PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_SS1
+  #define PIN_SPI_SS1       PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_SS2
+  #define PIN_SPI_SS2       PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_SS3
+  #define PIN_SPI_SS3       PNUM_NOT_DEFINED
+#endif
+#ifndef PIN_SPI_MOSI
+  #define PIN_SPI_MOSI      PB5
+#endif
+#ifndef PIN_SPI_MISO
+  #define PIN_SPI_MISO      PB4
+#endif
+#ifndef PIN_SPI_SCK
+  #define PIN_SPI_SCK       PB3
+#endif
+
+// I2C definitions
+#ifndef PIN_WIRE_SDA
+  #define PIN_WIRE_SDA      I2C2_SDA
+#endif
+#ifndef PIN_WIRE_SCL
+  #define PIN_WIRE_SCL      I2C2_SCL
+#endif
+
+// Timer Definitions
+// Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
+#ifndef TIMER_TONE
+  #define TIMER_TONE      TIM6
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO     TIM7
+#endif
+
+// UART Definitions
+#define SERIAL_UART_INSTANCE  1 //Connected to ST-Link
+
+// Default pin used for 'Serial' instance (ex: ST-Link)
+// Mandatory for Firmata
+#ifndef PIN_SERIAL_RX
+  #define PIN_SERIAL_RX     USART_RX
+#endif
+#ifndef PIN_SERIAL_TX
+  #define PIN_SERIAL_TX     USART_TX
+#endif
+
+/* HAL configuration */
+#define HSE_VALUE       (8000000UL)
+
+/* Extra HAL modules */
+#if !defined(HAL_DAC_MODULE_DISABLED)
+  #define HAL_DAC_MODULE_ENABLED
+#endif
+#if !defined(HAL_FDCAN_MODULE_DISABLED)
+  #define HAL_FDCAN_MODULE_ENABLED
+#endif


### PR DESCRIPTION
This adds the Phoque1 and Phoque2 brushless driver variants.

These boards are currently in the closed testing phase.