### PR TITLE
fix(uart): support STM32C5 HAL v2 reset and IRQ handling

### DIFF
--- a/libraries/SrcWrapper/src/stm32/uart.c
+++ b/libraries/SrcWrapper/src/stm32/uart.c
@@ -692,9 +692,14 @@ void uart_deinit(serial_t *obj)
 #endif
 #if defined(USART6_BASE)
       case UART6_INDEX:
+#if defined(USE_HALV2_DRIVER)
+        HAL_RCC_USART6_Reset();
+        HAL_RCC_USART6_DisableClock();
+#else
         __HAL_RCC_USART6_FORCE_RESET();
         __HAL_RCC_USART6_RELEASE_RESET();
         __HAL_RCC_USART6_CLK_DISABLE();
+#endif
         break;
 #endif
 #if defined(LPUART1_BASE)
@@ -725,9 +730,14 @@ void uart_deinit(serial_t *obj)
 #endif
 #if defined(UART7_BASE)
       case UART7_INDEX:
+#if defined(USE_HALV2_DRIVER)
+        HAL_RCC_UART7_Reset();
+        HAL_RCC_UART7_DisableClock();
+#else
         __HAL_RCC_UART7_FORCE_RESET();
         __HAL_RCC_UART7_RELEASE_RESET();
         __HAL_RCC_UART7_CLK_DISABLE();
+#endif
         break;
 #elif defined(USART7_BASE)
       case UART7_INDEX:
@@ -1460,7 +1470,11 @@ void UART5_IRQHandler(void)
 #if defined(USART6_BASE) && !defined(STM32F0xx) && !defined(STM32G0xx)
 void USART6_IRQHandler(void)
 {
+#if defined(USE_HALV2_DRIVER)
+  HAL_CORTEX_NVIC_ClearPendingIRQ(USART6_IRQn);
+#else
   HAL_NVIC_ClearPendingIRQ(USART6_IRQn);
+#endif
   HAL_UART_IRQHandler(uart_handlers[UART6_INDEX]);
 }
 #endif
@@ -1490,7 +1504,11 @@ void LPUART1_IRQHandler(void)
 #if defined(UART7_BASE)
 void UART7_IRQHandler(void)
 {
+#if defined(USE_HALV2_DRIVER)
+  HAL_CORTEX_NVIC_ClearPendingIRQ(UART7_IRQn);
+#else
   HAL_NVIC_ClearPendingIRQ(UART7_IRQn);
+#endif
   HAL_UART_IRQHandler(uart_handlers[UART7_INDEX]);
 }
 #endif


### PR DESCRIPTION
**Summary**

This PR fixes UART reset, clock-disable, and IRQ pending-clear helpers when the STM32 HAL v2 driver is enabled.

This PR fixes the following **bug**:

* [x] Use the HAL v2 RCC and Cortex/NVIC helper APIs for UART7/USART6.
* [ ] Breaking changes

The HAL v2 build does not provide the legacy helper implementation used by these paths. Without this change, UART deinitialization and interrupt handling for the affected peripherals do not compile or behave correctly on STM32C5 HAL v2 targets.

**Dependencies and split**

* This is an independent, generic HAL v2 UART fix.
* PR #3048 (XIAO STM32C5 board support) enables a C5 HAL v2 build of the shared UART wrapper; because C5 exposes `USART6`/`UART7` symbols, this compatibility fix should be merged together with, or before, #3048 for a clean build.
* It does not depend on PR #3059 (STM32C5 USB HAL v2 support), the UF2 recipe PR, or Arduino_Tools PR #122.

**Validation**

* The change is limited to the HAL v2 conditional paths in `libraries/SrcWrapper/src/stm32/uart.c`.
* Hardware validation and CI builds will be provided by the normal CI matrix.

**Code formatting**

* AStyle formatting is unchanged; CI should verify the repository formatting checks.

**Closing issues**

None.
