### PR TITLE
feat(upload): add generic UF2 uploader recipe

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -212,6 +212,15 @@ tools.massStorageCopy.upload.params.verbose=
 tools.massStorageCopy.upload.params.quiet=
 tools.massStorageCopy.upload.pattern="{tools_bin_path}/{cmd}" {upload.verbose} -I "{build.path}/{build.project_name}.bin" -O "{node}"
 
+# Upload a UF2 image through a CDC 1200-bps touch and a UF2 mass-storage
+# bootloader. Board-specific address, family ID, volume label and size limits
+# are supplied by boards.txt.
+tools.uf2upload.cmd=uf2upload
+tools.uf2upload.cmd.windows=uf2upload.exe
+tools.uf2upload.upload.params.verbose=
+tools.uf2upload.upload.params.quiet=
+tools.uf2upload.upload.pattern="{tools_bin_path}/{cmd}" --input "{build.path}/{build.project_name}.bin" --port "{serial.port}" --volume "{upload.uf2.volume}" --address {upload.uf2.address} --family {upload.uf2.family} --max-size {upload.maximum_size} --timeout {upload.uf2.timeout}
+
 # STM32CubeProgrammer upload
 tools.stm32CubeProg.path={runtime.tools.STM32Tools.path}
 tools.stm32CubeProg.cmd=stm32CubeProg.sh


### PR DESCRIPTION
**Summary**

This PR adds a generic Arduino upload recipe for boards that use a UF2 bootloader reached through a CDC 1200-bps touch and then exposed as a UF2 mass-storage volume.

This PR implements the following **feature**:

* [x] Add the `uf2upload` tool definition and upload command in `platform.txt`.
* [ ] Breaking changes

The recipe keeps board-specific UF2 address, family ID, volume label, size limit, and timeout values in `boards.txt`, while sharing one uploader definition across boards.

**Dependencies and split**

* PR #3048 (XIAO STM32C5 board support) sets `XIAO_STM32C5.upload.tool=uf2upload` and supplies the board-specific UF2 parameters; this recipe is therefore required for that board's Arduino upload menu to work. The two PRs can be reviewed independently, but #3048's UF2 upload path is complete only after this recipe is merged.
* The recipe invokes the `uf2upload` executable supplied by Arduino_Tools PR #122. That tools PR must land first (or together), followed by a STM32Tools release/package-index update that makes the executable available to Arduino users.
* The recipe itself is independent of PR #3059 (STM32C5 USB HAL v2 support), but end-to-end 1200-bps touch upload on the C5 requires the USB CDC support from #3059.
* It is independent of the UART PR #3060.

**Validation**

* The change is limited to the generic `tools.uf2upload.*` definition in `platform.txt`.
* End-to-end upload validation depends on the Arduino_Tools #122 executable and its packaged STM32Tools release.

**Code formatting**

* AStyle formatting is not applicable to this platform configuration change; CI should verify the repository checks.

**Closing issues**

None.
