### PR TITLE
feat: reboot into the ST system bootloader on a 1200 bps touch

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -6146,6 +6146,7 @@ GenF4.menu.upload_method.dfuMethod=STM32CubeProgrammer (DFU)
 GenF4.menu.upload_method.dfuMethod.upload.protocol=dfu
 GenF4.menu.upload_method.dfuMethod.upload.options=-v {upload.vid} -p {upload.pid} -a {upload.address} -s {upload.start}
 GenF4.menu.upload_method.dfuMethod.upload.tool=stm32CubeProg
+GenF4.menu.upload_method.dfuMethod.build.bootloader_flags=-DBL_SYSTEM
 
 GenF4.menu.upload_method.bmpMethod=BMP (Black Magic Probe)
 GenF4.menu.upload_method.bmpMethod.upload.protocol=gdb_bmp

--- a/cores/arduino/hooks.c
+++ b/cores/arduino/hooks.c
@@ -50,3 +50,25 @@ static void __empty_dtr_toggling(uint8_t *buf, uint32_t *len)
 }
 void dtr_togglingHook(uint8_t *buf, uint32_t *len) __attribute__((weak, alias("__empty_dtr_toggling")));
 #endif
+
+#if defined(USBCON) && defined(USBD_USE_CDC)
+/**
+ * Empty cdc_1200bps_touch() hook.
+ *
+ * Called when the host closes the CDC port while the line coding is set to
+ * 1200 bps, which is the Arduino convention for asking the board to reboot
+ * into its bootloader.
+ *
+ * Its defined as a weak symbol and it can be redefined to implement the
+ * bootloader entry a given board needs.
+ *
+ * It is called from the USB control transfer callback, so it runs in handler
+ * mode. Branching to a bootloader from here leaves the core inside an
+ * exception that never returns; schedule the work and perform it from thread
+ * mode or after a reset instead.
+ */
+static void __empty_1200bps_touch(void)
+{
+}
+void cdc_1200bps_touchHook(void) __attribute__((weak, alias("__empty_1200bps_touch")));
+#endif /* USBCON && USBD_USE_CDC */

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -19,11 +19,16 @@
 
 #define ARDUINO_MAIN
 #include "Arduino.h"
+#include "bootloader.h"
 
 // Force init to be called *first*, i.e. before static object allocation.
 // Otherwise, statically allocated objects that need HAL may fail.
 __attribute__((constructor(101))) void premain()
 {
+#if defined(BL_SYSTEM)
+  /* Before any clock or cache setup below, so the ROM gets a quiet part. */
+  jumpToSystemBootloaderIfRequested();
+#endif
 
   // Required by FreeRTOS, see http://www.freertos.org/RTOS-Cortex-M3-M4.html
 #ifdef NVIC_PRIORITYGROUP_4

--- a/libraries/SrcWrapper/inc/bootloader.h
+++ b/libraries/SrcWrapper/inc/bootloader.h
@@ -1,6 +1,8 @@
 #ifndef _BOOTLOADER_H_
 #define _BOOTLOADER_H_
 
+#include <stdint.h>
+
 /* Ensure DTR_TOGGLING_SEQ enabled */
 #if defined(BL_LEGACY_LEAF) || defined(BL_HID)
   #ifndef DTR_TOGGLING_SEQ
@@ -11,6 +13,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+#if defined(BL_SYSTEM)
+uint32_t systemBootloaderAddress(void);
+void jumpToSystemBootloaderIfRequested(void);
+#endif /* BL_SYSTEM */
 
 #ifdef __cplusplus
 }

--- a/libraries/SrcWrapper/src/stm32/bootloader.c
+++ b/libraries/SrcWrapper/src/stm32/bootloader.c
@@ -1,5 +1,7 @@
 #include "bootloader.h"
 
+#include <stdbool.h>
+
 #include "stm32_def.h"
 #include "backup.h"
 
@@ -37,3 +39,81 @@ void dtr_togglingHook(uint8_t *buf, uint32_t *len)
   }
 }
 #endif /* BL_HID */
+
+#if defined(BL_SYSTEM)
+/* Request to enter the ST system memory bootloader. It lives in .noinit so it
+ * survives the reset that carries it, and holds an arbitrary value after a
+ * power cycle, which is why it is only trusted after a software reset. A
+ * backup register would not do, some series have none. Low half counts
+ * attempts. */
+static uint32_t bootloaderRequest __attribute__((section(".noinit")));
+
+#define BOOTLOADER_REQUEST_MAGIC 0x5A5A0000
+#define BOOTLOADER_REQUEST_MASK  0xFFFF0000
+
+/* The ROM clocks USB from the HSE but does not know which crystal is fitted,
+ * so it measures one against the HSI and resets the part when that measurement
+ * misses, see AN2606 "HSE detected" -> no -> "Generate System reset". On a
+ * 12 MHz STM32F405 a single attempt reached DFU 5 times in 12, so the request
+ * survives the reset and is tried again. */
+#define BOOTLOADER_MAX_ATTEMPTS 16
+
+/* Where the bootloader's vector table lives, a stack pointer to load followed
+ * by an address to jump to. Remapping system memory to 0 keeps this free of
+ * per-series addresses. WEAK so a board can point it elsewhere. */
+WEAK uint32_t systemBootloaderAddress(void)
+{
+#ifdef __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH
+  /* Remap system Flash memory at address 0x00000000 */
+  __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
+  return 0;
+#else
+#error "System memory address unknown for this series"
+#endif
+}
+
+/* Called from premain(), before init() runs HAL_Init(), so the ROM gets the
+ * part close to reset state. It cannot be done from cdc_1200bps_touchHook():
+ * that runs in handler mode and the ROM would never leave the exception. */
+WEAK void jumpToSystemBootloaderIfRequested(void)
+{
+  uint32_t request = bootloaderRequest;
+  uint32_t attempts = request & ~BOOTLOADER_REQUEST_MASK;
+  bool requested = __HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)
+                   && ((request & BOOTLOADER_REQUEST_MASK) == BOOTLOADER_REQUEST_MAGIC);
+
+  /* Clear it in every other case, so a power cycle always leaves the
+   * bootloader and a completed session does not re-enter it. */
+  bootloaderRequest = 0;
+
+  if (!requested || (attempts >= BOOTLOADER_MAX_ATTEMPTS)) {
+    return;
+  }
+  bootloaderRequest = BOOTLOADER_REQUEST_MAGIC | (attempts + 1);
+  __HAL_RCC_CLEAR_RESET_FLAGS();
+
+  uint32_t sys = systemBootloaderAddress();
+
+  /* Assembly to prevent modifying the stack pointer after loading it, and to
+   * ensure a jump rather than a call. */
+  asm volatile(
+    "ldr r0, [%[sys], #0]   \n\t"  // get address of stack pointer
+    "msr msp, r0            \n\t"  // set stack pointer
+    "ldr r0, [%[sys], #4]   \n\t"  // get address of reset handler
+    "dsb                    \n\t"  // data sync barrier
+    "isb                    \n\t"  // instruction sync barrier
+    "bx r0                  \n\t"  // branch to bootloader
+    : : [sys] "l"(sys) : "r0"
+  );
+
+  __builtin_unreachable();
+}
+
+/* Host closed the CDC port at 1200 bps. Record the request and reset; a reset
+ * is safe from the control transfer callback where a branch is not. */
+void cdc_1200bps_touchHook(void)
+{
+  bootloaderRequest = BOOTLOADER_REQUEST_MAGIC;
+  NVIC_SystemReset();
+}
+#endif /* BL_SYSTEM */

--- a/libraries/USBDevice/src/cdc/usbd_cdc_if.c
+++ b/libraries/USBDevice/src/cdc/usbd_cdc_if.c
@@ -60,6 +60,8 @@ __IO bool rtsState = false;
 __IO bool receivePended = true;
 static uint32_t transmitStart = 0;
 
+extern void cdc_1200bps_touchHook(void);
+
 #ifdef DTR_TOGGLING_SEQ
   /* DTR toggling sequence management */
   extern void dtr_togglingHook(uint8_t *buf, uint32_t *len);
@@ -195,6 +197,11 @@ static int8_t USBD_CDC_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length)
         transmitStart = 0;
       }
       rtsState = (((USBD_SetupReqTypedef *)pbuf)->wValue & CLS_RTS);
+      /* Host closing the port at 1200 bps is the Arduino convention for
+         requesting a reboot into the bootloader. */
+      if (!dtrState && linecoding.bitrate == 1200) {
+        cdc_1200bps_touchHook();
+      }
 #ifdef DTR_TOGGLING_SEQ
       dtr_toggling++; /* Count DTR toggling */
 #endif


### PR DESCRIPTION
**Summary**

Makes the STM32CubeProgrammer (DFU) upload method work on its own: closing the USB CDC port at 1200 bps now reboots the board into the ST system memory bootloader, so a sketch can be uploaded without touching BOOT0 or power cycling.

This PR fixes/implements the following **bugs/features**

* [x] Feature 1: report the USB 1200 bps touch through a weak hook
* [x] Feature 2: enter the ST system bootloader on that touch, for STM32F4
* [ ] Breaking changes

Fixes #706

**Motivation**

`dfuMethod` already exists for essentially every series, so the board can be *flashed* over DFU. What is missing is anything to *put* it into DFU, which is why uploading still means reaching for BOOT0. This closes that gap.

Two commits, each self-contained:

1. `feat(cdc): add a 1200 bps touch hook` — a weak `cdc_1200bps_touchHook()` in `cores/arduino/hooks.c`, called from `CDC_SET_CONTROL_LINE_STATE` when the host closes the port at 1200 bps. It follows `yield()` and `dtr_togglingHook()`, has no series specific content, and does nothing by default. `dtr_togglingHook()` cannot serve here: it is invoked from `USBD_CDC_Receive`, so it needs the host to send data, and a 1200 bps touch sends none.
2. `feat(bootloader): add ST system bootloader entry` — the policy, behind `-DBL_SYSTEM` on the existing `dfuMethod` entry.

**Design notes, each of which cost a measurement**

- **The branch cannot happen in the hook.** It runs in handler mode, so setting MSP and branching leaves the ROM inside an exception that never returns. Same jump code on the same board: **0 of 8** from inside the hook, board hangs until a power cycle, against **5 of 8** deferred to thread mode. The hook therefore only records the request and calls `NVIC_SystemReset()`, which *is* safe from handler mode.
- **`.noinit`, not a backup register.** Some series have none, and `.noinit` holds an arbitrary value after a power cycle, so the request is only trusted after a software reset, which is also what makes leaving DFU clear it rather than re-enter.
- **`premain()` for the branch**, before `init()` calls `HAL_Init()`, so the ROM gets the part close to reset state. No `Reset_Handler` override and no startup assembly change.
- **The request is retried, gated on a software reset.** The ROM clocks USB from the HSE but does not know which crystal is fitted, so it measures one against the HSI, and per AN2606 Rev 61 Figure 32/33 it resets the part when that misses: `HSE detected` -> no -> "Generate System reset". Section 28.2.1 says lower frequencies detect better, "it is better to use 8 MHz instead of 25 MHz"; this board is 12 MHz. A single attempt reached DFU **5 times in 12**. Retrying reaches it every time. The software reset gate is what makes leaving DFU clear the request rather than re-enter it. Pre-starting HSE and waiting for `HSERDY` does not help, so this is not a crystal startup race.

**Series coverage**

`systemBootloaderAddress()` remaps system memory to zero with `__HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH()` and returns 0, rather than carrying a table of per series addresses. That macro is provided by the HAL for F0, F2, F3, F4, C0, G0, G4, L0, L1 and L4 among others, so the implementation is not F4 specific. Where it is absent the `#else` is a compile time error rather than a silent no-op, and since `-DBL_SYSTEM` is only set by the `boards.txt` entry, no series that does not opt in is affected. `systemBootloaderAddress()` is `WEAK` so a board with the bootloader somewhere else can redefine it.

I have only been able to verify this on STM32F4. I enabled the flag for GenF4 alone for that reason, rather than turning it on for series I cannot test.

**Validation**

Board: Adafruit Feather STM32F405 Express, 12 MHz crystal. Core built from this branch. FQBN `STMicroelectronics:stm32:GenF4:pnum=FEATHER_F405,usb=CDCgen,xusb=FS,upload_method=dfuMethod`. Host: Linux, board on a hub with per port power control, flashed over SWD with OpenOCD for the initial load.

The sketch is a stock blink with **no bootloader code at all**, which is the point:

```cpp
void setup() { Serial.begin(115200); pinMode(LED_BUILTIN, OUTPUT); }
void loop() { digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN)); delay(200); }
```

Each trial power cycles the port, waits for enumeration, then opens the port at 1200 bps, drops DTR and closes it. Entry is read from `/sys/bus/usb/devices/.../idProduct`.

| test | result |
|---|---|
| touch reaches DFU, 12 trials | **12 / 12** |
| full round trip: touch, `dfu-util ... :leave`, back to sketch | **3 / 3** |
| the hook itself firing on a touch | 10 / 10 |
| same core built with `upload_method=swdMethod` | builds, 176 bytes smaller, feature absent |

**Not tested:** series other than STM32F4, and hosts other than Linux.

**Code formatting**

`astyle --options=CI/astyle/.astylerc` reports every changed file unchanged. No generated or vendored file is touched. `cmake/scripts/cmake_updater_hook.py` was re-run after the `boards.txt` change, with submodules checked out, and produced no diff.

**Prior art**

#710 covered this ground in 2019. Credit to @fpistm and @matthijskooijman: the `.noinit` plus software reset gate, the `premain()` placement, the `WEAK` address function that remaps rather than tabulating addresses, and the inline asm branch all follow that branch. This is written fresh against current `main` rather than rebased on it, since the file layout has moved since and that branch is unfinished.

Claude Code was used. The measurements above are USB enumeration state read from sysfs, on the hardware named, not estimates.
